### PR TITLE
fix(tui): exit cleanly when broker shuts down (#69)

### DIFF
--- a/src/broker.rs
+++ b/src/broker.rs
@@ -240,21 +240,41 @@ async fn handle_client(
     // Wrap write half in Arc<Mutex> for shared use by outbound and inbound tasks
     let write_half = Arc::new(Mutex::new(write_half));
 
-    // Outbound: receive from broadcast channel, forward to client socket
+    // Outbound: receive from broadcast channel, forward to client socket.
+    // Also listens for the shutdown signal; drains the channel first so the
+    // client sees the shutdown system message before receiving EOF.
     let write_half_out = write_half.clone();
+    let shutdown_out = state.shutdown.clone();
     let outbound = tokio::spawn(async move {
         loop {
-            match rx.recv().await {
-                Ok(line) => {
-                    let mut wh = write_half_out.lock().await;
-                    if wh.write_all(line.as_bytes()).await.is_err() {
-                        break;
+            tokio::select! {
+                result = rx.recv() => {
+                    match result {
+                        Ok(line) => {
+                            let mut wh = write_half_out.lock().await;
+                            if wh.write_all(line.as_bytes()).await.is_err() {
+                                break;
+                            }
+                        }
+                        Err(broadcast::error::RecvError::Lagged(n)) => {
+                            eprintln!("[broker] cid={cid} lagged by {n}");
+                        }
+                        Err(broadcast::error::RecvError::Closed) => break,
                     }
                 }
-                Err(broadcast::error::RecvError::Lagged(n)) => {
-                    eprintln!("[broker] cid={cid} lagged by {n}");
+                _ = shutdown_out.notified() => {
+                    // Drain any messages already queued (e.g. the shutdown notice)
+                    // before closing so the client sees them before receiving EOF.
+                    while let Ok(line) = rx.try_recv() {
+                        let mut wh = write_half_out.lock().await;
+                        let _ = wh.write_all(line.as_bytes()).await;
+                    }
+                    // Explicitly shut down the write side to send EOF to the client,
+                    // even though write_half_in (in the inbound task) still holds
+                    // the Arc — without this, the socket stays open.
+                    let _ = write_half_out.lock().await.shutdown().await;
+                    break;
                 }
-                Err(broadcast::error::RecvError::Closed) => break,
             }
         }
     });
@@ -614,7 +634,8 @@ async fn handle_admin_cmd(cmd_line: &str, issuer: &str, state: &RoomState) -> Op
             let content = format!("{issuer} is shutting down the room");
             let msg = make_system(room_id, "broker", content);
             let _ = broadcast_and_persist(&msg, clients, chat_path, seq_counter).await;
-            shutdown.notify_one();
+            // Wake the main accept loop AND all outbound tasks simultaneously.
+            shutdown.notify_waiters();
         }
         "clear" => {
             // Truncate the history file.

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -291,27 +291,34 @@ pub async fn run(
         .await?;
 
     'main: loop {
-        // Drain pending messages from the socket reader
-        while let Ok(msg) = msg_rx.try_recv() {
-            match &msg {
-                Message::Join { user, .. } if !online_users.contains(user) => {
-                    online_users.push(user.clone());
+        // Drain pending messages from the socket reader.
+        // Break 'main when the broker disconnects (sender dropped).
+        loop {
+            match msg_rx.try_recv() {
+                Ok(msg) => {
+                    match &msg {
+                        Message::Join { user, .. } if !online_users.contains(user) => {
+                            online_users.push(user.clone());
+                        }
+                        Message::Leave { user, .. } => {
+                            online_users.retain(|u| u != user);
+                        }
+                        // Seed from message senders so @mention works for users who connected
+                        // via poll/send (no persistent connection, not in the status_map).
+                        Message::Message { user, .. } if !online_users.contains(user) => {
+                            online_users.push(user.clone());
+                        }
+                        // Parse the /who response to seed the authoritative user list.
+                        Message::System { user, content, .. } if user == "broker" => {
+                            seed_online_users_from_who(content, &mut online_users);
+                        }
+                        _ => {}
+                    }
+                    messages.push(msg);
                 }
-                Message::Leave { user, .. } => {
-                    online_users.retain(|u| u != user);
-                }
-                // Seed from message senders so @mention works for users who connected
-                // via poll/send (no persistent connection, not in the status_map).
-                Message::Message { user, .. } if !online_users.contains(user) => {
-                    online_users.push(user.clone());
-                }
-                // Parse the /who response to seed the authoritative user list.
-                Message::System { user, content, .. } if user == "broker" => {
-                    seed_online_users_from_who(content, &mut online_users);
-                }
-                _ => {}
+                Err(mpsc::error::TryRecvError::Empty) => break,
+                Err(mpsc::error::TryRecvError::Disconnected) => break 'main,
             }
-            messages.push(msg);
         }
 
         let term_area = terminal.size()?;
@@ -708,26 +715,33 @@ pub async fn run(
             }
         }
 
-        // Drain any messages that arrived during the poll
-        while let Ok(msg) = msg_rx.try_recv() {
-            match &msg {
-                Message::Join { user, .. } if !online_users.contains(user) => {
-                    online_users.push(user.clone());
+        // Drain any messages that arrived during the poll.
+        // Break 'main when the broker disconnects (sender dropped).
+        loop {
+            match msg_rx.try_recv() {
+                Ok(msg) => {
+                    match &msg {
+                        Message::Join { user, .. } if !online_users.contains(user) => {
+                            online_users.push(user.clone());
+                        }
+                        Message::Leave { user, .. } => {
+                            online_users.retain(|u| u != user);
+                        }
+                        // Seed from message senders so @mention works for users who connected
+                        // via poll/send (no persistent connection, not in the status_map).
+                        Message::Message { user, .. } if !online_users.contains(user) => {
+                            online_users.push(user.clone());
+                        }
+                        Message::System { user, content, .. } if user == "broker" => {
+                            seed_online_users_from_who(content, &mut online_users);
+                        }
+                        _ => {}
+                    }
+                    messages.push(msg);
                 }
-                Message::Leave { user, .. } => {
-                    online_users.retain(|u| u != user);
-                }
-                // Seed from message senders so @mention works for users who connected
-                // via poll/send (no persistent connection, not in the status_map).
-                Message::Message { user, .. } if !online_users.contains(user) => {
-                    online_users.push(user.clone());
-                }
-                Message::System { user, content, .. } if user == "broker" => {
-                    seed_online_users_from_who(content, &mut online_users);
-                }
-                _ => {}
+                Err(mpsc::error::TryRecvError::Empty) => break,
+                Err(mpsc::error::TryRecvError::Disconnected) => break 'main,
             }
-            messages.push(msg);
         }
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1518,6 +1518,62 @@ async fn admin_exit_shuts_down_broker() {
     );
 }
 
+
+/// After `/exit`, connected clients receive EOF (Ok(0)) on their socket read,
+/// which the TUI detects to exit cleanly without requiring Ctrl-C.
+#[tokio::test]
+async fn exit_causes_broker_to_close_client_connections() {
+    let broker = TestBroker::start("t_exit_eof").await;
+    let mut admin = TestClient::connect(&broker.socket_path, "admin").await;
+    admin
+        .recv_until(|m| matches!(m, Message::Join { .. }))
+        .await;
+
+    // A second client to verify all connections are closed, not just admin's.
+    let mut alice = TestClient::connect(&broker.socket_path, "alice").await;
+    alice
+        .recv_until(|m| matches!(m, Message::Join { user, .. } if user == "alice"))
+        .await;
+
+    admin
+        .send_json(r#"{"type":"command","cmd":"exit","params":[]}"#)
+        .await;
+
+    // Both clients should see the shutdown message.
+    admin
+        .recv_until(
+            |m| matches!(m, Message::System { content, .. } if content.contains("shutting down")),
+        )
+        .await;
+    alice
+        .recv_until(
+            |m| matches!(m, Message::System { content, .. } if content.contains("shutting down")),
+        )
+        .await;
+
+    // After the shutdown message the broker closes the sockets. Both clients
+    // should get EOF (read returns 0 bytes) within a short window.
+    let admin_eof = tokio::time::timeout(Duration::from_millis(500), async {
+        let mut buf = String::new();
+        admin.reader.read_line(&mut buf).await.unwrap_or(0)
+    })
+    .await;
+    assert!(
+        matches!(admin_eof, Ok(0)),
+        "admin socket should receive EOF after /exit"
+    );
+
+    let alice_eof = tokio::time::timeout(Duration::from_millis(500), async {
+        let mut buf = String::new();
+        alice.reader.read_line(&mut buf).await.unwrap_or(0)
+    })
+    .await;
+    assert!(
+        matches!(alice_eof, Ok(0)),
+        "alice socket should receive EOF after /exit"
+    );
+}
+
 // ── pull_messages tests ────────────────────────────────────────────────────────
 
 /// `pull_messages` returns the last N messages from history.


### PR DESCRIPTION
## Summary

Closes #69. `/exit` now causes all connected TUI clients to exit cleanly without requiring `Ctrl-C`.

**Root cause:** Two separate issues:
1. **Broker** (`src/broker.rs`): Each client's outbound task only exited on `RecvError::Closed` (sender dropped), which never happened during `/exit` — the client handlers stayed alive holding the socket open.
2. **TUI** (`src/tui.rs`): The `msg_rx.try_recv()` drain loops didn't detect `TryRecvError::Disconnected` (channel closed), so the main event loop kept running even when the broker disconnected.

**Fixes:**
- **broker.rs**: Outbound task now uses `tokio::select!` between `rx.recv()` and `shutdown_out.notified()`. On shutdown, it drains any pending channel messages (including the shutdown notice), then calls `OwnedWriteHalf::shutdown()` to send EOF to the client. Changed `notify_one()` → `notify_waiters()` so all N connected clients wake simultaneously.
- **tui.rs**: Both `msg_rx` drain loops now match on `TryRecvError::Disconnected` and `break 'main`, exiting the TUI loop.

## Test plan

- [x] New integration test `exit_causes_broker_to_close_client_connections` verifies admin and non-admin clients receive EOF within 500ms of `/exit`
- [x] 104 unit + 56 integration = 160 tests green