### PR TITLE
ci: add workflow_dispatch to release.yml for manual trigger fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g. v0.5.0) — use when tag push did not trigger CI'
+        required: true
 
 jobs:
   build:
@@ -24,6 +29,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -57,6 +64,7 @@ jobs:
           sha256sum room-* > SHA256SUMS
       - uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
           files: |
             artifacts/room-macos-arm64
             artifacts/room-macos-x86_64
@@ -70,6 +78,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Publish


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger to `release.yml` with a `tag` input
- All three jobs (`build`, `release`, `publish`) check out the correct ref when triggered manually
- `softprops/action-gh-release` targets the correct tag via `tag_name` input

## Usage (escape hatch when tag push doesn't fire CI)

```bash
gh workflow run release.yml -f tag=v0.5.0
```

## Why

`v0.5.0` release CI never triggered — tag was created via GitHub API rather than a local `git push`, which doesn't fire the `push` webhook. This adds a manual escape hatch so the situation can be recovered without deleting and re-pushing tags.

Closes #44