### PR TITLE
fix(broker): kick removes user from status map; /who works via oneshot

### DIFF
--- a/src/broker.rs
+++ b/src/broker.rs
@@ -121,7 +121,7 @@ async fn handle_client(
     cid: u64,
     stream: UnixStream,
     own_tx: broadcast::Sender<String>,
-    state: &RoomState,
+    state: &Arc<RoomState>,
 ) -> anyhow::Result<()> {
     // Clone the Arc fields up-front so spawned tasks can capture owned handles.
     let clients = state.clients.clone();
@@ -130,7 +130,6 @@ async fn handle_client(
     let token_map = state.token_map.clone();
     let chat_path = state.chat_path.clone();
     let room_id = state.room_id.clone();
-    let shutdown = state.shutdown.clone();
 
     let (read_half, mut write_half) = stream.into_split();
     let mut reader = BufReader::new(read_half);
@@ -255,9 +254,8 @@ async fn handle_client(
     let status_map_in = status_map.clone();
     let host_user_in = host_user.clone();
     let chat_path_in = chat_path.clone();
-    let token_map_in = token_map.clone();
-    let shutdown_in = shutdown.clone();
     let write_half_in = write_half.clone();
+    let state_in = state.clone();
     let inbound = tokio::spawn(async move {
         let mut line = String::new();
         loop {
@@ -271,16 +269,7 @@ async fn handle_client(
                     }
                     // Admin commands: lines starting with `\`
                     if let Some(admin_line) = trimmed.strip_prefix('\\') {
-                        handle_admin_cmd(
-                            admin_line,
-                            &username_in,
-                            &room_id_in,
-                            &clients_in,
-                            &token_map_in,
-                            &chat_path_in,
-                            &shutdown_in,
-                        )
-                        .await;
+                        handle_admin_cmd(admin_line, &username_in, &state_in).await;
                         continue;
                     }
                     match parse_client_line(trimmed, &room_id_in, &username_in) {
@@ -401,21 +390,39 @@ async fn handle_oneshot_send(
     }
     // Admin commands: lines starting with `\`
     if let Some(admin_line) = trimmed.strip_prefix('\\') {
-        handle_admin_cmd(
-            admin_line,
-            &username,
-            &state.room_id,
-            &state.clients,
-            &state.token_map,
-            &state.chat_path,
-            &state.shutdown,
-        )
-        .await;
+        handle_admin_cmd(admin_line, &username, state).await;
         let ack = serde_json::json!({"type":"system","user":"broker","content":"command executed"});
         write_half.write_all(format!("{ack}\n").as_bytes()).await?;
         return Ok(());
     }
     let msg = parse_client_line(trimmed, &state.room_id, &username)?;
+    // Handle /who privately in oneshot context: return the user list without broadcasting.
+    if let Message::Command { ref cmd, .. } = msg {
+        if cmd == "who" {
+            let map = state.status_map.lock().await;
+            let mut entries: Vec<String> = map
+                .iter()
+                .map(|(u, s)| {
+                    if s.is_empty() {
+                        u.clone()
+                    } else {
+                        format!("{u}: {s}")
+                    }
+                })
+                .collect();
+            entries.sort();
+            drop(map);
+            let content = if entries.is_empty() {
+                "no users online".to_owned()
+            } else {
+                format!("online — {}", entries.join(", "))
+            };
+            let sys = make_system(&state.room_id, "broker", content);
+            let json = serde_json::to_string(&sys)?;
+            write_half.write_all(format!("{json}\n").as_bytes()).await?;
+            return Ok(());
+        }
+    }
     let result = match &msg {
         Message::DirectMessage { to, .. } => {
             dm_and_persist(
@@ -465,19 +472,19 @@ async fn handle_oneshot_join(
 /// Supported commands:
 /// - `\kick <username>`      — invalidates the user's token so they cannot issue further
 ///   authenticated requests; the username remains reserved so they cannot rejoin without `\reauth`.
+///   Also removes them from the status map so `/who` no longer shows them as online.
 /// - `\reauth <username>`    — removes the user's token entirely so they can `room join` again.
 /// - `\clear-tokens`         — removes every token for this room (all users must rejoin).
 /// - `\exit`                 — broadcasts a shutdown notice then signals the broker to stop.
 /// - `\clear`                — truncates the chat history file and broadcasts a notice.
-async fn handle_admin_cmd(
-    cmd_line: &str,
-    issuer: &str,
-    room_id: &str,
-    clients: &ClientMap,
-    token_map: &TokenMap,
-    chat_path: &Arc<PathBuf>,
-    shutdown: &Arc<Notify>,
-) {
+async fn handle_admin_cmd(cmd_line: &str, issuer: &str, state: &RoomState) {
+    let room_id = state.room_id.as_str();
+    let clients = &state.clients;
+    let token_map = &state.token_map;
+    let status_map = &state.status_map;
+    let chat_path = &state.chat_path;
+    let shutdown = &state.shutdown;
+
     let mut parts = cmd_line.splitn(2, ' ');
     let cmd = parts.next().unwrap_or("").trim();
     let arg = parts.next().unwrap_or("").trim();
@@ -495,6 +502,8 @@ async fn handle_admin_cmd(
             map.retain(|_, u| u != &target);
             map.insert(format!("KICKED:{target}"), target.clone());
             drop(map);
+            // Remove from status map immediately so /who no longer shows the kicked user.
+            status_map.lock().await.remove(&target);
             let content = format!("{issuer} kicked {target} (token invalidated)");
             let msg = make_system(room_id, "broker", content);
             let _ = broadcast_and_persist(&msg, clients, chat_path).await;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1721,3 +1721,82 @@ async fn pull_messages_filters_dms_for_viewer() {
         "alice should see the DM addressed to her"
     );
 }
+
+/// After `\kick`, the kicked user must not appear in subsequent `/who` responses.
+#[tokio::test]
+async fn kick_removes_user_from_who() {
+    let broker = TestBroker::start("t_kick_who").await;
+    let mut admin = TestClient::connect(&broker.socket_path, "admin").await;
+    admin
+        .recv_until(|m| matches!(m, Message::Join { .. }))
+        .await;
+
+    let mut victim = TestClient::connect(&broker.socket_path, "victim").await;
+    victim
+        .recv_until(|m| matches!(m, Message::Join { user, .. } if user == "victim"))
+        .await;
+
+    // Admin kicks victim
+    admin.send_text(r"\kick victim").await;
+    admin
+        .recv_until(|m| matches!(m, Message::System { .. }))
+        .await;
+
+    // Admin queries /who — victim should no longer appear
+    admin
+        .send_json(r#"{"type":"command","cmd":"who","params":[]}"#)
+        .await;
+    let sys = admin
+        .recv_until(|m| matches!(m, Message::System { .. }))
+        .await;
+    let Message::System { content, .. } = &sys else {
+        panic!("expected system message");
+    };
+    assert!(
+        !content.contains("victim"),
+        "kicked user should not appear in /who, got: {content}"
+    );
+    assert!(
+        content.contains("admin"),
+        "admin should still appear in /who, got: {content}"
+    );
+}
+
+/// `/who` via oneshot send returns the user list to the sender without broadcasting.
+#[tokio::test]
+async fn oneshot_who_returns_user_list() {
+    let broker = TestBroker::start("t_oneshot_who").await;
+    let mut alice = TestClient::connect(&broker.socket_path, "alice").await;
+    alice
+        .recv_until(|m| matches!(m, Message::Join { .. }))
+        .await;
+
+    let (_, tok) = room::oneshot::join_session(&broker.socket_path, "bot")
+        .await
+        .unwrap();
+
+    let wire = serde_json::json!({"type":"command","cmd":"who","params":[]}).to_string();
+    let msg = room::oneshot::send_message_with_token(&broker.socket_path, &tok, &wire)
+        .await
+        .expect("oneshot /who should succeed");
+
+    let Message::System { content, .. } = msg else {
+        panic!("expected system message, got: {msg:?}");
+    };
+    assert!(
+        content.contains("alice"),
+        "/who should list alice, got: {content}"
+    );
+
+    // The Command should NOT have been broadcast to alice
+    let got_cmd = tokio::time::timeout(std::time::Duration::from_millis(200), async {
+        alice
+            .recv_until(|m| matches!(m, Message::Command { cmd, .. } if cmd == "who"))
+            .await
+    })
+    .await;
+    assert!(
+        got_cmd.is_err(),
+        "/who command should not be broadcast to other clients"
+    );
+}


### PR DESCRIPTION
## Summary

- `\kick` now removes the target from `StatusMap` immediately so `/who` no longer lists them as online before their TCP connection closes
- `handle_oneshot_send` intercepts `Command{who}` and returns the user list directly to the sender — previously it broadcast the raw Command to all clients with no response
- Refactored `handle_admin_cmd` to accept `&RoomState` instead of 8 individual params (fixes `clippy::too_many_arguments`)

## Tests

Added two regression tests:
- `kick_removes_user_from_who` — verifies kicked user is absent from subsequent `/who` responses
- `oneshot_who_returns_user_list` — verifies oneshot `/who` returns a System message with the user list

44 integration tests total, all green.

Closes #49