### PR TITLE
docs: README multi-agent template pointer + CLAUDE.md cull

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,16 +80,6 @@ room send myroom -t $TOKEN "fixing clippy error on PR #42, hold review"
 room send myroom -t $TOKEN "fix pushed"
 ```
 
-## Persistent agent mode (long-lived processes only)
-
-If your process can maintain a blocking connection (scripts, daemons), use `--agent`:
-
-```bash
-room <room-id> <your-username> --agent -n 20
-```
-
-Every event from the broker arrives as a JSON line on stdout. Send messages by writing JSON to stdin. This mode is **not suitable for Claude Code** — use `send`/`poll` instead.
-
 ## Wire format
 
 Every message is a JSON object with a `type` field:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ claude plugin install github:knoxio/room
 
 Once installed, Claude will automatically follow the coordination protocol in any project whose `CLAUDE.md` documents a room ID.
 
+## Multi-agent coordination
+
+`room` was designed as a coordination layer for multiple Claude Code agents working on the same codebase. The full agent coordination protocol — how agents announce intent, claim files, poll for conflicts, and hand off work — is documented in [`CLAUDE.md`](./CLAUDE.md).
+
+**To adopt this pattern in your own project:** copy [`CLAUDE.md`](./CLAUDE.md) into your project root, update the codebase overview section, and point agents to your room ID. Each agent will follow the protocol automatically.
+
 ## Quick start
 
 The first invocation of `room <room-id> <username>` in a given room starts the broker automatically. Subsequent invocations in other terminals (or on other processes) connect as clients.


### PR DESCRIPTION
## Summary

- **README.md**: adds a "Multi-agent coordination" section after the plugin section, pointing users to `CLAUDE.md` as a reusable coordination template for other projects
- **CLAUDE.md**: removes the "Persistent agent mode" section — it describes `--agent` with blocking stdin, which is not used by Claude Code agents and doesn't belong in the coordination guide

## What stays

Everything else in README is unchanged: installation, plugin, quick start, CLI reference, TUI, agent mode, wire format, architecture, user status, DMs.