### PR TITLE
feat(auth): restrict admin commands to room host

### DIFF
--- a/src/broker.rs
+++ b/src/broker.rs
@@ -121,16 +121,14 @@ async fn handle_client(
     cid: u64,
     stream: UnixStream,
     own_tx: broadcast::Sender<String>,
-    state: &RoomState,
+    state: &Arc<RoomState>,
 ) -> anyhow::Result<()> {
     // Clone the Arc fields up-front so spawned tasks can capture owned handles.
     let clients = state.clients.clone();
     let status_map = state.status_map.clone();
     let host_user = state.host_user.clone();
-    let token_map = state.token_map.clone();
     let chat_path = state.chat_path.clone();
     let room_id = state.room_id.clone();
-    let shutdown = state.shutdown.clone();
 
     let (read_half, mut write_half) = stream.into_split();
     let mut reader = BufReader::new(read_half);
@@ -148,7 +146,7 @@ async fn handle_client(
     }
 
     if let Some(token) = first_line.strip_prefix("TOKEN:") {
-        let username = token_map.lock().await.get(token).cloned();
+        let username = state.token_map.lock().await.get(token).cloned();
         return match username {
             Some(u) => handle_oneshot_send(u, reader, write_half, state).await,
             None => {
@@ -162,7 +160,7 @@ async fn handle_client(
     }
 
     if let Some(join_user) = first_line.strip_prefix("JOIN:") {
-        return handle_oneshot_join(join_user.to_owned(), write_half, &token_map).await;
+        return handle_oneshot_join(join_user.to_owned(), write_half, &state.token_map).await;
     }
 
     // Remaining path: full interactive join — first_line is the username.
@@ -255,8 +253,7 @@ async fn handle_client(
     let status_map_in = status_map.clone();
     let host_user_in = host_user.clone();
     let chat_path_in = chat_path.clone();
-    let token_map_in = token_map.clone();
-    let shutdown_in = shutdown.clone();
+    let state_in = state.clone();
     let write_half_in = write_half.clone();
     let inbound = tokio::spawn(async move {
         let mut line = String::new();
@@ -271,16 +268,18 @@ async fn handle_client(
                     }
                     // Admin commands: lines starting with `\`
                     if let Some(admin_line) = trimmed.strip_prefix('\\') {
-                        handle_admin_cmd(
-                            admin_line,
-                            &username_in,
-                            &room_id_in,
-                            &clients_in,
-                            &token_map_in,
-                            &chat_path_in,
-                            &shutdown_in,
-                        )
-                        .await;
+                        if let Some(err) =
+                            handle_admin_cmd(admin_line, &username_in, &state_in).await
+                        {
+                            let sys = make_system(&room_id_in, "broker", err);
+                            if let Ok(json) = serde_json::to_string(&sys) {
+                                let _ = write_half_in
+                                    .lock()
+                                    .await
+                                    .write_all(format!("{json}\n").as_bytes())
+                                    .await;
+                            }
+                        }
                         continue;
                     }
                     match parse_client_line(trimmed, &room_id_in, &username_in) {
@@ -401,18 +400,13 @@ async fn handle_oneshot_send(
     }
     // Admin commands: lines starting with `\`
     if let Some(admin_line) = trimmed.strip_prefix('\\') {
-        handle_admin_cmd(
-            admin_line,
-            &username,
-            &state.room_id,
-            &state.clients,
-            &state.token_map,
-            &state.chat_path,
-            &state.shutdown,
-        )
-        .await;
-        let ack = serde_json::json!({"type":"system","user":"broker","content":"command executed"});
-        write_half.write_all(format!("{ack}\n").as_bytes()).await?;
+        let content = match handle_admin_cmd(admin_line, &username, state).await {
+            None => "command executed".to_string(),
+            Some(err) => err,
+        };
+        let reply = make_system(&state.room_id, "broker", content);
+        let json = serde_json::to_string(&reply)?;
+        write_half.write_all(format!("{json}\n").as_bytes()).await?;
         return Ok(());
     }
     let msg = parse_client_line(trimmed, &state.room_id, &username)?;
@@ -462,6 +456,12 @@ async fn handle_oneshot_join(
 
 /// Dispatch a `\command [arg]` line sent from a connected client.
 ///
+/// Returns `None` on success or `Some(error_message)` if the command was rejected.
+/// The caller is responsible for delivering any error message back to the issuer.
+///
+/// Only the room host (the first user to complete the interactive join handshake) is
+/// authorised to run admin commands. All other callers receive a permission denied error.
+///
 /// Supported commands:
 /// - `\kick <username>`      — invalidates the user's token so they cannot issue further
 ///   authenticated requests; the username remains reserved so they cannot rejoin without `\reauth`.
@@ -469,15 +469,21 @@ async fn handle_oneshot_join(
 /// - `\clear-tokens`         — removes every token for this room (all users must rejoin).
 /// - `\exit`                 — broadcasts a shutdown notice then signals the broker to stop.
 /// - `\clear`                — truncates the chat history file and broadcasts a notice.
-async fn handle_admin_cmd(
-    cmd_line: &str,
-    issuer: &str,
-    room_id: &str,
-    clients: &ClientMap,
-    token_map: &TokenMap,
-    chat_path: &Arc<PathBuf>,
-    shutdown: &Arc<Notify>,
-) {
+async fn handle_admin_cmd(cmd_line: &str, issuer: &str, state: &RoomState) -> Option<String> {
+    // Auth: only the room host may run admin commands.
+    let host = state.host_user.lock().await.clone();
+    if host.as_deref() != Some(issuer) {
+        return Some(
+            "permission denied: admin commands are restricted to the room host".to_string(),
+        );
+    }
+
+    let room_id = state.room_id.as_str();
+    let clients = &state.clients;
+    let token_map = &state.token_map;
+    let chat_path = &state.chat_path;
+    let shutdown = &state.shutdown;
+
     let mut parts = cmd_line.splitn(2, ' ');
     let cmd = parts.next().unwrap_or("").trim();
     let arg = parts.next().unwrap_or("").trim();
@@ -485,7 +491,7 @@ async fn handle_admin_cmd(
     match cmd {
         "kick" => {
             if arg.is_empty() {
-                return;
+                return None;
             }
             let target = arg.to_owned();
             let mut map = token_map.lock().await;
@@ -501,7 +507,7 @@ async fn handle_admin_cmd(
         }
         "reauth" => {
             if arg.is_empty() {
-                return;
+                return None;
             }
             let target = arg.to_owned();
             let mut map = token_map.lock().await;
@@ -550,7 +556,7 @@ async fn handle_admin_cmd(
             // Truncate the history file.
             if let Err(e) = std::fs::write(chat_path.as_ref(), "") {
                 eprintln!("[broker] \\clear failed: {e}");
-                return;
+                return None;
             }
             let content = format!("{issuer} cleared chat history");
             let msg = make_system(room_id, "broker", content);
@@ -560,6 +566,7 @@ async fn handle_admin_cmd(
             eprintln!("[broker] unknown admin command from {issuer}: \\{cmd_line}");
         }
     }
+    None
 }
 
 /// Persist a message and fan it out to all connected clients.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1503,3 +1503,89 @@ async fn admin_exit_shuts_down_broker() {
         "broker should have stopped accepting connections after \\exit"
     );
 }
+
+/// A non-host user sending an admin command receives a private "permission denied"
+/// system message. The command is not executed and no broadcast is sent.
+#[tokio::test]
+async fn non_host_admin_cmd_is_rejected() {
+    let broker = TestBroker::start("t_admin_auth_reject").await;
+
+    // alice is host (first to join)
+    let mut alice = TestClient::connect(&broker.socket_path, "alice").await;
+    alice
+        .recv_until(|m| matches!(m, Message::Join { user, .. } if user == "alice"))
+        .await;
+
+    // bob joins — not the host
+    let mut bob = TestClient::connect(&broker.socket_path, "bob").await;
+    alice
+        .recv_until(|m| matches!(m, Message::Join { user, .. } if user == "bob"))
+        .await;
+    bob.recv_until(|m| matches!(m, Message::Join { user, .. } if user == "bob"))
+        .await;
+
+    // bot joins via token (oneshot JOIN), then attempts \kick alice
+    let (_, tok) = room::oneshot::join_session(&broker.socket_path, "bot")
+        .await
+        .unwrap();
+    let msg = room::oneshot::send_message_with_token(&broker.socket_path, &tok, r"\kick alice")
+        .await
+        .expect("oneshot send should succeed even when permission is denied");
+
+    let Message::System { content, .. } = msg else {
+        panic!("expected system message, got: {msg:?}");
+    };
+    assert!(
+        content.contains("permission denied"),
+        "non-host admin cmd should return permission denied, got: {content}"
+    );
+
+    // alice must NOT have received a kick broadcast
+    let got_kick = tokio::time::timeout(Duration::from_millis(200), async {
+        alice
+            .recv_until(
+                |m| matches!(m, Message::System { content, .. } if content.contains("kicked")),
+            )
+            .await
+    })
+    .await;
+    assert!(
+        got_kick.is_err(),
+        "kick must not execute; alice should not see a kick system message"
+    );
+}
+
+/// The room host (first interactive user) can execute admin commands.
+#[tokio::test]
+async fn host_can_run_admin_commands() {
+    let broker = TestBroker::start("t_admin_auth_host").await;
+
+    // alice is host (first to join)
+    let mut alice = TestClient::connect(&broker.socket_path, "alice").await;
+    alice
+        .recv_until(|m| matches!(m, Message::Join { user, .. } if user == "alice"))
+        .await;
+
+    let mut victim = TestClient::connect(&broker.socket_path, "victim").await;
+    alice
+        .recv_until(|m| matches!(m, Message::Join { user, .. } if user == "victim"))
+        .await;
+    victim
+        .recv_until(|m| matches!(m, Message::Join { user, .. } if user == "victim"))
+        .await;
+
+    // alice (host) kicks victim via the TUI interactive path
+    alice.send_text(r"\kick victim").await;
+
+    // broadcast: all connected users receive the kick system message
+    let sys = alice
+        .recv_until(|m| matches!(m, Message::System { content, .. } if content.contains("kicked")))
+        .await;
+    let Message::System { content, .. } = &sys else {
+        panic!("expected system message");
+    };
+    assert!(
+        content.contains("victim"),
+        "kick message should name the victim, got: {content}"
+    );
+}


### PR DESCRIPTION
## Summary

Only the room host (first user to complete the interactive join handshake) may issue admin commands. Non-host callers receive a private `permission denied` system message — the command is not executed and no broadcast is sent.

## Changes

- `handle_admin_cmd` refactored from 7 params to `(cmd_line, issuer, &RoomState) -> Option<String>` — avoids `clippy::too_many_arguments`; `None` = success, `Some(msg)` = error message to return privately
- `handle_client` now takes `&Arc<RoomState>` so the inbound task can clone it
- Host check at top of `handle_admin_cmd` using `state.host_user`
- Oneshot path: permission denied returned as a proper `make_system` message (includes `id`/`room`/`ts`, parseable as `Message::System`)
- 2 new integration tests: `non_host_admin_cmd_is_rejected`, `host_can_run_admin_commands`

## Test plan

- `cargo test` — 44 tests green
- `non_host_admin_cmd_is_rejected`: bot joins via token, sends `\kick alice` (not host), receives `permission denied` system message, alice sees no kick broadcast
- `host_can_run_admin_commands`: alice (host) sends `\kick victim`, receives kick broadcast

Closes #47