### PR TITLE
feat(cli): add 'room watch' subcommand

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,17 @@ enum Cmd {
         #[arg(long)]
         since: Option<String>,
     },
+    /// Watch for new messages from other users, blocking until at least one
+    /// arrives. Polls the chat file on a configurable interval. Shares the
+    /// cursor file with `room poll` so no messages are re-delivered. Exits
+    /// after printing the first batch of foreign messages as NDJSON.
+    Watch {
+        room_id: String,
+        username: String,
+        /// Poll interval in seconds (default: 5)
+        #[arg(long, default_value_t = 5)]
+        interval: u64,
+    },
 }
 
 #[derive(Parser, Debug)]
@@ -84,6 +95,13 @@ async fn main() -> anyhow::Result<()> {
             since,
         }) => {
             oneshot::cmd_poll(&room_id, &username, since).await?;
+        }
+        Some(Cmd::Watch {
+            room_id,
+            username,
+            interval,
+        }) => {
+            oneshot::cmd_watch(&room_id, &username, interval).await?;
         }
         None => {
             let room_id = args.room_id.unwrap_or_else(|| {

--- a/src/oneshot.rs
+++ b/src/oneshot.rs
@@ -100,6 +100,37 @@ pub async fn poll_messages(
     Ok(result)
 }
 
+/// Watch subcommand: poll in a loop until at least one foreign `Message` arrives.
+///
+/// Polls every `interval_secs` seconds. On each iteration, messages from the
+/// calling `username` and all non-`Message` variants (join/leave/system/command/DM)
+/// are filtered out. When foreign messages are found they are printed as NDJSON and
+/// the command exits. The cursor file is shared with `room poll` so the two
+/// subcommands never re-deliver the same message.
+pub async fn cmd_watch(room_id: &str, username: &str, interval_secs: u64) -> anyhow::Result<()> {
+    let meta_path = PathBuf::from(format!("/tmp/room-{room_id}.meta"));
+    let chat_path = chat_path_from_meta(room_id, &meta_path);
+    let cursor_path = PathBuf::from(format!("/tmp/room-{room_id}-{username}.cursor"));
+
+    loop {
+        let messages = poll_messages(&chat_path, &cursor_path, Some(username), None).await?;
+
+        let foreign: Vec<&Message> = messages
+            .iter()
+            .filter(|m| matches!(m, Message::Message { user, .. } if user != username))
+            .collect();
+
+        if !foreign.is_empty() {
+            for msg in foreign {
+                println!("{}", serde_json::to_string(msg)?);
+            }
+            return Ok(());
+        }
+
+        tokio::time::sleep(tokio::time::Duration::from_secs(interval_secs)).await;
+    }
+}
+
 /// One-shot poll subcommand: read messages since cursor, print as NDJSON, update cursor.
 pub async fn cmd_poll(room_id: &str, username: &str, since: Option<String>) -> anyhow::Result<()> {
     let meta_path = PathBuf::from(format!("/tmp/room-{room_id}.meta"));


### PR DESCRIPTION
## Summary
- Adds `room watch <room-id> <username> [--interval <secs>]` subcommand
- Replaces the external `/tmp/room_watch_*.sh` bash script — no more manual script creation per agent
- Polls chat file every `--interval` seconds (default 5), filters own messages and non-`message` types, exits after printing first batch of foreign messages as NDJSON
- Shares cursor file with `room poll` (`/tmp/room-<id>-<username>.cursor`) — no duplicate delivery
- No broker changes, no wire format changes

## Files changed
- `src/oneshot.rs` — `cmd_watch()` implementation
- `src/main.rs` — `Watch` variant in `Cmd` enum, dispatch in `main()`

## Test plan
- [x] `cargo check` clean
- [x] `cargo fmt` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] 74 unit tests + 30 integration tests pass (104 total)

Closes #36