### PR TITLE
feat: sequential message sequence numbers (#51)

### DIFF
--- a/src/broker.rs
+++ b/src/broker.rs
@@ -1,7 +1,10 @@
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
 };
 
 use tokio::{
@@ -44,6 +47,9 @@ struct RoomState {
     room_id: Arc<String>,
     /// Signalled by the `\exit` admin command to shut down the broker run loop.
     shutdown: Arc<Notify>,
+    /// Monotonically-increasing sequence counter. Incremented for every message
+    /// broadcast or persisted by the broker, starting at 1.
+    seq_counter: Arc<AtomicU64>,
 }
 
 pub struct Broker {
@@ -81,6 +87,7 @@ impl Broker {
             chat_path: Arc::new(self.chat_path.clone()),
             room_id: Arc::new(self.room_id.clone()),
             shutdown: shutdown.clone(),
+            seq_counter: Arc::new(AtomicU64::new(0)),
         });
         let mut next_id: u64 = 0;
 
@@ -130,6 +137,7 @@ async fn handle_client(
     let token_map = state.token_map.clone();
     let chat_path = state.chat_path.clone();
     let room_id = state.room_id.clone();
+    let seq_counter = state.seq_counter.clone();
 
     let (read_half, mut write_half) = stream.into_split();
     let mut reader = BufReader::new(read_half);
@@ -220,7 +228,7 @@ async fn handle_client(
 
     // Broadcast join event (also persists it)
     let join_msg = make_join(room_id.as_str(), &username);
-    if let Err(e) = broadcast_and_persist(&join_msg, &clients, &chat_path).await {
+    if let Err(e) = broadcast_and_persist(&join_msg, &clients, &chat_path, &seq_counter).await {
         eprintln!("[broker] broadcast_and_persist(join) failed: {e:#}");
         return Ok(());
     }
@@ -254,6 +262,7 @@ async fn handle_client(
     let status_map_in = status_map.clone();
     let host_user_in = host_user.clone();
     let chat_path_in = chat_path.clone();
+    let seq_counter_in = seq_counter.clone();
     let write_half_in = write_half.clone();
     let state_in = state.clone();
     let inbound = tokio::spawn(async move {
@@ -304,9 +313,13 @@ async fn handle_client(
                                         format!("{username_in} set status: {status}")
                                     };
                                     let sys = make_system(&room_id_in, "broker", display);
-                                    if let Err(e) =
-                                        broadcast_and_persist(&sys, &clients_in, &chat_path_in)
-                                            .await
+                                    if let Err(e) = broadcast_and_persist(
+                                        &sys,
+                                        &clients_in,
+                                        &chat_path_in,
+                                        &seq_counter_in,
+                                    )
+                                    .await
                                     {
                                         eprintln!("[broker] persist error: {e:#}");
                                     }
@@ -351,10 +364,19 @@ async fn handle_client(
                                         &host_user_in,
                                         &clients_in,
                                         &chat_path_in,
+                                        &seq_counter_in,
                                     )
                                     .await
                                 }
-                                _ => broadcast_and_persist(&msg, &clients_in, &chat_path_in).await,
+                                _ => {
+                                    broadcast_and_persist(
+                                        &msg,
+                                        &clients_in,
+                                        &chat_path_in,
+                                        &seq_counter_in,
+                                    )
+                                    .await
+                                }
                             };
                             if let Err(e) = result {
                                 eprintln!("[broker] persist error: {e:#}");
@@ -378,7 +400,7 @@ async fn handle_client(
 
     // Broadcast leave event
     let leave_msg = make_leave(room_id.as_str(), &username);
-    let _ = broadcast_and_persist(&leave_msg, &clients, &chat_path).await;
+    let _ = broadcast_and_persist(&leave_msg, &clients, &chat_path, &seq_counter).await;
     eprintln!("[broker] {username} left (cid={cid})");
 
     Ok(())
@@ -447,13 +469,16 @@ async fn handle_oneshot_send(
                 &state.host_user,
                 &state.clients,
                 &state.chat_path,
+                &state.seq_counter,
             )
             .await
         }
-        _ => broadcast_and_persist(&msg, &state.clients, &state.chat_path).await,
+        _ => {
+            broadcast_and_persist(&msg, &state.clients, &state.chat_path, &state.seq_counter).await
+        }
     };
-    result?;
-    let echo = format!("{}\n", serde_json::to_string(&msg)?);
+    let seq_msg = result?;
+    let echo = format!("{}\n", serde_json::to_string(&seq_msg)?);
     write_half.write_all(echo.as_bytes()).await?;
     Ok(())
 }
@@ -513,7 +538,7 @@ async fn handle_admin_cmd(cmd_line: &str, issuer: &str, state: &RoomState) -> Op
     let status_map = &state.status_map;
     let chat_path = &state.chat_path;
     let shutdown = &state.shutdown;
-
+    let seq_counter = &state.seq_counter;
     let mut parts = cmd_line.splitn(2, ' ');
     let cmd = parts.next().unwrap_or("").trim();
     let arg = parts.next().unwrap_or("").trim();
@@ -535,7 +560,7 @@ async fn handle_admin_cmd(cmd_line: &str, issuer: &str, state: &RoomState) -> Op
             status_map.lock().await.remove(&target);
             let content = format!("{issuer} kicked {target} (token invalidated)");
             let msg = make_system(room_id, "broker", content);
-            let _ = broadcast_and_persist(&msg, clients, chat_path).await;
+            let _ = broadcast_and_persist(&msg, clients, chat_path, seq_counter).await;
         }
         "reauth" => {
             if arg.is_empty() {
@@ -559,7 +584,7 @@ async fn handle_admin_cmd(cmd_line: &str, issuer: &str, state: &RoomState) -> Op
             }
             let content = format!("{issuer} reauthed {target} (token cleared, can rejoin)");
             let msg = make_system(room_id, "broker", content);
-            let _ = broadcast_and_persist(&msg, clients, chat_path).await;
+            let _ = broadcast_and_persist(&msg, clients, chat_path, seq_counter).await;
         }
         "clear-tokens" => {
             token_map.lock().await.clear();
@@ -576,12 +601,12 @@ async fn handle_admin_cmd(cmd_line: &str, issuer: &str, state: &RoomState) -> Op
             }
             let content = format!("{issuer} cleared all tokens (all users must rejoin)");
             let msg = make_system(room_id, "broker", content);
-            let _ = broadcast_and_persist(&msg, clients, chat_path).await;
+            let _ = broadcast_and_persist(&msg, clients, chat_path, seq_counter).await;
         }
         "exit" => {
             let content = format!("{issuer} is shutting down the room");
             let msg = make_system(room_id, "broker", content);
-            let _ = broadcast_and_persist(&msg, clients, chat_path).await;
+            let _ = broadcast_and_persist(&msg, clients, chat_path, seq_counter).await;
             shutdown.notify_one();
         }
         "clear" => {
@@ -592,7 +617,7 @@ async fn handle_admin_cmd(cmd_line: &str, issuer: &str, state: &RoomState) -> Op
             }
             let content = format!("{issuer} cleared chat history");
             let msg = make_system(room_id, "broker", content);
-            let _ = broadcast_and_persist(&msg, clients, chat_path).await;
+            let _ = broadcast_and_persist(&msg, clients, chat_path, seq_counter).await;
         }
         _ => {
             eprintln!("[broker] unknown admin command from {issuer}: \\{cmd_line}");
@@ -601,23 +626,31 @@ async fn handle_admin_cmd(cmd_line: &str, issuer: &str, state: &RoomState) -> Op
     None
 }
 
-/// Persist a message and fan it out to all connected clients.
+/// Assign the next sequence number, persist a message, and fan it out to all connected clients.
+///
+/// Returns the message with its `seq` field populated so callers can echo it to one-shot senders.
 async fn broadcast_and_persist(
     msg: &Message,
     clients: &ClientMap,
     chat_path: &Path,
-) -> anyhow::Result<()> {
-    history::append(chat_path, msg).await?;
+    seq_counter: &Arc<AtomicU64>,
+) -> anyhow::Result<Message> {
+    let seq = seq_counter.fetch_add(1, Ordering::SeqCst) + 1;
+    let mut msg = msg.clone();
+    msg.set_seq(seq);
 
-    let line = format!("{}\n", serde_json::to_string(msg)?);
+    history::append(chat_path, &msg).await?;
+
+    let line = format!("{}\n", serde_json::to_string(&msg)?);
     let map = clients.lock().await;
     for (_, tx) in map.values() {
         let _ = tx.send(line.clone());
     }
-    Ok(())
+    Ok(msg)
 }
 
-/// Persist a DM and deliver it only to the sender, the recipient, and the host.
+/// Assign the next sequence number, persist a DM, and deliver it only to the sender,
+/// the recipient, and the host.
 /// If the recipient is offline the message is still persisted and the sender
 /// receives their own echo; no error is returned.
 async fn dm_and_persist(
@@ -627,10 +660,15 @@ async fn dm_and_persist(
     host_user: &HostUser,
     clients: &ClientMap,
     chat_path: &Path,
-) -> anyhow::Result<()> {
-    history::append(chat_path, msg).await?;
+    seq_counter: &Arc<AtomicU64>,
+) -> anyhow::Result<Message> {
+    let seq = seq_counter.fetch_add(1, Ordering::SeqCst) + 1;
+    let mut msg = msg.clone();
+    msg.set_seq(seq);
 
-    let line = format!("{}\n", serde_json::to_string(msg)?);
+    history::append(chat_path, &msg).await?;
+
+    let line = format!("{}\n", serde_json::to_string(&msg)?);
     let host = host_user.lock().await;
     let host_name = host.as_deref();
     let map = clients.lock().await;
@@ -639,5 +677,5 @@ async fn dm_and_persist(
             let _ = tx.send(line.clone());
         }
     }
-    Ok(())
+    Ok(msg)
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -15,18 +15,24 @@ pub enum Message {
         room: String,
         user: String,
         ts: DateTime<Utc>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        seq: Option<u64>,
     },
     Leave {
         id: String,
         room: String,
         user: String,
         ts: DateTime<Utc>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        seq: Option<u64>,
     },
     Message {
         id: String,
         room: String,
         user: String,
         ts: DateTime<Utc>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        seq: Option<u64>,
         content: String,
     },
     Reply {
@@ -34,6 +40,8 @@ pub enum Message {
         room: String,
         user: String,
         ts: DateTime<Utc>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        seq: Option<u64>,
         reply_to: String,
         content: String,
     },
@@ -42,6 +50,8 @@ pub enum Message {
         room: String,
         user: String,
         ts: DateTime<Utc>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        seq: Option<u64>,
         cmd: String,
         params: Vec<String>,
     },
@@ -50,6 +60,8 @@ pub enum Message {
         room: String,
         user: String,
         ts: DateTime<Utc>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        seq: Option<u64>,
         content: String,
     },
     /// A private direct message. Delivered only to sender, recipient, and the
@@ -61,6 +73,8 @@ pub enum Message {
         /// Sender username (set by the broker).
         user: String,
         ts: DateTime<Utc>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        seq: Option<u64>,
         /// Recipient username.
         to: String,
         content: String,
@@ -115,6 +129,34 @@ impl Message {
             | Self::DirectMessage { ts, .. } => ts,
         }
     }
+
+    /// Returns the sequence number assigned by the broker, or `None` for
+    /// messages loaded from history files that predate this feature.
+    pub fn seq(&self) -> Option<u64> {
+        match self {
+            Self::Join { seq, .. }
+            | Self::Leave { seq, .. }
+            | Self::Message { seq, .. }
+            | Self::Reply { seq, .. }
+            | Self::Command { seq, .. }
+            | Self::System { seq, .. }
+            | Self::DirectMessage { seq, .. } => *seq,
+        }
+    }
+
+    /// Assign a broker-issued sequence number to this message.
+    pub fn set_seq(&mut self, seq: u64) {
+        let n = Some(seq);
+        match self {
+            Self::Join { seq, .. } => *seq = n,
+            Self::Leave { seq, .. } => *seq = n,
+            Self::Message { seq, .. } => *seq = n,
+            Self::Reply { seq, .. } => *seq = n,
+            Self::Command { seq, .. } => *seq = n,
+            Self::System { seq, .. } => *seq = n,
+            Self::DirectMessage { seq, .. } => *seq = n,
+        }
+    }
 }
 
 // ── Constructors ─────────────────────────────────────────────────────────────
@@ -129,6 +171,7 @@ pub fn make_join(room: &str, user: &str) -> Message {
         room: room.to_owned(),
         user: user.to_owned(),
         ts: Utc::now(),
+        seq: None,
     }
 }
 
@@ -138,6 +181,7 @@ pub fn make_leave(room: &str, user: &str) -> Message {
         room: room.to_owned(),
         user: user.to_owned(),
         ts: Utc::now(),
+        seq: None,
     }
 }
 
@@ -148,6 +192,7 @@ pub fn make_message(room: &str, user: &str, content: impl Into<String>) -> Messa
         user: user.to_owned(),
         ts: Utc::now(),
         content: content.into(),
+        seq: None,
     }
 }
 
@@ -164,6 +209,7 @@ pub fn make_reply(
         ts: Utc::now(),
         reply_to: reply_to.into(),
         content: content.into(),
+        seq: None,
     }
 }
 
@@ -180,6 +226,7 @@ pub fn make_command(
         ts: Utc::now(),
         cmd: cmd.into(),
         params,
+        seq: None,
     }
 }
 
@@ -190,6 +237,7 @@ pub fn make_system(room: &str, user: &str, content: impl Into<String>) -> Messag
         user: user.to_owned(),
         ts: Utc::now(),
         content: content.into(),
+        seq: None,
     }
 }
 
@@ -201,6 +249,7 @@ pub fn make_dm(room: &str, user: &str, to: &str, content: impl Into<String>) -> 
         ts: Utc::now(),
         to: to.to_owned(),
         content: content.into(),
+        seq: None,
     }
 }
 
@@ -267,6 +316,7 @@ mod tests {
             room: "r".into(),
             user: "alice".into(),
             ts: fixed_ts(),
+            seq: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         let back: Message = serde_json::from_str(&json).unwrap();
@@ -280,6 +330,7 @@ mod tests {
             room: "r".into(),
             user: "bob".into(),
             ts: fixed_ts(),
+            seq: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         let back: Message = serde_json::from_str(&json).unwrap();
@@ -294,6 +345,7 @@ mod tests {
             user: "alice".into(),
             ts: fixed_ts(),
             content: "hello world".into(),
+            seq: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         let back: Message = serde_json::from_str(&json).unwrap();
@@ -309,6 +361,7 @@ mod tests {
             ts: fixed_ts(),
             reply_to: "ffffffff-0000-0000-0000-000000000000".into(),
             content: "pong".into(),
+            seq: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         let back: Message = serde_json::from_str(&json).unwrap();
@@ -324,6 +377,7 @@ mod tests {
             ts: fixed_ts(),
             cmd: "claim".into(),
             params: vec!["task-123".into(), "fix the bug".into()],
+            seq: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         let back: Message = serde_json::from_str(&json).unwrap();
@@ -338,6 +392,7 @@ mod tests {
             user: "broker".into(),
             ts: fixed_ts(),
             content: "5 users online".into(),
+            seq: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         let back: Message = serde_json::from_str(&json).unwrap();
@@ -353,6 +408,7 @@ mod tests {
             room: "r".into(),
             user: "alice".into(),
             ts: fixed_ts(),
+            seq: None,
         };
         let v: serde_json::Value = serde_json::to_value(&msg).unwrap();
         assert_eq!(v["type"], "join");
@@ -372,6 +428,7 @@ mod tests {
             user: "alice".into(),
             ts: fixed_ts(),
             content: "hi".into(),
+            seq: None,
         };
         let v: serde_json::Value = serde_json::to_value(&msg).unwrap();
         assert_eq!(v["type"], "message");
@@ -462,6 +519,7 @@ mod tests {
             ts: fixed_ts(),
             to: "bob".into(),
             content: "secret".into(),
+            seq: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         let back: Message = serde_json::from_str(&json).unwrap();
@@ -477,6 +535,7 @@ mod tests {
             ts: fixed_ts(),
             to: "bob".into(),
             content: "hi".into(),
+            seq: None,
         };
         let v: serde_json::Value = serde_json::to_value(&msg).unwrap();
         assert_eq!(v["type"], "dm");
@@ -495,6 +554,7 @@ mod tests {
             user: "carol".into(),
             ts,
             content: "x".into(),
+            seq: None,
         };
         assert_eq!(msg.id(), fixed_id());
         assert_eq!(msg.room(), "testroom");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1886,3 +1886,130 @@ async fn host_can_run_admin_commands() {
         "kick message should name the victim, got: {content}"
     );
 }
+// ── seq numbering tests ───────────────────────────────────────────────────────
+
+/// Every broadcast message carries a monotonically increasing seq number.
+#[tokio::test]
+async fn broadcast_messages_have_monotonically_increasing_seq() {
+    let broker = TestBroker::start("t_seq_mono").await;
+    let mut alice = TestClient::connect(&broker.socket_path, "alice").await;
+    alice
+        .recv_until(|m| matches!(m, Message::Join { user, .. } if user == "alice"))
+        .await;
+
+    alice.send_text("first").await;
+    let m1 = alice
+        .recv_until(|m| matches!(m, Message::Message { content, .. } if content == "first"))
+        .await;
+
+    alice.send_text("second").await;
+    let m2 = alice
+        .recv_until(|m| matches!(m, Message::Message { content, .. } if content == "second"))
+        .await;
+
+    alice.send_text("third").await;
+    let m3 = alice
+        .recv_until(|m| matches!(m, Message::Message { content, .. } if content == "third"))
+        .await;
+
+    let s1 = m1.seq().expect("first message must have seq");
+    let s2 = m2.seq().expect("second message must have seq");
+    let s3 = m3.seq().expect("third message must have seq");
+
+    assert!(s1 < s2, "seq must be strictly increasing: {s1} < {s2}");
+    assert!(s2 < s3, "seq must be strictly increasing: {s2} < {s3}");
+    assert!(s1 >= 1, "seq must start at 1 or higher");
+}
+
+/// Join and leave events also receive seq numbers.
+#[tokio::test]
+async fn join_and_leave_events_have_seq() {
+    let broker = TestBroker::start("t_seq_join_leave").await;
+    let mut alice = TestClient::connect(&broker.socket_path, "alice").await;
+    let join_msg = alice
+        .recv_until(|m| matches!(m, Message::Join { user, .. } if user == "alice"))
+        .await;
+    assert!(
+        join_msg.seq().is_some(),
+        "join event must carry a seq number"
+    );
+
+    // Connect bob then disconnect to generate a leave event.
+    let mut bob = TestClient::connect(&broker.socket_path, "bob").await;
+    bob.recv_until(|m| matches!(m, Message::Join { user, .. } if user == "bob"))
+        .await;
+    drop(bob);
+
+    let leave_msg = alice
+        .recv_until(|m| matches!(m, Message::Leave { user, .. } if user == "bob"))
+        .await;
+    assert!(
+        leave_msg.seq().is_some(),
+        "leave event must carry a seq number"
+    );
+
+    let join_seq = join_msg.seq().unwrap();
+    let leave_seq = leave_msg.seq().unwrap();
+    // There may be intervening messages (bob's join), but leave must be strictly after alice's join.
+    assert!(
+        leave_seq > join_seq,
+        "leave seq ({leave_seq}) must be greater than alice's join seq ({join_seq})"
+    );
+}
+
+/// Messages persisted to the chat file include seq numbers.
+#[tokio::test]
+async fn persisted_messages_have_seq_in_history() {
+    let broker = TestBroker::start("t_seq_persist").await;
+    let mut alice = TestClient::connect(&broker.socket_path, "alice").await;
+    alice
+        .recv_until(|m| matches!(m, Message::Join { user, .. } if user == "alice"))
+        .await;
+
+    alice.send_text("check seq").await;
+    alice
+        .recv_until(|m| matches!(m, Message::Message { content, .. } if content == "check seq"))
+        .await;
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let history = history::load(&broker.chat_path).await.unwrap();
+    for msg in &history {
+        assert!(
+            msg.seq().is_some(),
+            "every persisted message must have seq, but {:?} does not",
+            msg
+        );
+    }
+
+    // Verify strictly increasing order.
+    let seqs: Vec<u64> = history.iter().map(|m| m.seq().unwrap()).collect();
+    for pair in seqs.windows(2) {
+        assert!(
+            pair[0] < pair[1],
+            "history seq must be strictly increasing: {} then {}",
+            pair[0],
+            pair[1]
+        );
+    }
+}
+
+/// History files without seq fields (old format) are still parsed without error.
+#[tokio::test]
+async fn history_without_seq_parses_as_none() {
+    let raw = r#"{"type":"message","id":"abc","room":"r","user":"alice","ts":"2026-03-05T10:00:00Z","content":"hi"}
+{"type":"join","id":"def","room":"r","user":"bob","ts":"2026-03-05T10:00:01Z"}
+"#;
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("old.chat");
+    std::fs::write(&path, raw).unwrap();
+
+    let msgs = history::load(&path).await.unwrap();
+    assert_eq!(msgs.len(), 2, "both lines should parse");
+    for msg in &msgs {
+        assert!(
+            msg.seq().is_none(),
+            "old messages without seq should deserialize to seq=None"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `seq: Option<u64>` to all 7 `Message` variants — `#[serde(default)]` so old history files parse as `seq: None`
- Broker stamps each message with the next seq number before persisting and broadcasting
- `seq` is strictly monotonically increasing per broker lifetime, starting at 1
- One-shot senders (`room send`) receive the seq-stamped echo, not the pre-seq version

## Key implementation notes

- `RoomState` gains `seq_counter: Arc<AtomicU64>` (fetch_add with SeqCst ordering)
- `handle_client` now takes `Arc<RoomState>` so the inbound spawn can call `handle_admin_cmd(line, user, &state)` without re-cloning all individual fields
- `broadcast_and_persist` and `dm_and_persist` now return `anyhow::Result<Message>` (the seq-stamped message)
- No wire-format breakage: old messages without `seq` deserialize to `seq: None`

## Files changed

- `src/message.rs` — seq field, `seq()` accessor, `set_seq()` mutator, updated constructors and test constructions
- `src/broker.rs` — AtomicU64 counter, Arc<RoomState> refactor, stamp in broadcast/dm paths
- `tests/integration.rs` — 4 new tests (46 total, all green)

## Test plan

- [x] `broadcast_messages_have_monotonically_increasing_seq` — 3 messages, strict ordering, starts ≥ 1
- [x] `join_and_leave_events_have_seq` — join and leave events carry seq
- [x] `persisted_messages_have_seq_in_history` — chat file contains seq, strictly ordered
- [x] `history_without_seq_parses_as_none` — old-format lines parse without error with seq=None

Closes #51