### PR TITLE
feat: unify command syntax to single / prefix (#48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,17 +177,17 @@ Prefix your input with `/` to send a command instead of a plain message:
 
 The command and its arguments are sent as a `command` message (see [Wire format](#wire-format)).
 
-**Admin commands (TUI only, backslash prefix):**
+**Admin commands (TUI only, slash prefix):**
 
-Admin commands use a backslash prefix and are sent from the TUI input:
+Admin commands use the same `/` prefix as user commands and are available in the command palette:
 
 | Command | Description |
 |---|---|
-| `\kick <username>` | Invalidates the user's token — they cannot send further messages. Their username remains reserved; use `\reauth` to let them rejoin. |
-| `\reauth <username>` | Clears the user's token entry so they can `room join` again with the same username. |
-| `\clear-tokens` | Clears all tokens for the room — every user must `room join` again. |
-| `\exit` | Broadcasts a shutdown notice and stops the broker. |
-| `\clear` | Truncates the chat history file and broadcasts a notice. |
+| `/kick <username>` | Invalidates the user's token — they cannot send further messages. Their username remains reserved; use `/reauth` to let them rejoin. |
+| `/reauth <username>` | Clears the user's token entry so they can `room join` again with the same username. |
+| `/clear-tokens` | Clears all tokens for the room — every user must `room join` again. |
+| `/exit` | Broadcasts a shutdown notice and stops the broker. |
+| `/clear` | Truncates the chat history file and broadcasts a notice. |
 
 ## Agent mode
 

--- a/src/broker.rs
+++ b/src/broker.rs
@@ -37,6 +37,10 @@ type HostUser = Arc<Mutex<Option<String>>>;
 /// Cleared when the broker process exits; token files on disk survive restarts.
 type TokenMap = Arc<Mutex<HashMap<String, String>>>;
 
+/// Admin command names — routed through `handle_admin_cmd` when received as
+/// a `Message::Command` with one of these cmd values.
+const ADMIN_CMD_NAMES: &[&str] = &["kick", "reauth", "clear-tokens", "exit", "clear"];
+
 /// Shared broker state passed to every client handler.
 struct RoomState {
     clients: ClientMap,
@@ -45,7 +49,7 @@ struct RoomState {
     token_map: TokenMap,
     chat_path: Arc<PathBuf>,
     room_id: Arc<String>,
-    /// Signalled by the `\exit` admin command to shut down the broker run loop.
+    /// Signalled by the `/exit` admin command to shut down the broker run loop.
     shutdown: Arc<Notify>,
     /// Monotonically-increasing sequence counter. Incremented for every message
     /// broadcast or persisted by the broker, starting at 1.
@@ -276,22 +280,6 @@ async fn handle_client(
                     if trimmed.is_empty() {
                         continue;
                     }
-                    // Admin commands: lines starting with `\`
-                    if let Some(admin_line) = trimmed.strip_prefix('\\') {
-                        if let Some(err) =
-                            handle_admin_cmd(admin_line, &username_in, &state_in).await
-                        {
-                            let sys = make_system(&room_id_in, "broker", err);
-                            if let Ok(json) = serde_json::to_string(&sys) {
-                                let _ = write_half_in
-                                    .lock()
-                                    .await
-                                    .write_all(format!("{json}\n").as_bytes())
-                                    .await;
-                            }
-                        }
-                        continue;
-                    }
                     match parse_client_line(trimmed, &room_id_in, &username_in) {
                         Ok(msg) => {
                             // Handle status commands privately (no broadcast of the Command itself)
@@ -350,6 +338,21 @@ async fn handle_client(
                                             .await
                                             .write_all(format!("{json}\n").as_bytes())
                                             .await;
+                                    }
+                                    continue;
+                                } else if ADMIN_CMD_NAMES.contains(&cmd.as_str()) {
+                                    let cmd_line = format!("{cmd} {}", params.join(" "));
+                                    if let Some(err) =
+                                        handle_admin_cmd(&cmd_line, &username_in, &state_in).await
+                                    {
+                                        let sys = make_system(&room_id_in, "broker", err);
+                                        if let Ok(json) = serde_json::to_string(&sys) {
+                                            let _ = write_half_in
+                                                .lock()
+                                                .await
+                                                .write_all(format!("{json}\n").as_bytes())
+                                                .await;
+                                        }
                                     }
                                     continue;
                                 }
@@ -421,20 +424,14 @@ async fn handle_oneshot_send(
     if trimmed.is_empty() {
         return Ok(());
     }
-    // Admin commands: lines starting with `\`
-    if let Some(admin_line) = trimmed.strip_prefix('\\') {
-        let content = match handle_admin_cmd(admin_line, &username, state).await {
-            None => "command executed".to_string(),
-            Some(err) => err,
-        };
-        let reply = make_system(&state.room_id, "broker", content);
-        let json = serde_json::to_string(&reply)?;
-        write_half.write_all(format!("{json}\n").as_bytes()).await?;
-        return Ok(());
-    }
     let msg = parse_client_line(trimmed, &state.room_id, &username)?;
     // Handle /who privately in oneshot context: return the user list without broadcasting.
-    if let Message::Command { ref cmd, .. } = msg {
+    if let Message::Command {
+        ref cmd,
+        ref params,
+        ..
+    } = msg
+    {
         if cmd == "who" {
             let map = state.status_map.lock().await;
             let mut entries: Vec<String> = map
@@ -456,6 +453,16 @@ async fn handle_oneshot_send(
             };
             let sys = make_system(&state.room_id, "broker", content);
             let json = serde_json::to_string(&sys)?;
+            write_half.write_all(format!("{json}\n").as_bytes()).await?;
+            return Ok(());
+        } else if ADMIN_CMD_NAMES.contains(&cmd.as_str()) {
+            let cmd_line = format!("{cmd} {}", params.join(" "));
+            let content = match handle_admin_cmd(&cmd_line, &username, state).await {
+                None => "command executed".to_string(),
+                Some(err) => err,
+            };
+            let reply = make_system(&state.room_id, "broker", content);
+            let json = serde_json::to_string(&reply)?;
             write_half.write_all(format!("{json}\n").as_bytes()).await?;
             return Ok(());
         }
@@ -516,13 +523,13 @@ async fn handle_oneshot_join(
 /// authorised to run admin commands. All other callers receive a permission denied error.
 ///
 /// Supported commands:
-/// - `\kick <username>`      — invalidates the user's token so they cannot issue further
+/// - `/kick <username>`      — invalidates the user's token so they cannot issue further
 ///   authenticated requests; the username remains reserved so they cannot rejoin without `\reauth`.
 ///   Also removes them from the status map so `/who` no longer shows them as online.
-/// - `\reauth <username>`    — removes the user's token entirely so they can `room join` again.
-/// - `\clear-tokens`         — removes every token for this room (all users must rejoin).
-/// - `\exit`                 — broadcasts a shutdown notice then signals the broker to stop.
-/// - `\clear`                — truncates the chat history file and broadcasts a notice.
+/// - `/reauth <username>`    — removes the user's token entirely so they can `room join` again.
+/// - `/clear-tokens`         — removes every token for this room (all users must rejoin).
+/// - `/exit`                 — broadcasts a shutdown notice then signals the broker to stop.
+/// - `/clear`                — truncates the chat history file and broadcasts a notice.
 async fn handle_admin_cmd(cmd_line: &str, issuer: &str, state: &RoomState) -> Option<String> {
     // Auth: only the room host may run admin commands.
     let host = state.host_user.lock().await.clone();

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -54,32 +54,30 @@ const PALETTE_COMMANDS: &[PaletteItem] = &[
         usage: "/who",
         description: "List users in the room",
     },
-];
-
-const ADMIN_COMMANDS: &[PaletteItem] = &[
+    // Admin commands
     PaletteItem {
         cmd: "kick",
-        usage: "\\kick <user>",
+        usage: "/kick <user>",
         description: "Kick a user from the room",
     },
     PaletteItem {
         cmd: "reauth",
-        usage: "\\reauth <user>",
+        usage: "/reauth <user>",
         description: "Invalidate a user's token",
     },
     PaletteItem {
         cmd: "clear-tokens",
-        usage: "\\clear-tokens",
+        usage: "/clear-tokens",
         description: "Revoke all session tokens",
     },
     PaletteItem {
         cmd: "exit",
-        usage: "\\exit",
+        usage: "/exit",
         description: "Shut down the broker",
     },
     PaletteItem {
         cmd: "clear",
-        usage: "\\clear",
+        usage: "/clear",
         description: "Clear the room history",
     },
 ];
@@ -282,7 +280,6 @@ pub async fn run(
     let mut input_row_scroll: usize = 0; // vertical scroll within the input box
     let mut scroll_offset: usize = 0;
     let mut palette = CommandPalette::new(PALETTE_COMMANDS);
-    let mut admin_palette = CommandPalette::new(ADMIN_COMMANDS);
     let mut mention = MentionPicker::new();
     let mut result: anyhow::Result<()> = Ok(());
 
@@ -498,58 +495,6 @@ pub async fn run(
                 );
                 f.render_widget(mention_list, popup_rect);
             }
-
-            // Render the admin command palette popup when `\` trigger is active.
-            if admin_palette.active && !admin_palette.filtered.is_empty() {
-                let admin_items: Vec<ListItem> = admin_palette
-                    .filtered
-                    .iter()
-                    .enumerate()
-                    .map(|(row, &idx)| {
-                        let item = &admin_palette.commands[idx];
-                        let style = if row == admin_palette.selected {
-                            Style::default()
-                                .fg(Color::Black)
-                                .bg(Color::Red)
-                                .add_modifier(Modifier::BOLD)
-                        } else {
-                            Style::default().fg(Color::White)
-                        };
-                        ListItem::new(Line::from(vec![
-                            Span::styled(
-                                format!("{:<20}", item.usage),
-                                style.add_modifier(Modifier::BOLD),
-                            ),
-                            Span::styled(
-                                format!("  {}", item.description),
-                                if row == admin_palette.selected {
-                                    Style::default().fg(Color::Black).bg(Color::Red)
-                                } else {
-                                    Style::default().fg(Color::DarkGray)
-                                },
-                            ),
-                        ]))
-                    })
-                    .collect();
-
-                let popup_height = (admin_palette.filtered.len() as u16 + 2).min(chunks[0].height);
-                let popup_y = chunks[1].y.saturating_sub(popup_height);
-                let popup_rect = Rect {
-                    x: chunks[1].x,
-                    y: popup_y,
-                    width: chunks[1].width,
-                    height: popup_height,
-                };
-
-                f.render_widget(Clear, popup_rect);
-                let admin_list = List::new(admin_items).block(
-                    Block::default()
-                        .title(" admin ")
-                        .borders(Borders::ALL)
-                        .border_style(Style::default().fg(Color::Red)),
-                );
-                f.render_widget(admin_list, popup_rect);
-            }
         })?;
 
         if event::poll(std::time::Duration::from_millis(50))? {
@@ -560,8 +505,6 @@ pub async fn run(
                             mention.deactivate();
                         } else if palette.active {
                             palette.deactivate();
-                        } else if admin_palette.active {
-                            admin_palette.deactivate();
                         }
                     }
                     KeyCode::Tab if mention.active => {
@@ -585,14 +528,6 @@ pub async fn run(
                         }
                         palette.deactivate();
                     }
-                    KeyCode::Tab if admin_palette.active => {
-                        if let Some(usage) = admin_palette.selected_usage() {
-                            input = usage.to_owned();
-                            cursor_pos = input.len();
-                            input_row_scroll = 0;
-                        }
-                        admin_palette.deactivate();
-                    }
                     KeyCode::Enter => {
                         if mention.active {
                             if let Some(user) = mention.selected_user() {
@@ -613,13 +548,6 @@ pub async fn run(
                                 input_row_scroll = 0;
                             }
                             palette.deactivate();
-                        } else if admin_palette.active {
-                            if let Some(usage) = admin_palette.selected_usage() {
-                                input = usage.to_owned();
-                                cursor_pos = input.len();
-                                input_row_scroll = 0;
-                            }
-                            admin_palette.deactivate();
                         } else if key.modifiers.contains(KeyModifiers::SHIFT) {
                             // Shift+Enter: insert a newline at the cursor.
                             input.insert(cursor_pos, '\n');
@@ -648,8 +576,6 @@ pub async fn run(
                             mention.move_up();
                         } else if palette.active {
                             palette.move_up();
-                        } else if admin_palette.active {
-                            admin_palette.move_up();
                         } else {
                             scroll_offset = scroll_offset.saturating_add(1);
                         }
@@ -659,8 +585,6 @@ pub async fn run(
                             mention.move_down();
                         } else if palette.active {
                             palette.move_down();
-                        } else if admin_palette.active {
-                            admin_palette.move_down();
                         } else {
                             scroll_offset = scroll_offset.saturating_sub(1);
                         }
@@ -694,18 +618,6 @@ pub async fn run(
                                 }
                             } else {
                                 palette.deactivate();
-                            }
-                        } else if c == '\\' && input == "\\" {
-                            // Activate admin palette when `\` is typed into an empty input.
-                            admin_palette.activate();
-                        } else if admin_palette.active {
-                            if let Some(query) = input.strip_prefix('\\') {
-                                admin_palette.update_filter(query);
-                                if admin_palette.filtered.is_empty() {
-                                    admin_palette.deactivate();
-                                }
-                            } else {
-                                admin_palette.deactivate();
                             }
                         }
                     }
@@ -742,17 +654,6 @@ pub async fn run(
                                     }
                                 } else {
                                     palette.deactivate();
-                                }
-                            } else if admin_palette.active {
-                                if input.is_empty() {
-                                    admin_palette.deactivate();
-                                } else if let Some(query) = input.strip_prefix('\\') {
-                                    admin_palette.update_filter(query);
-                                    if admin_palette.filtered.is_empty() {
-                                        admin_palette.deactivate();
-                                    }
-                                } else {
-                                    admin_palette.deactivate();
                                 }
                             }
                         }
@@ -1231,12 +1132,10 @@ mod tests {
     #[test]
     fn palette_filter_by_cmd_prefix() {
         let mut p = CommandPalette::new(PALETTE_COMMANDS);
-        p.update_filter("d");
-        assert!(!p.filtered.is_empty());
-        // All filtered entries must start with "d"
-        for &i in &p.filtered {
-            assert!(p.commands[i].cmd.starts_with('d'));
-        }
+        // "dm" matches exactly one command by cmd prefix (no description ambiguity)
+        p.update_filter("dm");
+        assert_eq!(p.filtered.len(), 1);
+        assert_eq!(p.commands[p.filtered[0]].cmd, "dm");
     }
 
     #[test]
@@ -1354,15 +1253,15 @@ mod tests {
     // ── ADMIN_COMMANDS palette tests ──────────────────────────────────────────
 
     #[test]
-    fn admin_palette_starts_inactive() {
-        let p = CommandPalette::new(ADMIN_COMMANDS);
+    fn unified_palette_starts_inactive() {
+        let p = CommandPalette::new(PALETTE_COMMANDS);
         assert!(!p.active);
-        assert_eq!(p.filtered.len(), ADMIN_COMMANDS.len());
+        assert_eq!(p.filtered.len(), PALETTE_COMMANDS.len());
     }
 
     #[test]
-    fn admin_palette_contains_all_five_commands() {
-        let cmds: Vec<&str> = ADMIN_COMMANDS.iter().map(|c| c.cmd).collect();
+    fn palette_contains_all_admin_commands() {
+        let cmds: Vec<&str> = PALETTE_COMMANDS.iter().map(|c| c.cmd).collect();
         assert!(cmds.contains(&"kick"));
         assert!(cmds.contains(&"reauth"));
         assert!(cmds.contains(&"clear-tokens"));
@@ -1371,30 +1270,34 @@ mod tests {
     }
 
     #[test]
-    fn admin_palette_usages_use_backslash_prefix() {
-        for item in ADMIN_COMMANDS {
-            assert!(
-                item.usage.starts_with('\\'),
-                "admin command '{}' usage must start with \\",
-                item.cmd
-            );
+    fn admin_usages_use_slash_prefix() {
+        let admin_cmds = ["kick", "reauth", "clear-tokens", "exit", "clear"];
+        for item in PALETTE_COMMANDS {
+            if admin_cmds.contains(&item.cmd) {
+                assert!(
+                    item.usage.starts_with('/'),
+                    "admin command '{}' usage must start with /",
+                    item.cmd
+                );
+            }
         }
     }
 
     #[test]
-    fn admin_palette_filter_kick() {
-        let mut p = CommandPalette::new(ADMIN_COMMANDS);
+    fn palette_filter_kick() {
+        let mut p = CommandPalette::new(PALETTE_COMMANDS);
         p.update_filter("ki");
         assert_eq!(p.filtered.len(), 1);
         assert_eq!(p.commands[p.filtered[0]].cmd, "kick");
     }
 
     #[test]
-    fn admin_palette_selected_usage_backslash() {
-        let mut p = CommandPalette::new(ADMIN_COMMANDS);
+    fn admin_selected_usage_slash() {
+        let mut p = CommandPalette::new(PALETTE_COMMANDS);
         p.activate();
+        // All commands use / prefix
         let usage = p.selected_usage().unwrap();
-        assert!(usage.starts_with('\\'));
+        assert!(usage.starts_with('/'));
     }
 
     // ── build_payload tests ───────────────────────────────────────────────────

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1314,7 +1314,9 @@ async fn admin_kick_invalidates_token() {
         .expect("join failed");
 
     // Admin kicks victim
-    admin.send_text(r"\kick victim").await;
+    admin
+        .send_json(r#"{"type":"command","cmd":"kick","params":["victim"]}"#)
+        .await;
 
     // Kick produces a system broadcast
     let sys = admin
@@ -1352,12 +1354,16 @@ async fn admin_kick_two_users_both_blocked() {
         .await
         .unwrap();
 
-    admin.send_text(r"\kick alice").await;
+    admin
+        .send_json(r#"{"type":"command","cmd":"kick","params":["alice"]}"#)
+        .await;
     admin
         .recv_until(|m| matches!(m, Message::System { .. }))
         .await;
 
-    admin.send_text(r"\kick bob").await;
+    admin
+        .send_json(r#"{"type":"command","cmd":"kick","params":["bob"]}"#)
+        .await;
     admin
         .recv_until(|m| matches!(m, Message::System { .. }))
         .await;
@@ -1372,7 +1378,7 @@ async fn admin_kick_two_users_both_blocked() {
     }
 }
 
-/// `\reauth <username>` removes the token so the user can rejoin.
+/// `/reauth <username>` removes the token so the user can rejoin.
 #[tokio::test]
 async fn admin_reauth_allows_rejoin() {
     let broker = TestBroker::start("t_reauth").await;
@@ -1393,7 +1399,9 @@ async fn admin_reauth_allows_rejoin() {
     assert!(err.to_string().contains("username_taken") || err.to_string().contains("alice"));
 
     // Admin reauthenticates alice
-    admin.send_text(r"\reauth alice").await;
+    admin
+        .send_json(r#"{"type":"command","cmd":"reauth","params":["alice"]}"#)
+        .await;
     admin
         .recv_until(|m| matches!(m, Message::System { .. }))
         .await;
@@ -1406,7 +1414,7 @@ async fn admin_reauth_allows_rejoin() {
     );
 }
 
-/// `\clear-tokens` removes all tokens; no user can send until they rejoin.
+/// `/clear-tokens` removes all tokens; no user can send until they rejoin.
 #[tokio::test]
 async fn admin_clear_tokens_blocks_all_sends() {
     let broker = TestBroker::start("t_clear_tokens").await;
@@ -1422,7 +1430,9 @@ async fn admin_clear_tokens_blocks_all_sends() {
         .await
         .unwrap();
 
-    admin.send_text(r"\clear-tokens").await;
+    admin
+        .send_json(r#"{"type":"command","cmd":"clear-tokens","params":[]}"#)
+        .await;
     admin
         .recv_until(|m| matches!(m, Message::System { content, .. } if content.contains("cleared all tokens")))
         .await;
@@ -1437,7 +1447,7 @@ async fn admin_clear_tokens_blocks_all_sends() {
     }
 }
 
-/// `\clear` truncates the history file and broadcasts a system message.
+/// `/clear` truncates the history file and broadcasts a system message.
 #[tokio::test]
 async fn admin_clear_history() {
     let broker = TestBroker::start("t_clear_history").await;
@@ -1459,12 +1469,14 @@ async fn admin_clear_history() {
         "history should have at least join + message"
     );
 
-    admin.send_text(r"\clear").await;
+    admin
+        .send_json(r#"{"type":"command","cmd":"clear","params":[]}"#)
+        .await;
     admin
         .recv_until(|m| matches!(m, Message::System { content, .. } if content.contains("cleared chat history")))
         .await;
 
-    // The \clear system message itself is written after truncation, so history
+    // The /clear system message itself is written after truncation, so history
     // should contain only that one entry now.
     let after = history::load(&broker.chat_path).await.unwrap();
     assert_eq!(
@@ -1477,7 +1489,7 @@ async fn admin_clear_history() {
     );
 }
 
-/// `\exit` broadcasts a shutdown notice and the broker stops accepting connections.
+/// `/exit` broadcasts a shutdown notice and the broker stops accepting connections.
 #[tokio::test]
 async fn admin_exit_shuts_down_broker() {
     let broker = TestBroker::start("t_exit").await;
@@ -1486,7 +1498,9 @@ async fn admin_exit_shuts_down_broker() {
         .recv_until(|m| matches!(m, Message::Join { .. }))
         .await;
 
-    admin.send_text(r"\exit").await;
+    admin
+        .send_json(r#"{"type":"command","cmd":"exit","params":[]}"#)
+        .await;
     admin
         .recv_until(
             |m| matches!(m, Message::System { content, .. } if content.contains("shutting down")),
@@ -1500,7 +1514,7 @@ async fn admin_exit_shuts_down_broker() {
     let result = UnixStream::connect(&broker.socket_path).await;
     assert!(
         result.is_err(),
-        "broker should have stopped accepting connections after \\exit"
+        "broker should have stopped accepting connections after /exit"
     );
 }
 
@@ -1722,7 +1736,7 @@ async fn pull_messages_filters_dms_for_viewer() {
     );
 }
 
-/// After `\kick`, the kicked user must not appear in subsequent `/who` responses.
+/// After `/kick`, the kicked user must not appear in subsequent `/who` responses.
 #[tokio::test]
 async fn kick_removes_user_from_who() {
     let broker = TestBroker::start("t_kick_who").await;
@@ -1737,7 +1751,9 @@ async fn kick_removes_user_from_who() {
         .await;
 
     // Admin kicks victim
-    admin.send_text(r"\kick victim").await;
+    admin
+        .send_json(r#"{"type":"command","cmd":"kick","params":["victim"]}"#)
+        .await;
     admin
         .recv_until(|m| matches!(m, Message::System { .. }))
         .await;
@@ -1821,13 +1837,17 @@ async fn non_host_admin_cmd_is_rejected() {
     bob.recv_until(|m| matches!(m, Message::Join { user, .. } if user == "bob"))
         .await;
 
-    // bot joins via token (oneshot JOIN), then attempts \kick alice
+    // bot joins via token (oneshot JOIN), then attempts /kick alice
     let (_, tok) = room::oneshot::join_session(&broker.socket_path, "bot")
         .await
         .unwrap();
-    let msg = room::oneshot::send_message_with_token(&broker.socket_path, &tok, r"\kick alice")
-        .await
-        .expect("oneshot send should succeed even when permission is denied");
+    let msg = room::oneshot::send_message_with_token(
+        &broker.socket_path,
+        &tok,
+        r#"{"type":"command","cmd":"kick","params":["alice"]}"#,
+    )
+    .await
+    .expect("oneshot send should succeed even when permission is denied");
 
     let Message::System { content, .. } = msg else {
         panic!("expected system message, got: {msg:?}");
@@ -1871,8 +1891,10 @@ async fn host_can_run_admin_commands() {
         .recv_until(|m| matches!(m, Message::Join { user, .. } if user == "victim"))
         .await;
 
-    // alice (host) kicks victim via the TUI interactive path
-    alice.send_text(r"\kick victim").await;
+    // alice (host) kicks via JSON command (matching TUI build_payload output)
+    alice
+        .send_json(r#"{"type":"command","cmd":"kick","params":["victim"]}"#)
+        .await;
 
     // broadcast: all connected users receive the kick system message
     let sys = alice


### PR DESCRIPTION
## Summary

Closes #48. Unifies all commands under the `/` prefix — admin commands (`/kick`, `/reauth`, `/clear-tokens`, `/exit`, `/clear`) are merged into the main command palette alongside user commands (`/dm`, `/who`, `/set_status`, etc.).

- **broker.rs**: Removed raw backslash-text admin detection. Admin commands now arrive as `{"type":"command","cmd":"kick",...}` JSON envelopes and are routed to `handle_admin_cmd` via an `ADMIN_CMD_NAMES` constant check in both the interactive and oneshot paths.
- **tui.rs**: Merged `ADMIN_COMMANDS` into `PALETTE_COMMANDS` with `/` prefix. Removed separate `admin_palette` variable, `\` trigger, and all associated render/event handling (net -80 lines). Single palette activates on `/`.
- **tests/integration.rs**: Updated all admin command sends to use JSON command envelopes matching what `build_payload` produces.
- **README.md**: Updated admin command table to `/` prefix.

## Test plan

- [ ] All commands (user and admin) appear in the `/` palette
- [ ] `/kick`, `/exit`, `/clear`, `/reauth`, `/clear-tokens` execute correctly from TUI
- [ ] Non-host receives permission denied for admin commands
- [ ] 99 unit + 55 integration tests green