### PR TITLE
Add private direct message (DM) feature

### DIFF
--- a/src/broker.rs
+++ b/src/broker.rs
@@ -15,8 +15,16 @@ use crate::{
     message::{make_join, make_leave, make_system, parse_client_line, Message},
 };
 
-type ClientMap = Arc<Mutex<HashMap<u64, broadcast::Sender<String>>>>;
+/// Maps client ID → (username, broadcast sender).
+/// Username is set after the handshake completes.
+type ClientMap = Arc<Mutex<HashMap<u64, (String, broadcast::Sender<String>)>>>;
+
+/// Maps username → status string. Status is ephemeral; cleared on disconnect.
 type StatusMap = Arc<Mutex<HashMap<String, String>>>;
+
+/// The username of the first client to complete the handshake.
+/// The host receives all DMs regardless of sender/recipient.
+type HostUser = Arc<Mutex<Option<String>>>;
 
 pub struct Broker {
     room_id: String,
@@ -46,6 +54,7 @@ impl Broker {
 
         let clients: ClientMap = Arc::new(Mutex::new(HashMap::new()));
         let status_map: StatusMap = Arc::new(Mutex::new(HashMap::new()));
+        let host_user: HostUser = Arc::new(Mutex::new(None));
         let chat_path = Arc::new(self.chat_path.clone());
         let room_id = Arc::new(self.room_id.clone());
         let mut next_id: u64 = 0;
@@ -56,10 +65,12 @@ impl Broker {
             let cid = next_id;
 
             let (tx, _) = broadcast::channel::<String>(256);
-            clients.lock().await.insert(cid, tx.clone());
+            // Insert with empty username; handle_client updates it after handshake.
+            clients.lock().await.insert(cid, (String::new(), tx.clone()));
 
             let clients_clone = clients.clone();
             let status_map_clone = status_map.clone();
+            let host_user_clone = host_user.clone();
             let chat_path_clone = chat_path.clone();
             let room_id_clone = room_id.clone();
 
@@ -70,6 +81,7 @@ impl Broker {
                     tx,
                     clients_clone.clone(),
                     status_map_clone,
+                    host_user_clone,
                     chat_path_clone,
                     room_id_clone,
                 )
@@ -89,6 +101,7 @@ async fn handle_client(
     own_tx: broadcast::Sender<String>,
     clients: ClientMap,
     status_map: StatusMap,
+    host_user: HostUser,
     chat_path: Arc<PathBuf>,
     room_id: Arc<String>,
 ) -> anyhow::Result<()> {
@@ -101,6 +114,22 @@ async fn handle_client(
     let username = username.trim().to_owned();
     if username.is_empty() {
         return Ok(());
+    }
+
+    // Register username in the client map
+    {
+        let mut map = clients.lock().await;
+        if let Some(entry) = map.get_mut(&cid) {
+            entry.0 = username.clone();
+        }
+    }
+
+    // Register as host if no host has been set yet (first to complete handshake)
+    {
+        let mut host = host_user.lock().await;
+        if host.is_none() {
+            *host = Some(username.clone());
+        }
     }
 
     eprintln!("[broker] {username} joined (cid={cid})");
@@ -155,6 +184,7 @@ async fn handle_client(
     let room_id_in = room_id.clone();
     let clients_in = clients.clone();
     let status_map_in = status_map.clone();
+    let host_user_in = host_user.clone();
     let chat_path_in = chat_path.clone();
     let write_half_in = write_half.clone();
     let inbound = tokio::spawn(async move {
@@ -170,6 +200,7 @@ async fn handle_client(
                     }
                     match parse_client_line(trimmed, &room_id_in, &username_in) {
                         Ok(msg) => {
+                            // Handle status commands privately (no broadcast of the Command itself)
                             if let Message::Command { ref cmd, ref params, .. } = msg {
                                 if cmd == "set_status" {
                                     let status = params.first().cloned().unwrap_or_default();
@@ -214,9 +245,22 @@ async fn handle_client(
                                     continue;
                                 }
                             }
-                            if let Err(e) =
-                                broadcast_and_persist(&msg, &clients_in, &chat_path_in).await
-                            {
+                            // Route DMs to sender + recipient + host only; broadcast everything else
+                            let result = match &msg {
+                                Message::DirectMessage { to, .. } => {
+                                    dm_and_persist(
+                                        &msg,
+                                        &username_in,
+                                        to,
+                                        &host_user_in,
+                                        &clients_in,
+                                        &chat_path_in,
+                                    )
+                                    .await
+                                }
+                                _ => broadcast_and_persist(&msg, &clients_in, &chat_path_in).await,
+                            };
+                            if let Err(e) = result {
                                 eprintln!("[broker] persist error: {e:#}");
                             }
                         }
@@ -244,6 +288,7 @@ async fn handle_client(
     Ok(())
 }
 
+/// Persist a message and fan it out to all connected clients.
 async fn broadcast_and_persist(
     msg: &Message,
     clients: &ClientMap,
@@ -253,8 +298,36 @@ async fn broadcast_and_persist(
 
     let line = format!("{}\n", serde_json::to_string(msg)?);
     let map = clients.lock().await;
-    for tx in map.values() {
+    for (_, tx) in map.values() {
         let _ = tx.send(line.clone());
+    }
+    Ok(())
+}
+
+/// Persist a DM and deliver it only to the sender, the recipient, and the host.
+/// If the recipient is offline the message is still persisted and the sender
+/// receives their own echo; no error is returned.
+async fn dm_and_persist(
+    msg: &Message,
+    sender: &str,
+    recipient: &str,
+    host_user: &HostUser,
+    clients: &ClientMap,
+    chat_path: &Path,
+) -> anyhow::Result<()> {
+    history::append(chat_path, msg).await?;
+
+    let line = format!("{}\n", serde_json::to_string(msg)?);
+    let host = host_user.lock().await;
+    let host_name = host.as_deref();
+    let map = clients.lock().await;
+    for (username, tx) in map.values() {
+        if username == sender
+            || username == recipient
+            || host_name == Some(username.as_str())
+        {
+            let _ = tx.send(line.clone());
+        }
     }
     Ok(())
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -52,6 +52,19 @@ pub enum Message {
         ts: DateTime<Utc>,
         content: String,
     },
+    /// A private direct message. Delivered only to sender, recipient, and the
+    /// broker host. Always written to the chat history file.
+    #[serde(rename = "dm")]
+    DirectMessage {
+        id: String,
+        room: String,
+        /// Sender username (set by the broker).
+        user: String,
+        ts: DateTime<Utc>,
+        /// Recipient username.
+        to: String,
+        content: String,
+    },
 }
 
 impl Message {
@@ -62,7 +75,8 @@ impl Message {
             | Self::Message { id, .. }
             | Self::Reply { id, .. }
             | Self::Command { id, .. }
-            | Self::System { id, .. } => id,
+            | Self::System { id, .. }
+            | Self::DirectMessage { id, .. } => id,
         }
     }
 
@@ -73,7 +87,8 @@ impl Message {
             | Self::Message { room, .. }
             | Self::Reply { room, .. }
             | Self::Command { room, .. }
-            | Self::System { room, .. } => room,
+            | Self::System { room, .. }
+            | Self::DirectMessage { room, .. } => room,
         }
     }
 
@@ -84,7 +99,8 @@ impl Message {
             | Self::Message { user, .. }
             | Self::Reply { user, .. }
             | Self::Command { user, .. }
-            | Self::System { user, .. } => user,
+            | Self::System { user, .. }
+            | Self::DirectMessage { user, .. } => user,
         }
     }
 
@@ -95,7 +111,8 @@ impl Message {
             | Self::Message { ts, .. }
             | Self::Reply { ts, .. }
             | Self::Command { ts, .. }
-            | Self::System { ts, .. } => ts,
+            | Self::System { ts, .. }
+            | Self::DirectMessage { ts, .. } => ts,
         }
     }
 }
@@ -176,6 +193,17 @@ pub fn make_system(room: &str, user: &str, content: impl Into<String>) -> Messag
     }
 }
 
+pub fn make_dm(room: &str, user: &str, to: &str, content: impl Into<String>) -> Message {
+    Message::DirectMessage {
+        id: new_id(),
+        room: room.to_owned(),
+        user: user.to_owned(),
+        ts: Utc::now(),
+        to: to.to_owned(),
+        content: content.into(),
+    }
+}
+
 /// Parse a raw line from a client socket.
 /// JSON envelope → Message with broker-assigned id/room/ts.
 /// Plain text → Message::Message with broker-assigned metadata.
@@ -186,6 +214,8 @@ pub fn parse_client_line(raw: &str, room: &str, user: &str) -> Result<Message, s
         Message { content: String },
         Reply { reply_to: String, content: String },
         Command { cmd: String, params: Vec<String> },
+        #[serde(rename = "dm")]
+        Dm { to: String, content: String },
     }
 
     if raw.starts_with('{') {
@@ -194,6 +224,7 @@ pub fn parse_client_line(raw: &str, room: &str, user: &str) -> Result<Message, s
             Envelope::Message { content } => make_message(room, user, content),
             Envelope::Reply { reply_to, content } => make_reply(room, user, reply_to, content),
             Envelope::Command { cmd, params } => make_command(room, user, cmd, params),
+            Envelope::Dm { to, content } => make_dm(room, user, &to, content),
         };
         Ok(msg)
     } else {
@@ -394,6 +425,47 @@ mod tests {
     fn parse_invalid_json_errors() {
         let result = parse_client_line(r#"{"type":"unknown_type"}"#, "r", "u");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_dm_envelope() {
+        let raw = r#"{"type":"dm","to":"bob","content":"hey bob"}"#;
+        let msg = parse_client_line(raw, "r", "alice").unwrap();
+        assert!(
+            matches!(&msg, Message::DirectMessage { to, content, .. } if to == "bob" && content == "hey bob")
+        );
+        assert_eq!(msg.user(), "alice");
+    }
+
+    #[test]
+    fn dm_round_trips() {
+        let msg = Message::DirectMessage {
+            id: fixed_id(),
+            room: "r".into(),
+            user: "alice".into(),
+            ts: fixed_ts(),
+            to: "bob".into(),
+            content: "secret".into(),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let back: Message = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, back);
+    }
+
+    #[test]
+    fn dm_json_has_type_dm() {
+        let msg = Message::DirectMessage {
+            id: fixed_id(),
+            room: "r".into(),
+            user: "alice".into(),
+            ts: fixed_ts(),
+            to: "bob".into(),
+            content: "hi".into(),
+        };
+        let v: serde_json::Value = serde_json::to_value(&msg).unwrap();
+        assert_eq!(v["type"], "dm");
+        assert_eq!(v["to"], "bob");
+        assert_eq!(v["content"], "hi");
     }
 
     // ── Accessor tests ────────────────────────────────────────────────────────

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -258,11 +258,29 @@ fn format_message(msg: &Message) -> Line<'static> {
                 ),
             ])
         }
+        Message::DirectMessage { ts, user, to, content, .. } => {
+            let ts_str = ts.format("%H:%M:%S").to_string();
+            Line::from(vec![
+                Span::styled(format!("[{ts_str}] "), Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    format!("[dm] {user}→{to}: "),
+                    Style::default().fg(Color::Magenta).add_modifier(Modifier::BOLD),
+                ),
+                Span::raw(content.clone()),
+            ])
+        }
     }
 }
 
 /// Convert TUI input to a JSON envelope for the broker.
 fn build_payload(input: &str) -> String {
+    // `/dm <user> <message>` — preserve spaces in the message body.
+    if let Some(rest) = input.strip_prefix("/dm ") {
+        let mut parts = rest.splitn(2, ' ');
+        let to = parts.next().unwrap_or("").to_owned();
+        let content = parts.next().unwrap_or("").to_owned();
+        return serde_json::json!({ "type": "dm", "to": to, "content": content }).to_string();
+    }
     if let Some(rest) = input.strip_prefix('/') {
         let mut parts = rest.splitn(2, ' ');
         let cmd = parts.next().unwrap_or("").to_owned();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -463,6 +463,162 @@ async fn stale_socket_is_cleaned_up() {
     panic!("broker did not recover from stale socket");
 }
 
+/// A DM is delivered to the sender, the recipient, and the broker host.
+/// It must NOT be delivered to other connected clients.
+#[tokio::test]
+async fn dm_delivered_to_sender_recipient_and_host() {
+    let broker = TestBroker::start("t_dm_fanout").await;
+
+    // alice connects first → she becomes the host
+    let mut alice = TestClient::connect(&broker.socket_path, "alice").await;
+    alice.recv_until(|m| matches!(m, Message::Join { user, .. } if user == "alice")).await;
+
+    let mut bob = TestClient::connect(&broker.socket_path, "bob").await;
+    alice.recv_until(|m| matches!(m, Message::Join { user, .. } if user == "bob")).await;
+    bob.recv_until(|m| matches!(m, Message::Join { user, .. } if user == "bob")).await;
+
+    let mut carol = TestClient::connect(&broker.socket_path, "carol").await;
+    alice.recv_until(|m| matches!(m, Message::Join { user, .. } if user == "carol")).await;
+    bob.recv_until(|m| matches!(m, Message::Join { user, .. } if user == "carol")).await;
+    carol.recv_until(|m| matches!(m, Message::Join { user, .. } if user == "carol")).await;
+
+    // dan is a bystander — not sender, recipient, or host
+    let mut dan = TestClient::connect(&broker.socket_path, "dan").await;
+    alice.recv_until(|m| matches!(m, Message::Join { user, .. } if user == "dan")).await;
+    bob.recv_until(|m| matches!(m, Message::Join { user, .. } if user == "dan")).await;
+    carol.recv_until(|m| matches!(m, Message::Join { user, .. } if user == "dan")).await;
+    dan.recv_until(|m| matches!(m, Message::Join { user, .. } if user == "dan")).await;
+
+    // bob sends a DM to carol
+    bob.send_json(r#"{"type":"dm","to":"carol","content":"psst"}"#).await;
+
+    // carol (recipient) receives it
+    let msg = carol
+        .recv_until(|m| matches!(m, Message::DirectMessage { content, .. } if content == "psst"))
+        .await;
+    assert_eq!(msg.user(), "bob");
+    if let Message::DirectMessage { to, .. } = &msg {
+        assert_eq!(to, "carol");
+    }
+
+    // bob (sender) receives the echo
+    bob.recv_until(|m| matches!(m, Message::DirectMessage { content, .. } if content == "psst"))
+        .await;
+
+    // alice (host) receives it
+    alice
+        .recv_until(|m| matches!(m, Message::DirectMessage { content, .. } if content == "psst"))
+        .await;
+
+    // dan (bystander) must NOT receive it — collect all of dan's messages for 300 ms
+    let got_dm = tokio::time::timeout(Duration::from_millis(300), async {
+        let mut line = String::new();
+        loop {
+            line.clear();
+            if dan.reader.read_line(&mut line).await.unwrap_or(0) == 0 {
+                break false;
+            }
+            if let Ok(msg) = serde_json::from_str::<Message>(line.trim()) {
+                if matches!(&msg, Message::DirectMessage { content, .. } if content == "psst") {
+                    break true;
+                }
+            }
+        }
+    })
+    .await;
+    assert!(
+        got_dm.is_err() || !got_dm.unwrap(),
+        "dan should not receive the DM"
+    );
+}
+
+/// DMs are persisted to the chat history file.
+#[tokio::test]
+async fn dm_is_persisted_to_history() {
+    let broker = TestBroker::start("t_dm_persist").await;
+
+    let mut alice = TestClient::connect(&broker.socket_path, "alice").await;
+    alice.recv_until(|m| matches!(m, Message::Join { user, .. } if user == "alice")).await;
+
+    let mut bob = TestClient::connect(&broker.socket_path, "bob").await;
+    alice.recv_until(|m| matches!(m, Message::Join { user, .. } if user == "bob")).await;
+    bob.recv_until(|m| matches!(m, Message::Join { user, .. } if user == "bob")).await;
+
+    alice
+        .send_json(r#"{"type":"dm","to":"bob","content":"private"}"#)
+        .await;
+    // wait for echo to confirm the broker processed it
+    alice
+        .recv_until(|m| matches!(m, Message::DirectMessage { content, .. } if content == "private"))
+        .await;
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let history = history::load(&broker.chat_path).await.unwrap();
+    assert!(
+        history
+            .iter()
+            .any(|m| matches!(m, Message::DirectMessage { content, .. } if content == "private")),
+        "DM not found in history"
+    );
+}
+
+/// When the host is also the DM sender, delivery still works correctly.
+#[tokio::test]
+async fn dm_from_host_is_delivered_to_recipient() {
+    let broker = TestBroker::start("t_dm_host_sender").await;
+
+    // alice is host (first connect)
+    let mut alice = TestClient::connect(&broker.socket_path, "alice").await;
+    alice.recv_until(|m| matches!(m, Message::Join { user, .. } if user == "alice")).await;
+
+    let mut bob = TestClient::connect(&broker.socket_path, "bob").await;
+    alice.recv_until(|m| matches!(m, Message::Join { user, .. } if user == "bob")).await;
+    bob.recv_until(|m| matches!(m, Message::Join { user, .. } if user == "bob")).await;
+
+    alice
+        .send_json(r#"{"type":"dm","to":"bob","content":"host dm"}"#)
+        .await;
+
+    // bob receives it
+    bob.recv_until(|m| matches!(m, Message::DirectMessage { content, .. } if content == "host dm"))
+        .await;
+
+    // alice receives the echo (she is both sender and host)
+    alice
+        .recv_until(|m| matches!(m, Message::DirectMessage { content, .. } if content == "host dm"))
+        .await;
+}
+
+/// A DM sent to an offline user is still persisted and the sender gets the echo.
+#[tokio::test]
+async fn dm_to_offline_user_is_persisted() {
+    let broker = TestBroker::start("t_dm_offline").await;
+
+    let mut alice = TestClient::connect(&broker.socket_path, "alice").await;
+    alice.recv_until(|m| matches!(m, Message::Join { user, .. } if user == "alice")).await;
+
+    // ghost is not connected
+    alice
+        .send_json(r#"{"type":"dm","to":"ghost","content":"nobody home"}"#)
+        .await;
+
+    // alice (sender = host) gets the echo
+    alice
+        .recv_until(|m| matches!(m, Message::DirectMessage { content, .. } if content == "nobody home"))
+        .await;
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let history = history::load(&broker.chat_path).await.unwrap();
+    assert!(
+        history.iter().any(
+            |m| matches!(m, Message::DirectMessage { content, .. } if content == "nobody home")
+        ),
+        "DM to offline user not found in history"
+    );
+}
+
 #[tokio::test]
 async fn writes_to_tmp_slash_directly() {
     let path = std::path::PathBuf::from("/tmp/room_test_direct.chat");


### PR DESCRIPTION
## Summary

- New `DirectMessage` wire type (`"type": "dm"`) with `to`, `user`, and `content` fields
- Broker delivers DMs only to sender, recipient, and the host (first connected user) — not broadcast to all
- DMs are always written to the chat history file for full audit trail
- TUI command: `/dm <user> <message>` (preserves spaces in message body)
- Agent mode: `{"type":"dm","to":"<username>","content":"..."}`

## Files changed

- `src/message.rs` — `DirectMessage` variant, `make_dm` constructor, `Dm` envelope in `parse_client_line`
- `src/broker.rs` — `ClientMap` now tracks username alongside sender; `HostUser` records first connected user; `dm_and_persist` for selective fanout
- `src/tui.rs` — `/dm` input handling, `DirectMessage` rendering in magenta
- `tests/integration.rs` — 4 new integration tests: fanout routing (including bystander exclusion), persistence, host-as-sender, offline-recipient

## Test plan

- [x] All 45 tests pass (`cargo test`): 27 unit + 18 integration
- [x] `dm_delivered_to_sender_recipient_and_host` — verifies bystander does not receive DM
- [x] `dm_is_persisted_to_history` — DM appears in chat file
- [x] `dm_from_host_is_delivered_to_recipient` — host-as-sender works correctly
- [x] `dm_to_offline_user_is_persisted` — offline recipient: message saved, sender gets echo