### PR TITLE
feat(auth): session token — room join issues token, send/poll/watch use token

### DIFF
--- a/src/broker.rs
+++ b/src/broker.rs
@@ -12,6 +12,7 @@ use tokio::{
     },
     sync::{broadcast, Mutex},
 };
+use uuid::Uuid;
 
 use crate::{
     history,
@@ -29,11 +30,16 @@ type StatusMap = Arc<Mutex<HashMap<String, String>>>;
 /// The host receives all DMs regardless of sender/recipient.
 type HostUser = Arc<Mutex<Option<String>>>;
 
+/// Maps token UUID → username. Populated by one-shot JOIN requests.
+/// Cleared when the broker process exits; token files on disk survive restarts.
+type TokenMap = Arc<Mutex<HashMap<String, String>>>;
+
 /// Shared broker state passed to every client handler.
 struct RoomState {
     clients: ClientMap,
     status_map: StatusMap,
     host_user: HostUser,
+    token_map: TokenMap,
     chat_path: Arc<PathBuf>,
     room_id: Arc<String>,
 }
@@ -68,6 +74,7 @@ impl Broker {
             clients: Arc::new(Mutex::new(HashMap::new())),
             status_map: Arc::new(Mutex::new(HashMap::new())),
             host_user: Arc::new(Mutex::new(None)),
+            token_map: Arc::new(Mutex::new(HashMap::new())),
             chat_path: Arc::new(self.chat_path.clone()),
             room_id: Arc::new(self.room_id.clone()),
         });
@@ -108,16 +115,20 @@ async fn handle_client(
     let clients = state.clients.clone();
     let status_map = state.status_map.clone();
     let host_user = state.host_user.clone();
+    let token_map = state.token_map.clone();
     let chat_path = state.chat_path.clone();
     let room_id = state.room_id.clone();
 
     let (read_half, mut write_half) = stream.into_split();
     let mut reader = BufReader::new(read_half);
 
-    // First line: username handshake (or SEND:<username> for one-shot sends)
-    let mut username = String::new();
-    reader.read_line(&mut username).await?;
-    let first_line = username.trim();
+    // First line: username handshake, or one of the one-shot prefixes:
+    //   SEND:<username>  — legacy one-shot send
+    //   TOKEN:<uuid>     — token-authenticated one-shot send
+    //   JOIN:<username>  — register username, receive a session token
+    let mut first = String::new();
+    reader.read_line(&mut first).await?;
+    let first_line = first.trim();
 
     if let Some(send_user) = first_line.strip_prefix("SEND:") {
         return handle_oneshot_send(
@@ -132,6 +143,30 @@ async fn handle_client(
         .await;
     }
 
+    if let Some(token) = first_line.strip_prefix("TOKEN:") {
+        let username = token_map.lock().await.get(token).cloned();
+        return match username {
+            Some(u) => {
+                handle_oneshot_send(
+                    u, reader, write_half, &clients, &host_user, &chat_path, &room_id,
+                )
+                .await
+            }
+            None => {
+                let err = serde_json::json!({"type":"error","code":"invalid_token"});
+                write_half
+                    .write_all(format!("{err}\n").as_bytes())
+                    .await
+                    .map_err(Into::into)
+            }
+        };
+    }
+
+    if let Some(join_user) = first_line.strip_prefix("JOIN:") {
+        return handle_oneshot_join(join_user.to_owned(), write_half, &token_map).await;
+    }
+
+    // Remaining path: full interactive join — first_line is the username.
     let username = first_line.to_owned();
     if username.is_empty() {
         return Ok(());
@@ -362,6 +397,30 @@ async fn handle_oneshot_send(
     result?;
     let echo = format!("{}\n", serde_json::to_string(&msg)?);
     write_half.write_all(echo.as_bytes()).await?;
+    Ok(())
+}
+
+/// Handle a one-shot JOIN request: register a username, issue a UUID session token.
+///
+/// If the username is already registered the broker returns an error envelope and
+/// closes the connection without issuing a token. The token is held in-memory for
+/// the lifetime of the broker process; token files on disk are managed by the CLI.
+async fn handle_oneshot_join(
+    username: String,
+    mut write_half: OwnedWriteHalf,
+    token_map: &TokenMap,
+) -> anyhow::Result<()> {
+    let mut map = token_map.lock().await;
+    if map.values().any(|u| u == &username) {
+        let err = serde_json::json!({"type":"error","code":"username_taken","username": username});
+        write_half.write_all(format!("{err}\n").as_bytes()).await?;
+        return Ok(());
+    }
+    let token = Uuid::new_v4().to_string();
+    map.insert(token.clone(), username.clone());
+    drop(map);
+    let resp = serde_json::json!({"type":"token","token": token,"username": username});
+    write_half.write_all(format!("{resp}\n").as_bytes()).await?;
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,11 +6,19 @@ use tokio::net::UnixStream;
 
 #[derive(Subcommand, Debug)]
 enum Cmd {
+    /// Register a username with the broker and receive a session token.
+    ///
+    /// Writes the token to `/tmp/room-<room_id>.token`. Subsequent `send`,
+    /// `poll`, and `watch` calls read the username and token from that file —
+    /// no username argument required. Returns an error if the username is
+    /// already in use in the room.
+    Join { room_id: String, username: String },
     /// One-shot send a message to a room (requires a running broker).
-    /// Prints the broadcast message JSON and exits.
+    ///
+    /// Reads the caller's identity from the session token file created by
+    /// `room join`. Prints the broadcast message JSON and exits.
     Send {
         room_id: String,
-        username: String,
         /// Recipient username for a direct message
         #[arg(long)]
         to: Option<String>,
@@ -18,12 +26,12 @@ enum Cmd {
         #[arg(trailing_var_arg = true, num_args = 1..)]
         message: Vec<String>,
     },
-    /// Poll for new messages, printing NDJSON to stdout. Reads the chat file
-    /// directly — no broker required. Updates a per-user cursor file so
-    /// subsequent calls return only unseen messages.
+    /// Poll for new messages, printing NDJSON to stdout.
+    ///
+    /// Reads the caller's identity from the session token file. Updates a
+    /// per-user cursor file so subsequent calls return only unseen messages.
     Poll {
         room_id: String,
-        username: String,
         /// Return only messages after this message ID (overrides stored cursor)
         #[arg(long)]
         since: Option<String>,
@@ -32,9 +40,10 @@ enum Cmd {
     /// arrives. Polls the chat file on a configurable interval. Shares the
     /// cursor file with `room poll` so no messages are re-delivered. Exits
     /// after printing the first batch of foreign messages as NDJSON.
+    ///
+    /// Reads the caller's identity from the session token file.
     Watch {
         room_id: String,
-        username: String,
         /// Poll interval in seconds (default: 5)
         #[arg(long, default_value_t = 5)]
         interval: u64,
@@ -80,28 +89,22 @@ async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
     match args.command {
+        Some(Cmd::Join { room_id, username }) => {
+            oneshot::cmd_join(&room_id, &username).await?;
+        }
         Some(Cmd::Send {
             room_id,
-            username,
             to,
             message,
         }) => {
             let content = message.join(" ");
-            oneshot::cmd_send(&room_id, &username, to.as_deref(), &content).await?;
+            oneshot::cmd_send(&room_id, to.as_deref(), &content).await?;
         }
-        Some(Cmd::Poll {
-            room_id,
-            username,
-            since,
-        }) => {
-            oneshot::cmd_poll(&room_id, &username, since).await?;
+        Some(Cmd::Poll { room_id, since }) => {
+            oneshot::cmd_poll(&room_id, since).await?;
         }
-        Some(Cmd::Watch {
-            room_id,
-            username,
-            interval,
-        }) => {
-            oneshot::cmd_watch(&room_id, &username, interval).await?;
+        Some(Cmd::Watch { room_id, interval }) => {
+            oneshot::cmd_watch(&room_id, interval).await?;
         }
         None => {
             let room_id = args.room_id.unwrap_or_else(|| {

--- a/src/oneshot.rs
+++ b/src/oneshot.rs
@@ -29,16 +29,117 @@ pub async fn send_message(
     Ok(msg)
 }
 
+/// Connect to a running broker and deliver a single message authenticated by token.
+///
+/// Sends `TOKEN:<token>\n` as the handshake (instead of `SEND:<username>\n`).
+/// The broker resolves the username from its in-memory token map.
+pub async fn send_message_with_token(
+    socket_path: &Path,
+    token: &str,
+    content: &str,
+) -> anyhow::Result<Message> {
+    let stream = UnixStream::connect(socket_path).await.map_err(|e| {
+        anyhow::anyhow!("cannot connect to broker at {}: {e}", socket_path.display())
+    })?;
+    let (r, mut w) = stream.into_split();
+    w.write_all(format!("TOKEN:{token}\n").as_bytes()).await?;
+    // content is already a JSON envelope from cmd_send; newlines are escaped by serde.
+    w.write_all(format!("{content}\n").as_bytes()).await?;
+
+    let mut reader = BufReader::new(r);
+    let mut line = String::new();
+    reader.read_line(&mut line).await?;
+    // Broker may return an error envelope instead of a broadcast echo.
+    let v: serde_json::Value = serde_json::from_str(line.trim())
+        .map_err(|e| anyhow::anyhow!("broker returned invalid JSON: {e}: {:?}", line.trim()))?;
+    if v["type"] == "error" {
+        let code = v["code"].as_str().unwrap_or("unknown");
+        if code == "invalid_token" {
+            anyhow::bail!("invalid token — run: room join {}", socket_path.display());
+        }
+        anyhow::bail!("broker error: {code}");
+    }
+    let msg: Message = serde_json::from_value(v)
+        .map_err(|e| anyhow::anyhow!("broker returned unexpected JSON: {e}"))?;
+    Ok(msg)
+}
+
+/// Register a username with the broker and obtain a session token.
+///
+/// The broker checks for username collisions. On success it returns a token
+/// envelope; on collision it returns an error envelope.
+pub async fn join_session(socket_path: &Path, username: &str) -> anyhow::Result<(String, String)> {
+    let stream = UnixStream::connect(socket_path).await.map_err(|e| {
+        anyhow::anyhow!("cannot connect to broker at {}: {e}", socket_path.display())
+    })?;
+    let (r, mut w) = stream.into_split();
+    w.write_all(format!("JOIN:{username}\n").as_bytes()).await?;
+
+    let mut reader = BufReader::new(r);
+    let mut line = String::new();
+    reader.read_line(&mut line).await?;
+    let v: serde_json::Value = serde_json::from_str(line.trim())
+        .map_err(|e| anyhow::anyhow!("broker returned invalid JSON: {e}: {:?}", line.trim()))?;
+    if v["type"] == "error" {
+        let code = v["code"].as_str().unwrap_or("unknown");
+        if code == "username_taken" {
+            anyhow::bail!("username '{}' is already in use in this room", username);
+        }
+        anyhow::bail!("broker error: {code}");
+    }
+    let token = v["token"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("broker response missing 'token' field"))?
+        .to_owned();
+    let returned_user = v["username"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("broker response missing 'username' field"))?
+        .to_owned();
+    Ok((returned_user, token))
+}
+
+/// One-shot join subcommand: register username, receive token, write token file.
+///
+/// The token file at `/tmp/room-<room_id>.token` is used by subsequent `send`,
+/// `poll`, and `watch` calls to identify the caller without requiring a username arg.
+pub async fn cmd_join(room_id: &str, username: &str) -> anyhow::Result<()> {
+    let socket_path = PathBuf::from(format!("/tmp/room-{room_id}.sock"));
+    let (returned_user, token) = join_session(&socket_path, username).await?;
+    let token_data = serde_json::json!({"username": returned_user, "token": token});
+    let token_path = PathBuf::from(format!("/tmp/room-{room_id}.token"));
+    std::fs::write(&token_path, format!("{token_data}\n"))?;
+    println!("{token_data}");
+    Ok(())
+}
+
+/// Read the session token file for `room_id`.
+///
+/// Returns `(username, token)`. Prints a clear error and exits with code 1 if
+/// the file is missing — the caller should run `room join <room_id> <username>`.
+pub fn read_token(room_id: &str) -> anyhow::Result<(String, String)> {
+    let token_path = PathBuf::from(format!("/tmp/room-{room_id}.token"));
+    let data = std::fs::read_to_string(&token_path)
+        .map_err(|_| anyhow::anyhow!("token not found — run: room join {room_id} <username>"))?;
+    let v: serde_json::Value = serde_json::from_str(data.trim())
+        .map_err(|e| anyhow::anyhow!("malformed token file {}: {e}", token_path.display()))?;
+    let username = v["username"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("token file missing 'username' field"))?
+        .to_owned();
+    let token = v["token"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("token file missing 'token' field"))?
+        .to_owned();
+    Ok((username, token))
+}
+
 /// One-shot send subcommand: connect, send, print echo JSON to stdout, exit.
 ///
-/// When `to` is `Some(recipient)`, the message is sent as a DM envelope so the
-/// broker routes it only to the sender, recipient, and host.
-pub async fn cmd_send(
-    room_id: &str,
-    username: &str,
-    to: Option<&str>,
-    content: &str,
-) -> anyhow::Result<()> {
+/// Reads the caller's username and token from the session token file created by
+/// `room join`. When `to` is `Some(recipient)`, the message is sent as a DM
+/// envelope so the broker routes it only to the sender, recipient, and host.
+pub async fn cmd_send(room_id: &str, to: Option<&str>, content: &str) -> anyhow::Result<()> {
+    let (username, token) = read_token(room_id)?;
     let socket_path = PathBuf::from(format!("/tmp/room-{room_id}.sock"));
     let wire = match to {
         Some(recipient) => {
@@ -46,7 +147,16 @@ pub async fn cmd_send(
         }
         None => serde_json::json!({"type": "message", "content": content}).to_string(),
     };
-    let msg = send_message(&socket_path, username, &wire).await?;
+    let msg = send_message_with_token(&socket_path, &token, &wire)
+        .await
+        .map_err(|e| {
+            // Provide the room-id in the re-join hint rather than the socket path.
+            if e.to_string().contains("invalid token") {
+                anyhow::anyhow!("invalid token — run: room join {room_id} {username}")
+            } else {
+                e
+            }
+        })?;
     println!("{}", serde_json::to_string(&msg)?);
     Ok(())
 }
@@ -102,22 +212,23 @@ pub async fn poll_messages(
 
 /// Watch subcommand: poll in a loop until at least one foreign `Message` arrives.
 ///
-/// Polls every `interval_secs` seconds. On each iteration, messages from the
-/// calling `username` and all non-`Message` variants (join/leave/system/command/DM)
-/// are filtered out. When foreign messages are found they are printed as NDJSON and
-/// the command exits. The cursor file is shared with `room poll` so the two
-/// subcommands never re-deliver the same message.
-pub async fn cmd_watch(room_id: &str, username: &str, interval_secs: u64) -> anyhow::Result<()> {
+/// Reads the caller's username from the session token file. Polls every
+/// `interval_secs` seconds, filtering out own messages and non-`Message` variants.
+/// Exits after printing the first batch of foreign messages as NDJSON.
+/// Shares the cursor file with `room poll` — the two subcommands never re-deliver
+/// the same message.
+pub async fn cmd_watch(room_id: &str, interval_secs: u64) -> anyhow::Result<()> {
+    let (username, _token) = read_token(room_id)?;
     let meta_path = PathBuf::from(format!("/tmp/room-{room_id}.meta"));
     let chat_path = chat_path_from_meta(room_id, &meta_path);
     let cursor_path = PathBuf::from(format!("/tmp/room-{room_id}-{username}.cursor"));
 
     loop {
-        let messages = poll_messages(&chat_path, &cursor_path, Some(username), None).await?;
+        let messages = poll_messages(&chat_path, &cursor_path, Some(&username), None).await?;
 
         let foreign: Vec<&Message> = messages
             .iter()
-            .filter(|m| matches!(m, Message::Message { user, .. } if user != username))
+            .filter(|m| matches!(m, Message::Message { user, .. } if user != &username))
             .collect();
 
         if !foreign.is_empty() {
@@ -132,13 +243,16 @@ pub async fn cmd_watch(room_id: &str, username: &str, interval_secs: u64) -> any
 }
 
 /// One-shot poll subcommand: read messages since cursor, print as NDJSON, update cursor.
-pub async fn cmd_poll(room_id: &str, username: &str, since: Option<String>) -> anyhow::Result<()> {
+///
+/// Reads the caller's username from the session token file.
+pub async fn cmd_poll(room_id: &str, since: Option<String>) -> anyhow::Result<()> {
+    let (username, _token) = read_token(room_id)?;
     let meta_path = PathBuf::from(format!("/tmp/room-{room_id}.meta"));
     let chat_path = chat_path_from_meta(room_id, &meta_path);
     let cursor_path = PathBuf::from(format!("/tmp/room-{room_id}-{username}.cursor"));
 
     let messages =
-        poll_messages(&chat_path, &cursor_path, Some(username), since.as_deref()).await?;
+        poll_messages(&chat_path, &cursor_path, Some(&username), since.as_deref()).await?;
     for msg in &messages {
         println!("{}", serde_json::to_string(msg)?);
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1188,3 +1188,111 @@ async fn who_excludes_disconnected_users() {
         );
     }
 }
+
+// ── Token auth tests ──────────────────────────────────────────────────────────
+
+/// `join_session` returns a non-empty token and the correct username on success.
+#[tokio::test]
+async fn join_session_returns_token() {
+    let broker = TestBroker::start("t_join_token").await;
+    let (username, token) = room::oneshot::join_session(&broker.socket_path, "agent1")
+        .await
+        .expect("join_session failed");
+    assert_eq!(username, "agent1");
+    assert!(!token.is_empty(), "token must be non-empty");
+}
+
+/// A second `join_session` for the same username is rejected with a clear error.
+#[tokio::test]
+async fn join_session_rejects_duplicate_username() {
+    let broker = TestBroker::start("t_join_dup").await;
+    room::oneshot::join_session(&broker.socket_path, "bot")
+        .await
+        .expect("first join failed");
+    let err = room::oneshot::join_session(&broker.socket_path, "bot")
+        .await
+        .expect_err("second join should have failed");
+    assert!(
+        err.to_string().contains("already in use"),
+        "error should mention 'already in use': {err}"
+    );
+}
+
+/// Two distinct usernames can both register in the same room.
+#[tokio::test]
+async fn join_session_allows_different_usernames() {
+    let broker = TestBroker::start("t_join_two").await;
+    let (_, tok1) = room::oneshot::join_session(&broker.socket_path, "alice")
+        .await
+        .expect("alice join failed");
+    let (_, tok2) = room::oneshot::join_session(&broker.socket_path, "bob")
+        .await
+        .expect("bob join failed");
+    assert_ne!(tok1, tok2, "each user must receive a distinct token");
+}
+
+/// `send_message_with_token` delivers a message and returns the broadcast echo.
+#[tokio::test]
+async fn send_with_token_delivers_message() {
+    let broker = TestBroker::start("t_send_token").await;
+
+    let mut watcher = TestClient::connect(&broker.socket_path, "watcher").await;
+    watcher
+        .recv_until(|m| matches!(m, Message::Join { user, .. } if user == "watcher"))
+        .await;
+
+    let (_, token) = room::oneshot::join_session(&broker.socket_path, "agent")
+        .await
+        .expect("join_session failed");
+
+    let wire = serde_json::json!({"type": "message", "content": "hello from token"}).to_string();
+    let msg = room::oneshot::send_message_with_token(&broker.socket_path, &token, &wire)
+        .await
+        .expect("send_message_with_token failed");
+
+    assert!(
+        matches!(&msg, Message::Message { user, content, .. }
+            if user == "agent" && content == "hello from token"),
+        "unexpected message: {msg:?}"
+    );
+
+    let received = watcher
+        .recv_until(|m| matches!(m, Message::Message { user, .. } if user == "agent"))
+        .await;
+    assert!(
+        matches!(&received, Message::Message { content, .. } if content == "hello from token"),
+        "watcher got unexpected message: {received:?}"
+    );
+}
+
+/// An invalid (unknown) token returns a clear error from the broker.
+#[tokio::test]
+async fn send_with_invalid_token_returns_error() {
+    let broker = TestBroker::start("t_invalid_token").await;
+    let wire = serde_json::json!({"type": "message", "content": "hi"}).to_string();
+    let err =
+        room::oneshot::send_message_with_token(&broker.socket_path, "not-a-real-token", &wire)
+            .await
+            .expect_err("should have failed with invalid token");
+    assert!(
+        err.to_string().contains("invalid token"),
+        "error should mention 'invalid token': {err}"
+    );
+}
+
+/// After a `join_session` the token can be used from two sequential sends.
+#[tokio::test]
+async fn token_is_reusable_across_sends() {
+    let broker = TestBroker::start("t_token_reuse").await;
+    let (_, token) = room::oneshot::join_session(&broker.socket_path, "agent")
+        .await
+        .expect("join_session failed");
+
+    for i in 0..2u8 {
+        let wire =
+            serde_json::json!({"type": "message", "content": format!("msg {i}")}).to_string();
+        room::oneshot::send_message_with_token(&broker.socket_path, &token, &wire)
+            .await
+            .unwrap_or_else(|e| panic!("send {i} failed: {e}"));
+    }
+}


### PR DESCRIPTION
## Summary

- New `room join <room-id> <username>` subcommand: registers username with the broker, receives a UUID session token, writes it to `/tmp/room-<room-id>.token`
- Broker enforces username uniqueness at join time — duplicate usernames are rejected with a clear error envelope
- `room send`, `room poll`, `room watch` no longer take a `<username>` positional arg; identity is read from the token file
- `TOKEN:<uuid>` handshake accepted by the broker in place of `SEND:<username>` for one-shot sends
- Invalid or expired tokens (e.g. after broker restart) return a clear error; CLI prints re-join hint and exits 1

## Files changed

- `src/broker.rs` — `TokenMap`, `JOIN:` and `TOKEN:` one-shot handlers
- `src/oneshot.rs` — `join_session`, `cmd_join`, `read_token`, `send_message_with_token`; username arg dropped from `cmd_send`/`cmd_poll`/`cmd_watch`
- `src/main.rs` — `Join` subcommand; `username` removed from `Send`/`Poll`/`Watch`
- `tests/integration.rs` — 6 new token auth tests (join success, collision, two users, send-by-token, invalid token, token reuse)

## Test plan

- [ ] `cargo test` — 36 tests green
- [ ] `cargo clippy -- -D warnings` — clean
- [ ] `cargo fmt` — no changes
- [ ] Manual: `room join <id> alice` → token file written; `room send <id> hello` → message delivered; second `room join <id> alice` → error

Closes #37