### PR TITLE
docs: quick-start.md and broker-internals.md

### DIFF
--- a/docs/broker-internals.md
+++ b/docs/broker-internals.md
@@ -1,0 +1,190 @@
+# Broker internals
+
+A technical reference for contributors and advanced users.
+
+## Overview
+
+The broker is a single async Tokio process that:
+
+1. Listens on a Unix domain socket (`/tmp/room-<id>.sock`)
+2. Accepts client connections and runs a per-client handler task
+3. Fans out messages to all connected clients via a `tokio::broadcast` channel
+4. Appends every event to an NDJSON chat file
+
+```
+/tmp/room-<id>.sock  ←──────────────────────────────────┐
+                                                         │
+room myroom alice  ──[connect]──► Broker                 │
+                                    │                    │
+room myroom bob    ──[connect]──►   ├── handle_client(alice)
+                                    │      ├── inbound task  (reads from socket)
+room send ...      ──[connect]──►   │      └── outbound task (writes to socket)
+                                    │
+                                    ├── handle_client(bob)
+                                    │      ├── inbound task
+                                    │      └── outbound task
+                                    │
+                                    └── handle_oneshot_send (for room send / room join)
+```
+
+## Socket lifecycle
+
+On startup the broker checks for a stale socket file at the expected path. If found, it removes it synchronously (using `std::fs::remove_file`, not `tokio::fs` — see [Why not `tokio::fs`](#why-not-tokiofs)) before binding. This handles the case where a previous broker crashed without cleaning up.
+
+```rust
+if self.socket_path.exists() {
+    std::fs::remove_file(&self.socket_path)?;
+}
+let listener = UnixListener::bind(&self.socket_path)?;
+```
+
+The socket file is not removed on clean shutdown — it remains until the next broker start. Clients that connect after shutdown receive a connection error and must retry.
+
+## Client connection protocol
+
+Every connection begins with a single line of text that determines how the broker handles it:
+
+| Prefix | Handled by | Description |
+|---|---|---|
+| `SEND:<username>` | `handle_oneshot_send` | Legacy one-shot send (no token) |
+| `TOKEN:<uuid>` | `handle_oneshot_send` (after token lookup) | Token-authenticated one-shot send |
+| `JOIN:<username>` | `handle_oneshot_join` | Token registration request |
+| *(plain username)* | `handle_client` | Full interactive session |
+
+### Interactive join handshake
+
+For TUI and `--agent` connections, the first line is the bare username. The broker:
+
+1. Registers the client in the `ClientMap` (username → broadcast sender)
+2. Records the user as host if no host is set yet (first connected user)
+3. Adds the user to the `StatusMap` with an empty status
+4. Replays the full chat history, filtering DMs the user is not party to
+5. Broadcasts a `join` event to all clients
+6. Spawns inbound and outbound tasks (see below)
+
+### Token handshake (`room join`)
+
+A `JOIN:<username>` connection generates a UUID token and writes it to the broker's in-memory `TokenMap`. The token file on disk is written by the CLI (`room join`), not the broker.
+
+If the username is already registered, the broker returns an error and closes the connection without issuing a token.
+
+### One-shot send (`room send`)
+
+A `TOKEN:<uuid>` connection resolves the UUID to a username via the `TokenMap`, then calls the same `handle_oneshot_send` path. The broker:
+
+1. Reads one message line
+2. Parses it (JSON command/message/dm or plain text)
+3. Broadcasts and persists it
+4. Echoes the broadcast record (with assigned `id`, `ts`, and `seq`) back to the sender
+5. Closes the connection
+
+No `join` or `leave` events are emitted for one-shot connections.
+
+## Per-client tasks
+
+For each interactive connection, the broker spawns two concurrent tasks:
+
+### Inbound task
+
+Reads lines from the client's socket. For each line:
+
+- Parses it via `parse_client_line` into a `Message` enum variant
+- Routes commands: `set_status` and `who` are handled privately; admin commands go to `handle_admin_cmd`; all others are broadcast
+- DMs (`Message::DirectMessage`) are delivered only to sender, recipient, and host via `dm_and_persist`
+- Everything else goes to `broadcast_and_persist`
+
+The inbound task exits when the client disconnects (EOF) or on a read error.
+
+### Outbound task
+
+Receives from the broadcast channel and forwards lines to the client socket. Also listens for the shutdown signal:
+
+```rust
+loop {
+    tokio::select! {
+        result = rx.recv() => {
+            // forward message to socket
+        }
+        _ = shutdown_rx.changed() => {
+            // drain pending messages, call write_half.shutdown(), break
+        }
+    }
+}
+```
+
+The outbound task exits on broadcast channel close, write error, or shutdown signal.
+
+`handle_client` waits for whichever task exits first (via `tokio::select!` on both `JoinHandle`s), then broadcasts a `leave` event and removes the user from the `StatusMap`.
+
+## Message fan-out
+
+Every broadcast goes through a single `tokio::broadcast::channel::<String>(256)`. Each interactive client holds a receiver. When `broadcast_and_persist` is called:
+
+1. Assigns the next sequence number (monotonic `AtomicU64`)
+2. Appends the message to the NDJSON chat file
+3. Serialises the message to a JSON line
+4. Sends the line to the broadcast channel — all receivers get a copy
+
+If a receiver lags by more than 256 messages, it receives `RecvError::Lagged` and the lagged count is logged. Messages are not re-delivered.
+
+### Sequence numbers
+
+Every persisted message gets a monotonically increasing `seq` field, assigned by the broker via an `AtomicU64` counter. Clients and tooling can use `seq` to detect gaps in delivery.
+
+## Shutdown signal
+
+The broker uses `tokio::sync::watch::channel::<bool>(false)` as its shutdown signal. The sender (`Arc<watch::Sender<bool>>`) is stored in `RoomState`. Receivers are created with `sender.subscribe()` before each outbound task is spawned.
+
+When `/exit` is processed by `handle_admin_cmd`:
+
+1. Broadcasts a system shutdown notice to all clients
+2. Calls `shutdown.send(true)` on the watch sender
+
+Every outbound task's `shutdown_rx.changed()` arm fires on the next `select!` iteration. Because watch stores state (the current value is `true`), tasks that reach the select after the send still see the change immediately — there is no race window.
+
+The main accept loop also holds a watch receiver and exits when `changed()` fires.
+
+> **Why not `Arc<Notify>`?** `Notify::notify_waiters()` only wakes futures that are currently registered (polled). If the outbound task is mid-write when the signal fires, its `notified()` future is not yet registered, and the wakeup is silently dropped. `watch` avoids this by storing the signal value.
+
+## NDJSON persistence
+
+The chat file (default: `/tmp/<room-id>.chat`) is an NDJSON file — one JSON object per line. The broker is the **sole writer**; clients must never write to it directly.
+
+All writes go through `history::append`, which opens the file in append mode. Tokio's `tokio::fs` wrappers are not used here — see below.
+
+`room poll` and `room watch` read the chat file directly without a socket connection. Multiple concurrent readers are safe because append-only writes are atomic for small payloads on local filesystems.
+
+## Why not `tokio::fs`
+
+`tokio::fs` operations are dispatched to a blocking thread pool managed by Tokio. If the runtime is shutting down, those threads may have already stopped, causing `tokio::fs` calls to be silently cancelled or to hang. All file I/O in `room` uses `std::fs` (synchronous) or explicit `spawn_blocking` wrappers to avoid this.
+
+## Shared state
+
+`RoomState` is wrapped in `Arc` and passed to every client handler:
+
+| Field | Type | Description |
+|---|---|---|
+| `clients` | `Arc<Mutex<HashMap<u64, (String, broadcast::Sender<String>)>>>` | Maps client ID to username + broadcast sender |
+| `status_map` | `Arc<Mutex<HashMap<String, String>>>` | Maps username to status string (ephemeral) |
+| `host_user` | `Arc<Mutex<Option<String>>>` | Username of the first connected client |
+| `token_map` | `Arc<Mutex<HashMap<String, String>>>` | Maps token UUID to username |
+| `chat_path` | `Arc<PathBuf>` | Path to the NDJSON chat file |
+| `room_id` | `Arc<String>` | Room identifier |
+| `shutdown` | `Arc<watch::Sender<bool>>` | Shutdown signal |
+| `seq_counter` | `Arc<AtomicU64>` | Monotonic sequence counter |
+
+## Admin commands
+
+Admin commands are restricted to the room host (first connected user). They are routed through `handle_admin_cmd` when received as a `Message::Command` with a `cmd` matching `ADMIN_CMD_NAMES`:
+
+```rust
+const ADMIN_CMD_NAMES: &[&str] = &["kick", "reauth", "clear-tokens", "exit", "clear"];
+```
+
+| Command | Effect |
+|---|---|
+| `kick <user>` | Removes all tokens for `<user>`, inserts a `KICKED:<user>` sentinel so the username stays reserved. Removes from `StatusMap`. |
+| `reauth <user>` | Removes all tokens for `<user>` (including the kicked sentinel) and deletes the on-disk token file. The user can `room join` again. |
+| `clear-tokens` | Clears the full `TokenMap` and removes all `room-<id>-*.token` files from `/tmp`. |
+| `exit` | Broadcasts a shutdown notice, then calls `shutdown.send(true)`. |
+| `clear` | Truncates the chat history file via `std::fs::write(path, "")`. |

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,0 +1,108 @@
+# Quick start
+
+From zero to a working room in five minutes.
+
+## Install
+
+```bash
+cargo install agentroom
+```
+
+The binary is named `room`. Verify with:
+
+```bash
+room --version
+```
+
+## Start a room (TUI)
+
+Open two terminals. In the first:
+
+```bash
+room myroom alice
+```
+
+This starts the broker (if one is not already running for `myroom`) and opens the full-screen TUI. You are `alice`.
+
+In the second terminal:
+
+```bash
+room myroom bob
+```
+
+You are now `bob`, connected to the same room. Type a message and press `Enter` to send. It appears in both windows.
+
+> **How it works:** the first `room myroom alice` call looks for `/tmp/room-myroom.sock`. Finding none, it starts a broker listening on that socket and connects as a TUI client. `room myroom bob` finds the socket and connects directly.
+
+## Key bindings
+
+| Key | Action |
+|---|---|
+| `Enter` | Send message |
+| `Shift+Enter` | Insert newline (multi-line message) |
+| `Up` / `Down` | Scroll history one line |
+| `PageUp` / `PageDown` | Scroll ten lines |
+| `Ctrl-C` | Quit |
+
+Type `/` to open the command palette.
+
+## Send a command
+
+From the TUI input, prefix with `/`:
+
+```
+/who
+/set_status reviewing PRs
+/dm bob hey, can we sync?
+```
+
+See [commands.md](commands.md) for the full reference.
+
+## One-shot usage (scripts and agents)
+
+For scripts or AI agents that need to send and poll without a persistent connection:
+
+### 1. Register a session token (once per broker lifetime)
+
+```bash
+room join myroom bot
+# {"type":"token","token":"<uuid>","username":"bot"}
+```
+
+The token is automatically written to `/tmp/room-myroom-bot.token`. Subsequent `send`, `poll`, and `watch` calls find it automatically — you do not need to pass `-t` explicitly if the file is present.
+
+```bash
+TOKEN=$(room join myroom bot | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])')
+```
+
+### 2. Send a message
+
+```bash
+room send myroom -t "$TOKEN" hello from a script
+# {"type":"message","id":"...","room":"myroom","user":"bot","ts":"...","content":"hello from a script","seq":1}
+```
+
+### 3. Poll for new messages
+
+```bash
+room poll myroom -t "$TOKEN"
+# prints NDJSON lines for any messages since last poll, then exits
+```
+
+A cursor file at `/tmp/room-myroom-bot.cursor` tracks your position. Each `poll` call returns only messages since the last cursor. Delete the file to reset to the beginning of history.
+
+### 4. Watch (block until a message arrives)
+
+```bash
+room watch myroom -t "$TOKEN"
+# blocks until a message from another user arrives, prints it, exits
+```
+
+Use this in a loop to stay resident without polling in a tight loop. See [agent-coordination.md](agent-coordination.md) for the recommended pattern.
+
+## What's next
+
+- [commands.md](commands.md) — full command reference (TUI and one-shot)
+- [authentication.md](authentication.md) — token lifecycle, rejoin after restart, kick/reauth
+- [agent-coordination.md](agent-coordination.md) — multi-agent protocol for Claude Code agents
+- [broker-internals.md](broker-internals.md) — architecture deep-dive for contributors


### PR DESCRIPTION
## Summary

Closes #85. Closes #84. Part of #77.

Two new documentation pages:

**`docs/quick-start.md`** — tutorial-style onboarding: install, start a room, join from a second terminal, TUI key bindings, one-shot send/poll/watch workflow for scripts and agents. Links to commands.md, authentication.md, agent-coordination.md.

**`docs/broker-internals.md`** — technical reference for contributors: Unix socket lifecycle, client connection protocol (handshake prefixes), per-client inbound/outbound task model, `tokio::broadcast` fan-out, sequence numbers, `watch::channel<bool>` shutdown signal (with explanation of why `Arc<Notify>` had a race), NDJSON persistence, why `std::fs` is used instead of `tokio::fs`, shared `RoomState` fields, admin command routing.

No changes to `src/`, `tests/`, or `CLAUDE.md`.

## Test plan

- [x] `cargo check` passes (docs-only change)
- [x] All facts cross-checked against README and broker.rs source