### PR TITLE
feat(auth): restrict admin commands to room host

### DIFF
--- a/src/broker.rs
+++ b/src/broker.rs
@@ -269,7 +269,18 @@ async fn handle_client(
                     }
                     // Admin commands: lines starting with `\`
                     if let Some(admin_line) = trimmed.strip_prefix('\\') {
-                        handle_admin_cmd(admin_line, &username_in, &state_in).await;
+                        if let Some(err) =
+                            handle_admin_cmd(admin_line, &username_in, &state_in).await
+                        {
+                            let sys = make_system(&room_id_in, "broker", err);
+                            if let Ok(json) = serde_json::to_string(&sys) {
+                                let _ = write_half_in
+                                    .lock()
+                                    .await
+                                    .write_all(format!("{json}\n").as_bytes())
+                                    .await;
+                            }
+                        }
                         continue;
                     }
                     match parse_client_line(trimmed, &room_id_in, &username_in) {
@@ -390,9 +401,13 @@ async fn handle_oneshot_send(
     }
     // Admin commands: lines starting with `\`
     if let Some(admin_line) = trimmed.strip_prefix('\\') {
-        handle_admin_cmd(admin_line, &username, state).await;
-        let ack = serde_json::json!({"type":"system","user":"broker","content":"command executed"});
-        write_half.write_all(format!("{ack}\n").as_bytes()).await?;
+        let content = match handle_admin_cmd(admin_line, &username, state).await {
+            None => "command executed".to_string(),
+            Some(err) => err,
+        };
+        let reply = make_system(&state.room_id, "broker", content);
+        let json = serde_json::to_string(&reply)?;
+        write_half.write_all(format!("{json}\n").as_bytes()).await?;
         return Ok(());
     }
     let msg = parse_client_line(trimmed, &state.room_id, &username)?;
@@ -469,6 +484,12 @@ async fn handle_oneshot_join(
 
 /// Dispatch a `\command [arg]` line sent from a connected client.
 ///
+/// Returns `None` on success or `Some(error_message)` if the command was rejected.
+/// The caller is responsible for delivering any error message back to the issuer.
+///
+/// Only the room host (the first user to complete the interactive join handshake) is
+/// authorised to run admin commands. All other callers receive a permission denied error.
+///
 /// Supported commands:
 /// - `\kick <username>`      — invalidates the user's token so they cannot issue further
 ///   authenticated requests; the username remains reserved so they cannot rejoin without `\reauth`.
@@ -477,7 +498,15 @@ async fn handle_oneshot_join(
 /// - `\clear-tokens`         — removes every token for this room (all users must rejoin).
 /// - `\exit`                 — broadcasts a shutdown notice then signals the broker to stop.
 /// - `\clear`                — truncates the chat history file and broadcasts a notice.
-async fn handle_admin_cmd(cmd_line: &str, issuer: &str, state: &RoomState) {
+async fn handle_admin_cmd(cmd_line: &str, issuer: &str, state: &RoomState) -> Option<String> {
+    // Auth: only the room host may run admin commands.
+    let host = state.host_user.lock().await.clone();
+    if host.as_deref() != Some(issuer) {
+        return Some(
+            "permission denied: admin commands are restricted to the room host".to_string(),
+        );
+    }
+
     let room_id = state.room_id.as_str();
     let clients = &state.clients;
     let token_map = &state.token_map;
@@ -492,7 +521,7 @@ async fn handle_admin_cmd(cmd_line: &str, issuer: &str, state: &RoomState) {
     match cmd {
         "kick" => {
             if arg.is_empty() {
-                return;
+                return None;
             }
             let target = arg.to_owned();
             let mut map = token_map.lock().await;
@@ -510,7 +539,7 @@ async fn handle_admin_cmd(cmd_line: &str, issuer: &str, state: &RoomState) {
         }
         "reauth" => {
             if arg.is_empty() {
-                return;
+                return None;
             }
             let target = arg.to_owned();
             let mut map = token_map.lock().await;
@@ -559,7 +588,7 @@ async fn handle_admin_cmd(cmd_line: &str, issuer: &str, state: &RoomState) {
             // Truncate the history file.
             if let Err(e) = std::fs::write(chat_path.as_ref(), "") {
                 eprintln!("[broker] \\clear failed: {e}");
-                return;
+                return None;
             }
             let content = format!("{issuer} cleared chat history");
             let msg = make_system(room_id, "broker", content);
@@ -569,6 +598,7 @@ async fn handle_admin_cmd(cmd_line: &str, issuer: &str, state: &RoomState) {
             eprintln!("[broker] unknown admin command from {issuer}: \\{cmd_line}");
         }
     }
+    None
 }
 
 /// Persist a message and fan it out to all connected clients.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1800,3 +1800,89 @@ async fn oneshot_who_returns_user_list() {
         "/who command should not be broadcast to other clients"
     );
 }
+
+/// A non-host user sending an admin command receives a private "permission denied"
+/// system message. The command is not executed and no broadcast is sent.
+#[tokio::test]
+async fn non_host_admin_cmd_is_rejected() {
+    let broker = TestBroker::start("t_admin_auth_reject").await;
+
+    // alice is host (first to join)
+    let mut alice = TestClient::connect(&broker.socket_path, "alice").await;
+    alice
+        .recv_until(|m| matches!(m, Message::Join { user, .. } if user == "alice"))
+        .await;
+
+    // bob joins — not the host
+    let mut bob = TestClient::connect(&broker.socket_path, "bob").await;
+    alice
+        .recv_until(|m| matches!(m, Message::Join { user, .. } if user == "bob"))
+        .await;
+    bob.recv_until(|m| matches!(m, Message::Join { user, .. } if user == "bob"))
+        .await;
+
+    // bot joins via token (oneshot JOIN), then attempts \kick alice
+    let (_, tok) = room::oneshot::join_session(&broker.socket_path, "bot")
+        .await
+        .unwrap();
+    let msg = room::oneshot::send_message_with_token(&broker.socket_path, &tok, r"\kick alice")
+        .await
+        .expect("oneshot send should succeed even when permission is denied");
+
+    let Message::System { content, .. } = msg else {
+        panic!("expected system message, got: {msg:?}");
+    };
+    assert!(
+        content.contains("permission denied"),
+        "non-host admin cmd should return permission denied, got: {content}"
+    );
+
+    // alice must NOT have received a kick broadcast
+    let got_kick = tokio::time::timeout(Duration::from_millis(200), async {
+        alice
+            .recv_until(
+                |m| matches!(m, Message::System { content, .. } if content.contains("kicked")),
+            )
+            .await
+    })
+    .await;
+    assert!(
+        got_kick.is_err(),
+        "kick must not execute; alice should not see a kick system message"
+    );
+}
+
+/// The room host (first interactive user) can execute admin commands.
+#[tokio::test]
+async fn host_can_run_admin_commands() {
+    let broker = TestBroker::start("t_admin_auth_host").await;
+
+    // alice is host (first to join)
+    let mut alice = TestClient::connect(&broker.socket_path, "alice").await;
+    alice
+        .recv_until(|m| matches!(m, Message::Join { user, .. } if user == "alice"))
+        .await;
+
+    let mut victim = TestClient::connect(&broker.socket_path, "victim").await;
+    alice
+        .recv_until(|m| matches!(m, Message::Join { user, .. } if user == "victim"))
+        .await;
+    victim
+        .recv_until(|m| matches!(m, Message::Join { user, .. } if user == "victim"))
+        .await;
+
+    // alice (host) kicks victim via the TUI interactive path
+    alice.send_text(r"\kick victim").await;
+
+    // broadcast: all connected users receive the kick system message
+    let sys = alice
+        .recv_until(|m| matches!(m, Message::System { content, .. } if content.contains("kicked")))
+        .await;
+    let Message::System { content, .. } = &sys else {
+        panic!("expected system message");
+    };
+    assert!(
+        content.contains("victim"),
+        "kick message should name the victim, got: {content}"
+    );
+}


### PR DESCRIPTION
## Summary

Only the room host (first user to complete the interactive join handshake) may issue admin commands (`\kick`, `\reauth`, `\clear-tokens`, `\exit`, `\clear`). Non-host callers receive a private `permission denied` system message — the command is not executed and no broadcast is sent.

Clean rebase on top of current master (after #55 merged).

## Changes

- `handle_admin_cmd` return type `()` → `Option<String>`: `None` = success, `Some(msg)` = private error
- Auth check at top: reads `state.host_user`, returns `Some("permission denied...")` if mismatch
- Inbound task: handles `Option`, sends private `System` message to issuer on error
- Oneshot path: error returned as a proper `make_system` message (includes `id`/`room`/`ts`)
- 2 new integration tests: `non_host_admin_cmd_is_rejected`, `host_can_run_admin_commands`

## Test plan

- `cargo test` — 51 tests green
- `non_host_admin_cmd_is_rejected`: bot (token join, not host) sends `\kick alice`, receives `permission denied` system message, alice sees no kick broadcast
- `host_can_run_admin_commands`: alice (host) sends `\kick victim` via TUI, receives kick system broadcast

Closes #47