### PR TITLE
docs: clarify announce-before-acting applies to fix commits and CI failures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,14 @@ room send myroom -t $TOKEN "opening PR for #42"
   "fixing conflict on PR #30, hold review"
   "about to modify src/tui.rs — adding palette overlay only, not touching input rendering"
   ```
+- **Fix commits, CI failures, and rebases require the same announce-first discipline.**
+  Do not silently push a fix. Announce before you start, then again when pushed:
+  ```
+  "clippy error on PR #42 — fixing, hold review"
+  "rebase conflict on PR #38, resolving now"
+  "addressing review feedback on PR #55 — touching broker.rs only"
+  ```
+  After the fix is pushed: `"fix pushed, PR #42 ready for re-review"`
 - **Poll and send a milestone update at natural breakpoints:**
   - After reading the target file (before writing any code)
   - After completing a first working draft (before running tests)


### PR DESCRIPTION
## Summary

- Adds an explicit bullet point under **During work** for fix commits, CI failures, and rebases
- The existing rule mentioned fix commits in passing; this makes it a first-class, standalone requirement with concrete examples
- Covers the three most common silent-fix patterns: clippy/CI failures, rebase conflicts, and review feedback
- Includes the "after fix is pushed" follow-up announcement pattern

## Changes

`CLAUDE.md` — "During work" section gains a new bullet:

> **Fix commits, CI failures, and rebases require the same announce-first discipline.**  
> Do not silently push a fix. Announce before you start, then again when pushed.

Closes #31