### PR TITLE
feat: add -v / --version flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -30,9 +30,15 @@ enum Cmd {
 #[derive(Parser, Debug)]
 #[command(
     name = "room",
+    version,
+    disable_version_flag = true,
     about = "Multi-user chat room for agent/human coordination"
 )]
 struct Args {
+    /// Print version and exit
+    #[arg(short = 'v', long = "version", action = clap::ArgAction::Version)]
+    _version: bool,
+
     /// Room identifier (required when no subcommand is given)
     room_id: Option<String>,
 


### PR DESCRIPTION
## Summary

- Adds `-v` and `--version` flags to the `room` CLI
- Prints `room 0.2.0` (read from `Cargo.toml` via `env!("CARGO_PKG_VERSION")`) and exits cleanly
- Disables clap's default `-V` shorthand; `-v`/`--version` are the only version flags

## Implementation

Uses clap 4's `ArgAction::Version` with `disable_version_flag = true` on the command, then registers a custom field with `short = 'v'` and `long = "version"`. No new dependencies.

## Test plan

- [x] `room --version` → `room 0.2.0`
- [x] `room -v` → `room 0.2.0`
- [x] `cargo test` — all 27 tests pass

Closes #20