### PR TITLE
refactor(auth): -t/--token required on send/poll/watch

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,13 +15,13 @@ enum Cmd {
     Join { room_id: String, username: String },
     /// One-shot send a message to a room (requires a running broker).
     ///
-    /// Reads the caller's identity from the session token file created by
-    /// `room join`. Prints the broadcast message JSON and exits.
+    /// The broker resolves the sender's identity from the token issued by `room join`.
+    /// Prints the broadcast message JSON and exits.
     Send {
         room_id: String,
-        /// Select token by username (required when multiple sessions share this machine)
-        #[arg(long)]
-        user: Option<String>,
+        /// Session token from `room join` (required)
+        #[arg(short = 't', long)]
+        token: String,
         /// Recipient username for a direct message
         #[arg(long)]
         to: Option<String>,
@@ -31,28 +31,26 @@ enum Cmd {
     },
     /// Poll for new messages, printing NDJSON to stdout.
     ///
-    /// Reads the caller's identity from the session token file. Updates a
-    /// per-user cursor file so subsequent calls return only unseen messages.
+    /// Updates a per-user cursor file so subsequent calls return only unseen messages.
     Poll {
         room_id: String,
-        /// Select token by username (required when multiple sessions share this machine)
-        #[arg(long)]
-        user: Option<String>,
+        /// Session token from `room join` (required)
+        #[arg(short = 't', long)]
+        token: String,
         /// Return only messages after this message ID (overrides stored cursor)
         #[arg(long)]
         since: Option<String>,
     },
-    /// Watch for new messages from other users, blocking until at least one
-    /// arrives. Polls the chat file on a configurable interval. Shares the
-    /// cursor file with `room poll` so no messages are re-delivered. Exits
-    /// after printing the first batch of foreign messages as NDJSON.
+    /// Watch for new messages from other users, blocking until at least one arrives.
     ///
-    /// Reads the caller's identity from the session token file.
+    /// Polls the chat file on a configurable interval. Shares the cursor file with
+    /// `room poll` so no messages are re-delivered. Exits after printing the first
+    /// batch of foreign messages as NDJSON.
     Watch {
         room_id: String,
-        /// Select token by username (required when multiple sessions share this machine)
-        #[arg(long)]
-        user: Option<String>,
+        /// Session token from `room join` (required)
+        #[arg(short = 't', long)]
+        token: String,
         /// Poll interval in seconds (default: 5)
         #[arg(long, default_value_t = 5)]
         interval: u64,
@@ -103,26 +101,26 @@ async fn main() -> anyhow::Result<()> {
         }
         Some(Cmd::Send {
             room_id,
-            user,
+            token,
             to,
             message,
         }) => {
             let content = message.join(" ");
-            oneshot::cmd_send(&room_id, user.as_deref(), to.as_deref(), &content).await?;
+            oneshot::cmd_send(&room_id, &token, to.as_deref(), &content).await?;
         }
         Some(Cmd::Poll {
             room_id,
-            user,
+            token,
             since,
         }) => {
-            oneshot::cmd_poll(&room_id, user.as_deref(), since).await?;
+            oneshot::cmd_poll(&room_id, &token, since).await?;
         }
         Some(Cmd::Watch {
             room_id,
-            user,
+            token,
             interval,
         }) => {
-            oneshot::cmd_watch(&room_id, user.as_deref(), interval).await?;
+            oneshot::cmd_watch(&room_id, &token, interval).await?;
         }
         None => {
             let room_id = args.room_id.unwrap_or_else(|| {

--- a/src/oneshot.rs
+++ b/src/oneshot.rs
@@ -121,80 +121,53 @@ pub async fn cmd_join(room_id: &str, username: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Read the session token file for `room_id`.
+/// Look up the username associated with `token` by scanning stored token files for `room_id`.
 ///
-/// - `username_hint = Some(u)` → reads `/tmp/room-<room_id>-<u>.token` directly.
-/// - `username_hint = None` → scans `/tmp` for matching token files:
-///   - Exactly one found: use it (single-agent convenience).
-///   - Multiple found: error listing the candidates; the caller should retry with
-///     `--user <username>` to select the right one.
-///   - None found: error directing the caller to run `room join`.
-pub fn read_token(room_id: &str, username_hint: Option<&str>) -> anyhow::Result<(String, String)> {
-    let token_path = match username_hint {
-        Some(u) => token_file_path(room_id, u),
-        None => {
-            let prefix = format!("room-{room_id}-");
-            let suffix = ".token";
-            let mut matches: Vec<PathBuf> = std::fs::read_dir("/tmp")
-                .map_err(|e| anyhow::anyhow!("cannot read /tmp: {e}"))?
-                .filter_map(|e| e.ok())
-                .map(|e| e.path())
-                .filter(|p| {
-                    p.file_name()
-                        .and_then(|n| n.to_str())
-                        .map(|n| n.starts_with(&prefix) && n.ends_with(suffix))
-                        .unwrap_or(false)
-                })
-                .collect();
-            matches.sort();
-            match matches.len() {
-                0 => anyhow::bail!("token not found — run: room join {room_id} <username>"),
-                1 => matches.remove(0),
-                _ => {
-                    let users: Vec<String> = matches
-                        .iter()
-                        .filter_map(|p| {
-                            let name = p.file_name()?.to_str()?.to_owned();
-                            Some(name.strip_prefix(&prefix)?.strip_suffix(suffix)?.to_owned())
-                        })
-                        .collect();
-                    anyhow::bail!(
-                        "multiple sessions active for room '{room_id}' ({}). \
-                         use --user <username> to select one",
-                        users.join(", ")
-                    )
+/// `room join` writes `/tmp/room-<room_id>-<username>.token` for each session.
+/// This function finds the file whose `token` field matches the given value and
+/// returns the corresponding username. Used by `poll` and `watch` to resolve the
+/// cursor file path without requiring the caller to pass a username explicitly.
+pub fn username_from_token(room_id: &str, token: &str) -> anyhow::Result<String> {
+    let prefix = format!("room-{room_id}-");
+    let suffix = ".token";
+    let files: Vec<PathBuf> = std::fs::read_dir("/tmp")
+        .map_err(|e| anyhow::anyhow!("cannot read /tmp: {e}"))?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .map(|n| n.starts_with(&prefix) && n.ends_with(suffix))
+                .unwrap_or(false)
+        })
+        .collect();
+
+    for path in files {
+        if let Ok(data) = std::fs::read_to_string(&path) {
+            if let Ok(v) = serde_json::from_str::<serde_json::Value>(data.trim()) {
+                if v["token"].as_str() == Some(token) {
+                    if let Some(u) = v["username"].as_str() {
+                        return Ok(u.to_owned());
+                    }
                 }
             }
         }
-    };
+    }
 
-    let data = std::fs::read_to_string(&token_path)
-        .map_err(|_| anyhow::anyhow!("token not found — run: room join {room_id} <username>"))?;
-    let v: serde_json::Value = serde_json::from_str(data.trim())
-        .map_err(|e| anyhow::anyhow!("malformed token file {}: {e}", token_path.display()))?;
-    let username = v["username"]
-        .as_str()
-        .ok_or_else(|| anyhow::anyhow!("token file missing 'username' field"))?
-        .to_owned();
-    let token = v["token"]
-        .as_str()
-        .ok_or_else(|| anyhow::anyhow!("token file missing 'token' field"))?
-        .to_owned();
-    Ok((username, token))
+    anyhow::bail!("token not recognised — run: room join {room_id} <username> to get a fresh token")
 }
 
 /// One-shot send subcommand: connect, send, print echo JSON to stdout, exit.
 ///
-/// Reads the caller's username and token from the session token file created by
-/// `room join`. When `to` is `Some(recipient)`, the message is sent as a DM
-/// envelope so the broker routes it only to the sender, recipient, and host.
+/// Authenticates via `token` (from `room join`). The broker resolves the sender's
+/// username from the token — no username arg required. When `to` is `Some(recipient)`,
+/// the message is sent as a DM routed only to sender, recipient, and host.
 pub async fn cmd_send(
     room_id: &str,
-    user: Option<&str>,
+    token: &str,
     to: Option<&str>,
     content: &str,
 ) -> anyhow::Result<()> {
-    let (username, token) = read_token(room_id, user)?;
     let socket_path = PathBuf::from(format!("/tmp/room-{room_id}.sock"));
     let wire = match to {
         Some(recipient) => {
@@ -202,12 +175,11 @@ pub async fn cmd_send(
         }
         None => serde_json::json!({"type": "message", "content": content}).to_string(),
     };
-    let msg = send_message_with_token(&socket_path, &token, &wire)
+    let msg = send_message_with_token(&socket_path, token, &wire)
         .await
         .map_err(|e| {
-            // Provide the room-id in the re-join hint rather than the socket path.
             if e.to_string().contains("invalid token") {
-                anyhow::anyhow!("invalid token — run: room join {room_id} {username}")
+                anyhow::anyhow!("invalid token — run: room join {room_id} <username>")
             } else {
                 e
             }
@@ -272,12 +244,8 @@ pub async fn poll_messages(
 /// Exits after printing the first batch of foreign messages as NDJSON.
 /// Shares the cursor file with `room poll` — the two subcommands never re-deliver
 /// the same message.
-pub async fn cmd_watch(
-    room_id: &str,
-    user: Option<&str>,
-    interval_secs: u64,
-) -> anyhow::Result<()> {
-    let (username, _token) = read_token(room_id, user)?;
+pub async fn cmd_watch(room_id: &str, token: &str, interval_secs: u64) -> anyhow::Result<()> {
+    let username = username_from_token(room_id, token)?;
     let meta_path = PathBuf::from(format!("/tmp/room-{room_id}.meta"));
     let chat_path = chat_path_from_meta(room_id, &meta_path);
     let cursor_path = PathBuf::from(format!("/tmp/room-{room_id}-{username}.cursor"));
@@ -304,12 +272,8 @@ pub async fn cmd_watch(
 /// One-shot poll subcommand: read messages since cursor, print as NDJSON, update cursor.
 ///
 /// Reads the caller's username from the session token file.
-pub async fn cmd_poll(
-    room_id: &str,
-    user: Option<&str>,
-    since: Option<String>,
-) -> anyhow::Result<()> {
-    let (username, _token) = read_token(room_id, user)?;
+pub async fn cmd_poll(room_id: &str, token: &str, since: Option<String>) -> anyhow::Result<()> {
+    let username = username_from_token(room_id, token)?;
     let meta_path = PathBuf::from(format!("/tmp/room-{room_id}.meta"));
     let chat_path = chat_path_from_meta(room_id, &meta_path);
     let cursor_path = PathBuf::from(format!("/tmp/room-{room_id}-{username}.cursor"));
@@ -353,146 +317,110 @@ mod token_tests {
     use std::fs;
     use tempfile::TempDir;
 
-    /// Write a token file for testing using an explicit directory instead of /tmp.
+    /// Write a token file into a temp dir and return the token string.
     fn write_token_file(dir: &std::path::Path, room_id: &str, username: &str, token: &str) {
         let name = format!("room-{room_id}-{username}.token");
         let data = serde_json::json!({"username": username, "token": token});
-        fs::write(dir.join(&name), format!("{data}\n")).unwrap();
+        fs::write(dir.join(name), format!("{data}\n")).unwrap();
     }
 
-    /// A version of read_token that scans a custom directory (for hermetic tests).
-    fn read_token_from(
+    /// A version of username_from_token that scans a custom directory (for hermetic tests).
+    fn username_from_token_in(
         dir: &std::path::Path,
         room_id: &str,
-        username_hint: Option<&str>,
-    ) -> anyhow::Result<(String, String)> {
-        let token_path = match username_hint {
-            Some(u) => dir.join(format!("room-{room_id}-{u}.token")),
-            None => {
-                let prefix = format!("room-{room_id}-");
-                let suffix = ".token";
-                let mut matches: Vec<PathBuf> = fs::read_dir(dir)
-                    .unwrap()
-                    .filter_map(|e| e.ok())
-                    .map(|e| e.path())
-                    .filter(|p| {
-                        p.file_name()
-                            .and_then(|n| n.to_str())
-                            .map(|n| n.starts_with(&prefix) && n.ends_with(suffix))
-                            .unwrap_or(false)
-                    })
-                    .collect();
-                matches.sort();
-                match matches.len() {
-                    0 => anyhow::bail!("token not found — run: room join {room_id} <username>"),
-                    1 => matches.remove(0),
-                    _ => {
-                        let users: Vec<String> = matches
-                            .iter()
-                            .filter_map(|p| {
-                                let name = p.file_name()?.to_str()?.to_owned();
-                                Some(name.strip_prefix(&prefix)?.strip_suffix(suffix)?.to_owned())
-                            })
-                            .collect();
-                        anyhow::bail!(
-                            "multiple sessions active for room '{room_id}' ({}). \
-                             use --user <username> to select one",
-                            users.join(", ")
-                        )
+        token: &str,
+    ) -> anyhow::Result<String> {
+        let prefix = format!("room-{room_id}-");
+        let suffix = ".token";
+        let files: Vec<PathBuf> = fs::read_dir(dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| {
+                p.file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|n| n.starts_with(&prefix) && n.ends_with(suffix))
+                    .unwrap_or(false)
+            })
+            .collect();
+
+        for path in files {
+            if let Ok(data) = fs::read_to_string(&path) {
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(data.trim()) {
+                    if v["token"].as_str() == Some(token) {
+                        if let Some(u) = v["username"].as_str() {
+                            return Ok(u.to_owned());
+                        }
                     }
                 }
             }
-        };
-        let data = fs::read_to_string(&token_path).unwrap();
-        let v: serde_json::Value = serde_json::from_str(data.trim()).unwrap();
-        let username = v["username"].as_str().unwrap().to_owned();
-        let token = v["token"].as_str().unwrap().to_owned();
-        Ok((username, token))
+        }
+        anyhow::bail!("token not recognised — run: room join {room_id} <username>")
     }
 
     /// token_file_path produces a per-user path that differs between users.
     #[test]
     fn token_file_path_is_per_user() {
-        let p_alice = token_file_path("myroom", "alice");
-        let p_bob = token_file_path("myroom", "bob");
-        assert_ne!(p_alice, p_bob);
-        assert!(p_alice.to_str().unwrap().contains("alice"));
-        assert!(p_bob.to_str().unwrap().contains("bob"));
+        let alice = token_file_path("myroom", "alice");
+        let bob = token_file_path("myroom", "bob");
+        assert_ne!(alice, bob);
+        assert!(alice.to_str().unwrap().contains("alice"));
+        assert!(bob.to_str().unwrap().contains("bob"));
     }
 
-    /// Single token file → read_token resolves it without a hint.
+    /// Given a valid token, username_from_token returns the correct username.
     #[test]
-    fn read_token_single_file_no_hint() {
+    fn username_from_token_finds_correct_user() {
         let dir = TempDir::new().unwrap();
         write_token_file(dir.path(), "r1", "alice", "tok-alice");
-        let (user, tok) = read_token_from(dir.path(), "r1", None).unwrap();
+        let user = username_from_token_in(dir.path(), "r1", "tok-alice").unwrap();
         assert_eq!(user, "alice");
-        assert_eq!(tok, "tok-alice");
     }
 
-    /// Multiple token files → read_token errors without a hint.
+    /// Multiple token files coexist — each resolves to the right username.
     #[test]
-    fn read_token_multiple_files_no_hint_errors() {
+    fn username_from_token_disambiguates_multiple_users() {
         let dir = TempDir::new().unwrap();
         write_token_file(dir.path(), "r2", "alice", "tok-alice");
         write_token_file(dir.path(), "r2", "bob", "tok-bob");
 
-        let err = read_token_from(dir.path(), "r2", None).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("multiple sessions"),
-            "expected 'multiple sessions' in: {msg}"
+        assert_eq!(
+            username_from_token_in(dir.path(), "r2", "tok-alice").unwrap(),
+            "alice"
         );
-        assert!(msg.contains("--user"), "expected '--user' hint in: {msg}");
-        // Both usernames must be listed
-        assert!(msg.contains("alice"), "expected 'alice' in: {msg}");
-        assert!(msg.contains("bob"), "expected 'bob' in: {msg}");
+        assert_eq!(
+            username_from_token_in(dir.path(), "r2", "tok-bob").unwrap(),
+            "bob"
+        );
     }
 
-    /// With a hint, the correct token is returned even when multiple files exist.
+    /// Unknown token → clear error with join hint.
     #[test]
-    fn read_token_hint_selects_correct_file() {
+    fn username_from_token_unknown_errors_with_join_hint() {
         let dir = TempDir::new().unwrap();
-        write_token_file(dir.path(), "r3", "alice", "tok-alice");
-        write_token_file(dir.path(), "r3", "bob", "tok-bob");
-
-        let (user, tok) = read_token_from(dir.path(), "r3", Some("alice")).unwrap();
-        assert_eq!(user, "alice");
-        assert_eq!(tok, "tok-alice");
-
-        let (user2, tok2) = read_token_from(dir.path(), "r3", Some("bob")).unwrap();
-        assert_eq!(user2, "bob");
-        assert_eq!(tok2, "tok-bob");
+        let err = username_from_token_in(dir.path(), "r3", "not-a-real-token").unwrap_err();
+        assert!(
+            err.to_string().contains("room join"),
+            "expected 'room join' hint in: {err}"
+        );
     }
 
     /// Two agents joining the same room write independent token files and neither
-    /// overwrites the other. This is the core regression for issue #40.
+    /// overwrites the other — core regression for issue #40.
     #[test]
     fn two_agents_tokens_do_not_collide() {
         let dir = TempDir::new().unwrap();
         write_token_file(dir.path(), "r4", "alice", "tok-alice");
         write_token_file(dir.path(), "r4", "bob", "tok-bob");
 
-        // alice's token is intact after bob wrote his
-        let (user, tok) = read_token_from(dir.path(), "r4", Some("alice")).unwrap();
-        assert_eq!(user, "alice");
-        assert_eq!(tok, "tok-alice");
-
-        // bob's token is intact after alice wrote hers
-        let (user, tok) = read_token_from(dir.path(), "r4", Some("bob")).unwrap();
-        assert_eq!(user, "bob");
-        assert_eq!(tok, "tok-bob");
-    }
-
-    /// No token file → clear error message directing the user to join.
-    #[test]
-    fn read_token_no_file_errors_with_join_hint() {
-        let dir = TempDir::new().unwrap();
-        let err = read_token_from(dir.path(), "r5", None).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("room join"),
-            "expected 'room join' hint in: {msg}"
+        // Both files survive; each resolves to the right user via their token.
+        assert_eq!(
+            username_from_token_in(dir.path(), "r4", "tok-alice").unwrap(),
+            "alice"
+        );
+        assert_eq!(
+            username_from_token_in(dir.path(), "r4", "tok-bob").unwrap(),
+            "bob"
         );
     }
 }


### PR DESCRIPTION
## Summary

- `--user <username>` removed from `send`, `poll`, `watch`
- `-t/--token <uuid>` added as a **required** flag on all three
- Broker already resolves sender identity from token for `send`
- For `poll`/`watch` (file-based), `username_from_token()` scans local token files to find the username matching the given token
- `--to` remains solely for DM recipient

## Usage after this change

```bash
TOKEN=$(room join agent-room alice | jq -r .token)
room send agent-room -t $TOKEN "hello"
room poll agent-room -t $TOKEN
room watch agent-room -t $TOKEN
room send agent-room -t $TOKEN --to bob "dm for bob"
```

## Tests updated

Unit tests in `token_tests` rewritten around `username_from_token` — same collision-safety coverage, simpler helpers.