### PR TITLE
fix(auth): namespace token files per user to prevent same-machine collision

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,9 @@ enum Cmd {
     /// `room join`. Prints the broadcast message JSON and exits.
     Send {
         room_id: String,
+        /// Select token by username (required when multiple sessions share this machine)
+        #[arg(long)]
+        user: Option<String>,
         /// Recipient username for a direct message
         #[arg(long)]
         to: Option<String>,
@@ -32,6 +35,9 @@ enum Cmd {
     /// per-user cursor file so subsequent calls return only unseen messages.
     Poll {
         room_id: String,
+        /// Select token by username (required when multiple sessions share this machine)
+        #[arg(long)]
+        user: Option<String>,
         /// Return only messages after this message ID (overrides stored cursor)
         #[arg(long)]
         since: Option<String>,
@@ -44,6 +50,9 @@ enum Cmd {
     /// Reads the caller's identity from the session token file.
     Watch {
         room_id: String,
+        /// Select token by username (required when multiple sessions share this machine)
+        #[arg(long)]
+        user: Option<String>,
         /// Poll interval in seconds (default: 5)
         #[arg(long, default_value_t = 5)]
         interval: u64,
@@ -94,17 +103,26 @@ async fn main() -> anyhow::Result<()> {
         }
         Some(Cmd::Send {
             room_id,
+            user,
             to,
             message,
         }) => {
             let content = message.join(" ");
-            oneshot::cmd_send(&room_id, to.as_deref(), &content).await?;
+            oneshot::cmd_send(&room_id, user.as_deref(), to.as_deref(), &content).await?;
         }
-        Some(Cmd::Poll { room_id, since }) => {
-            oneshot::cmd_poll(&room_id, since).await?;
+        Some(Cmd::Poll {
+            room_id,
+            user,
+            since,
+        }) => {
+            oneshot::cmd_poll(&room_id, user.as_deref(), since).await?;
         }
-        Some(Cmd::Watch { room_id, interval }) => {
-            oneshot::cmd_watch(&room_id, interval).await?;
+        Some(Cmd::Watch {
+            room_id,
+            user,
+            interval,
+        }) => {
+            oneshot::cmd_watch(&room_id, user.as_deref(), interval).await?;
         }
         None => {
             let room_id = args.room_id.unwrap_or_else(|| {

--- a/src/oneshot.rs
+++ b/src/oneshot.rs
@@ -98,15 +98,24 @@ pub async fn join_session(socket_path: &Path, username: &str) -> anyhow::Result<
     Ok((returned_user, token))
 }
 
+/// Returns the canonical token file path: `/tmp/room-<room_id>-<username>.token`.
+///
+/// One file per (room, user) pair — multiple agents on the same machine never
+/// overwrite each other's tokens.
+pub fn token_file_path(room_id: &str, username: &str) -> PathBuf {
+    PathBuf::from(format!("/tmp/room-{room_id}-{username}.token"))
+}
+
 /// One-shot join subcommand: register username, receive token, write token file.
 ///
-/// The token file at `/tmp/room-<room_id>.token` is used by subsequent `send`,
-/// `poll`, and `watch` calls to identify the caller without requiring a username arg.
+/// Writes to `/tmp/room-<room_id>-<username>.token` so agents sharing a machine
+/// do not clobber each other. Subsequent `send`, `poll`, and `watch` calls find
+/// the file automatically (single-agent) or via `--user <username>` (multi-agent).
 pub async fn cmd_join(room_id: &str, username: &str) -> anyhow::Result<()> {
     let socket_path = PathBuf::from(format!("/tmp/room-{room_id}.sock"));
     let (returned_user, token) = join_session(&socket_path, username).await?;
     let token_data = serde_json::json!({"username": returned_user, "token": token});
-    let token_path = PathBuf::from(format!("/tmp/room-{room_id}.token"));
+    let token_path = token_file_path(room_id, &returned_user);
     std::fs::write(&token_path, format!("{token_data}\n"))?;
     println!("{token_data}");
     Ok(())
@@ -114,10 +123,51 @@ pub async fn cmd_join(room_id: &str, username: &str) -> anyhow::Result<()> {
 
 /// Read the session token file for `room_id`.
 ///
-/// Returns `(username, token)`. Prints a clear error and exits with code 1 if
-/// the file is missing — the caller should run `room join <room_id> <username>`.
-pub fn read_token(room_id: &str) -> anyhow::Result<(String, String)> {
-    let token_path = PathBuf::from(format!("/tmp/room-{room_id}.token"));
+/// - `username_hint = Some(u)` → reads `/tmp/room-<room_id>-<u>.token` directly.
+/// - `username_hint = None` → scans `/tmp` for matching token files:
+///   - Exactly one found: use it (single-agent convenience).
+///   - Multiple found: error listing the candidates; the caller should retry with
+///     `--user <username>` to select the right one.
+///   - None found: error directing the caller to run `room join`.
+pub fn read_token(room_id: &str, username_hint: Option<&str>) -> anyhow::Result<(String, String)> {
+    let token_path = match username_hint {
+        Some(u) => token_file_path(room_id, u),
+        None => {
+            let prefix = format!("room-{room_id}-");
+            let suffix = ".token";
+            let mut matches: Vec<PathBuf> = std::fs::read_dir("/tmp")
+                .map_err(|e| anyhow::anyhow!("cannot read /tmp: {e}"))?
+                .filter_map(|e| e.ok())
+                .map(|e| e.path())
+                .filter(|p| {
+                    p.file_name()
+                        .and_then(|n| n.to_str())
+                        .map(|n| n.starts_with(&prefix) && n.ends_with(suffix))
+                        .unwrap_or(false)
+                })
+                .collect();
+            matches.sort();
+            match matches.len() {
+                0 => anyhow::bail!("token not found — run: room join {room_id} <username>"),
+                1 => matches.remove(0),
+                _ => {
+                    let users: Vec<String> = matches
+                        .iter()
+                        .filter_map(|p| {
+                            let name = p.file_name()?.to_str()?.to_owned();
+                            Some(name.strip_prefix(&prefix)?.strip_suffix(suffix)?.to_owned())
+                        })
+                        .collect();
+                    anyhow::bail!(
+                        "multiple sessions active for room '{room_id}' ({}). \
+                         use --user <username> to select one",
+                        users.join(", ")
+                    )
+                }
+            }
+        }
+    };
+
     let data = std::fs::read_to_string(&token_path)
         .map_err(|_| anyhow::anyhow!("token not found — run: room join {room_id} <username>"))?;
     let v: serde_json::Value = serde_json::from_str(data.trim())
@@ -138,8 +188,13 @@ pub fn read_token(room_id: &str) -> anyhow::Result<(String, String)> {
 /// Reads the caller's username and token from the session token file created by
 /// `room join`. When `to` is `Some(recipient)`, the message is sent as a DM
 /// envelope so the broker routes it only to the sender, recipient, and host.
-pub async fn cmd_send(room_id: &str, to: Option<&str>, content: &str) -> anyhow::Result<()> {
-    let (username, token) = read_token(room_id)?;
+pub async fn cmd_send(
+    room_id: &str,
+    user: Option<&str>,
+    to: Option<&str>,
+    content: &str,
+) -> anyhow::Result<()> {
+    let (username, token) = read_token(room_id, user)?;
     let socket_path = PathBuf::from(format!("/tmp/room-{room_id}.sock"));
     let wire = match to {
         Some(recipient) => {
@@ -217,8 +272,12 @@ pub async fn poll_messages(
 /// Exits after printing the first batch of foreign messages as NDJSON.
 /// Shares the cursor file with `room poll` — the two subcommands never re-deliver
 /// the same message.
-pub async fn cmd_watch(room_id: &str, interval_secs: u64) -> anyhow::Result<()> {
-    let (username, _token) = read_token(room_id)?;
+pub async fn cmd_watch(
+    room_id: &str,
+    user: Option<&str>,
+    interval_secs: u64,
+) -> anyhow::Result<()> {
+    let (username, _token) = read_token(room_id, user)?;
     let meta_path = PathBuf::from(format!("/tmp/room-{room_id}.meta"));
     let chat_path = chat_path_from_meta(room_id, &meta_path);
     let cursor_path = PathBuf::from(format!("/tmp/room-{room_id}-{username}.cursor"));
@@ -245,8 +304,12 @@ pub async fn cmd_watch(room_id: &str, interval_secs: u64) -> anyhow::Result<()> 
 /// One-shot poll subcommand: read messages since cursor, print as NDJSON, update cursor.
 ///
 /// Reads the caller's username from the session token file.
-pub async fn cmd_poll(room_id: &str, since: Option<String>) -> anyhow::Result<()> {
-    let (username, _token) = read_token(room_id)?;
+pub async fn cmd_poll(
+    room_id: &str,
+    user: Option<&str>,
+    since: Option<String>,
+) -> anyhow::Result<()> {
+    let (username, _token) = read_token(room_id, user)?;
     let meta_path = PathBuf::from(format!("/tmp/room-{room_id}.meta"));
     let chat_path = chat_path_from_meta(room_id, &meta_path);
     let cursor_path = PathBuf::from(format!("/tmp/room-{room_id}-{username}.cursor"));
@@ -282,4 +345,154 @@ fn read_cursor(cursor_path: &Path) -> Option<String> {
 fn write_cursor(cursor_path: &Path, id: &str) -> anyhow::Result<()> {
     std::fs::write(cursor_path, id)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod token_tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Write a token file for testing using an explicit directory instead of /tmp.
+    fn write_token_file(dir: &std::path::Path, room_id: &str, username: &str, token: &str) {
+        let name = format!("room-{room_id}-{username}.token");
+        let data = serde_json::json!({"username": username, "token": token});
+        fs::write(dir.join(&name), format!("{data}\n")).unwrap();
+    }
+
+    /// A version of read_token that scans a custom directory (for hermetic tests).
+    fn read_token_from(
+        dir: &std::path::Path,
+        room_id: &str,
+        username_hint: Option<&str>,
+    ) -> anyhow::Result<(String, String)> {
+        let token_path = match username_hint {
+            Some(u) => dir.join(format!("room-{room_id}-{u}.token")),
+            None => {
+                let prefix = format!("room-{room_id}-");
+                let suffix = ".token";
+                let mut matches: Vec<PathBuf> = fs::read_dir(dir)
+                    .unwrap()
+                    .filter_map(|e| e.ok())
+                    .map(|e| e.path())
+                    .filter(|p| {
+                        p.file_name()
+                            .and_then(|n| n.to_str())
+                            .map(|n| n.starts_with(&prefix) && n.ends_with(suffix))
+                            .unwrap_or(false)
+                    })
+                    .collect();
+                matches.sort();
+                match matches.len() {
+                    0 => anyhow::bail!("token not found — run: room join {room_id} <username>"),
+                    1 => matches.remove(0),
+                    _ => {
+                        let users: Vec<String> = matches
+                            .iter()
+                            .filter_map(|p| {
+                                let name = p.file_name()?.to_str()?.to_owned();
+                                Some(name.strip_prefix(&prefix)?.strip_suffix(suffix)?.to_owned())
+                            })
+                            .collect();
+                        anyhow::bail!(
+                            "multiple sessions active for room '{room_id}' ({}). \
+                             use --user <username> to select one",
+                            users.join(", ")
+                        )
+                    }
+                }
+            }
+        };
+        let data = fs::read_to_string(&token_path).unwrap();
+        let v: serde_json::Value = serde_json::from_str(data.trim()).unwrap();
+        let username = v["username"].as_str().unwrap().to_owned();
+        let token = v["token"].as_str().unwrap().to_owned();
+        Ok((username, token))
+    }
+
+    /// token_file_path produces a per-user path that differs between users.
+    #[test]
+    fn token_file_path_is_per_user() {
+        let p_alice = token_file_path("myroom", "alice");
+        let p_bob = token_file_path("myroom", "bob");
+        assert_ne!(p_alice, p_bob);
+        assert!(p_alice.to_str().unwrap().contains("alice"));
+        assert!(p_bob.to_str().unwrap().contains("bob"));
+    }
+
+    /// Single token file → read_token resolves it without a hint.
+    #[test]
+    fn read_token_single_file_no_hint() {
+        let dir = TempDir::new().unwrap();
+        write_token_file(dir.path(), "r1", "alice", "tok-alice");
+        let (user, tok) = read_token_from(dir.path(), "r1", None).unwrap();
+        assert_eq!(user, "alice");
+        assert_eq!(tok, "tok-alice");
+    }
+
+    /// Multiple token files → read_token errors without a hint.
+    #[test]
+    fn read_token_multiple_files_no_hint_errors() {
+        let dir = TempDir::new().unwrap();
+        write_token_file(dir.path(), "r2", "alice", "tok-alice");
+        write_token_file(dir.path(), "r2", "bob", "tok-bob");
+
+        let err = read_token_from(dir.path(), "r2", None).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("multiple sessions"),
+            "expected 'multiple sessions' in: {msg}"
+        );
+        assert!(msg.contains("--user"), "expected '--user' hint in: {msg}");
+        // Both usernames must be listed
+        assert!(msg.contains("alice"), "expected 'alice' in: {msg}");
+        assert!(msg.contains("bob"), "expected 'bob' in: {msg}");
+    }
+
+    /// With a hint, the correct token is returned even when multiple files exist.
+    #[test]
+    fn read_token_hint_selects_correct_file() {
+        let dir = TempDir::new().unwrap();
+        write_token_file(dir.path(), "r3", "alice", "tok-alice");
+        write_token_file(dir.path(), "r3", "bob", "tok-bob");
+
+        let (user, tok) = read_token_from(dir.path(), "r3", Some("alice")).unwrap();
+        assert_eq!(user, "alice");
+        assert_eq!(tok, "tok-alice");
+
+        let (user2, tok2) = read_token_from(dir.path(), "r3", Some("bob")).unwrap();
+        assert_eq!(user2, "bob");
+        assert_eq!(tok2, "tok-bob");
+    }
+
+    /// Two agents joining the same room write independent token files and neither
+    /// overwrites the other. This is the core regression for issue #40.
+    #[test]
+    fn two_agents_tokens_do_not_collide() {
+        let dir = TempDir::new().unwrap();
+        write_token_file(dir.path(), "r4", "alice", "tok-alice");
+        write_token_file(dir.path(), "r4", "bob", "tok-bob");
+
+        // alice's token is intact after bob wrote his
+        let (user, tok) = read_token_from(dir.path(), "r4", Some("alice")).unwrap();
+        assert_eq!(user, "alice");
+        assert_eq!(tok, "tok-alice");
+
+        // bob's token is intact after alice wrote hers
+        let (user, tok) = read_token_from(dir.path(), "r4", Some("bob")).unwrap();
+        assert_eq!(user, "bob");
+        assert_eq!(tok, "tok-bob");
+    }
+
+    /// No token file → clear error message directing the user to join.
+    #[test]
+    fn read_token_no_file_errors_with_join_hint() {
+        let dir = TempDir::new().unwrap();
+        let err = read_token_from(dir.path(), "r5", None).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("room join"),
+            "expected 'room join' hint in: {msg}"
+        );
+    }
 }


### PR DESCRIPTION
## Problem

Token files were stored at `/tmp/room-<id>.token` — one file per room. When multiple agents joined the same room on the same machine, each `room join` overwrote the previous agent's token. Subsequent `send`/`poll`/`watch` calls used the wrong identity and sent messages under the wrong username.

Discovered during live testing: ba's token was overwritten by claude-sonnet, causing ba's messages to be broadcast as claude-sonnet.

## Fix

- Token file path is now `/tmp/room-<id>-<username>.token` — one file per (room, user) pair. Multiple agents on the same machine never clobber each other.
- `read_token()` scans `/tmp` for a unique match when no hint is given (single-agent convenience). If multiple files exist it errors with a clear message listing candidates.
- `--user <username>` flag added to `send`, `poll`, `watch` as an explicit selector for the multi-agent same-machine case.

## Tests

5 new unit tests in `oneshot::token_tests`:
- `token_file_path_is_per_user` — paths differ between users
- `read_token_single_file_no_hint` — auto-resolves with one file
- `read_token_multiple_files_no_hint_errors` — clear error + `--user` hint when multiple exist
- `read_token_hint_selects_correct_file` — `--user` picks the right token
- `two_agents_tokens_do_not_collide` — core regression: alice's token survives bob joining

These are the tests that would have caught this before ship.

Fixes #40