### PR TITLE
feat(tui): multi-line input with line wrapping (#17)

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -350,7 +350,11 @@ fn cursor_display_pos(input: &str, cursor_pos: usize, width: usize) -> (usize, u
     // If col == width and there is remaining content that is not a newline,
     // the next character would start on a new row — advance the cursor there
     // so it doesn't render past the right border of the input box.
-    if width > 0 && col == width && cursor_pos < input.len() && !input[cursor_pos..].starts_with('\n') {
+    if width > 0
+        && col == width
+        && cursor_pos < input.len()
+        && !input[cursor_pos..].starts_with('\n')
+    {
         row += 1;
         col = 0;
     }


### PR DESCRIPTION
## Summary
- Replace horizontal scrolling in the input box with vertical line wrapping
- Input box grows dynamically up to 6 content lines as the user types
- `Shift+Enter` inserts a newline; plain `Enter` sends as before

## Implementation
- `wrap_input_display(input, width)` — splits on `\n`, char-wraps each logical line at `width` display columns (Unicode-width-aware)
- `cursor_display_pos(input, cursor_pos, width)` — returns `(row, col)` in the wrapped grid for accurate cursor placement
- `input_row_scroll` tracks vertical scroll within the input box when content exceeds `MAX_INPUT_LINES` (6)
- Layout `Constraint::Length` for the input pane is now computed dynamically each frame

## Merge note
The `Enter` key arm structure is compatible with #26 (command palette): when merged, the order should be `palette.active` check → `Shift+Enter` newline → plain send.

## Test plan
- [ ] Type a long message and confirm it wraps visually instead of hiding
- [ ] Press `Shift+Enter` mid-message and confirm a newline is inserted
- [ ] Confirm plain `Enter` still sends the full message (including embedded newlines)
- [ ] Confirm cursor stays visible when input exceeds 6 lines (scrolls within box)
- [ ] All 57 existing tests pass

Closes #17