### PR TITLE
docs: add testing guide

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,3 +1,167 @@
-# Writing Integration Tests
+# Testing
 
-> Coming soon.
+`room` has two test suites: **unit tests** (inside `src/`) and **integration
+tests** (`tests/integration.rs`) that run a real broker over a Unix socket.
+
+---
+
+## Running the tests
+
+```bash
+cargo test
+```
+
+This runs all unit and integration tests. The integration tests spin up
+real broker processes against temporary sockets, so they require no external
+setup.
+
+Pre-push, always run the full checklist in order:
+
+```bash
+cargo check                  # catches syntax/type errors first
+cargo fmt                    # reformat; commit the result if changed
+cargo clippy -- -D warnings  # fix root causes, never suppress
+cargo test                   # all tests must pass
+```
+
+Run a single test by name:
+
+```bash
+cargo test test_name
+```
+
+Run all tests whose names contain a substring:
+
+```bash
+cargo test broadcast
+```
+
+---
+
+## Test structure
+
+```
+src/
+  tui.rs           — unit tests for wrap_words, cursor, palette, mention picker
+  message.rs       — unit tests for Message serde round-trips
+  history.rs       — unit tests for NDJSON load/append
+tests/
+  integration.rs   — integration tests against a live broker
+```
+
+Unit tests live in `#[cfg(test)]` modules at the bottom of each source file.
+Integration tests import the `room` crate via `room::` and spin up real broker
+instances.
+
+---
+
+## Integration test helpers
+
+### `TestBroker`
+
+Starts a broker bound to a temporary socket and waits until the socket is
+ready:
+
+```rust
+let broker = TestBroker::start("my_test_room").await;
+// broker.socket_path — path to the Unix socket
+// broker.chat_path   — path to the NDJSON chat file
+```
+
+The `TempDir` is kept alive for the duration of the test; the socket and
+chat file are cleaned up automatically when `TestBroker` drops.
+
+### `TestClient`
+
+Connects a raw client to the broker and provides helpers for sending and
+receiving messages:
+
+```rust
+let mut client = TestClient::connect(&broker.socket_path, "alice").await;
+
+// Receive the next message (1 s timeout):
+let msg = client.recv().await;
+
+// Wait for a specific message (2 s timeout):
+let join_msg = client
+    .recv_until(|m| matches!(m, Message::Join { user, .. } if user == "alice"))
+    .await;
+
+// Send a plain-text line:
+client.send_text("hello everyone").await;
+
+// Send a JSON envelope:
+client.send_json(r#"{"type":"message","content":"hello"}"#).await;
+```
+
+### Token auth helpers
+
+For tests that require authentication (send/poll via oneshot):
+
+```rust
+let (username, token) = room::oneshot::join_session(&broker.socket_path, "bot")
+    .await
+    .expect("join_session failed");
+
+let wire = serde_json::json!({"type":"message","content":"hi"}).to_string();
+let msg = room::oneshot::send_message_with_token(&broker.socket_path, &token, &wire)
+    .await
+    .expect("send failed");
+```
+
+---
+
+## Writing a new integration test
+
+A typical test follows this pattern:
+
+```rust
+#[tokio::test]
+async fn my_feature_works() {
+    // 1. Start a broker with a unique room ID (avoids socket conflicts).
+    let broker = TestBroker::start("t_my_feature").await;
+
+    // 2. Connect one or more clients.
+    let mut alice = TestClient::connect(&broker.socket_path, "alice").await;
+
+    // 3. Drain the initial join event so subsequent recvs are clean.
+    alice
+        .recv_until(|m| matches!(m, Message::Join { user, .. } if user == "alice"))
+        .await;
+
+    // 4. Exercise the feature.
+    alice.send_text("hello").await;
+
+    // 5. Assert the expected outcome.
+    let msg = alice
+        .recv_until(|m| matches!(m, Message::Message { user, .. } if user == "alice"))
+        .await;
+    if let Message::Message { content, .. } = msg {
+        assert_eq!(content, "hello");
+    }
+}
+```
+
+**Tips:**
+
+- Use a unique `room_id` per test (e.g. `t_my_feature`) to avoid socket path
+  conflicts when tests run in parallel.
+- Always drain your own join event before asserting on subsequent messages;
+  the broker replays history on connect, which can include messages from
+  earlier in the same test run.
+- Use `recv_until` rather than `recv` when you need to skip unrelated events
+  (joins from other clients, system messages, etc.).
+- For timing-sensitive tests involving the broker on an encrypted volume,
+  allow generous sleep margins — startup can take >300 ms.
+
+---
+
+## Test coverage targets
+
+- Every new broker behaviour should have at least one integration test that
+  exercises it at the wire level (connect → send → assert received).
+- Every new TUI helper (wrap function, palette filter, cursor logic) should
+  have a unit test in the corresponding `#[cfg(test)]` block.
+- Tests should aim to surface real failure modes, not just happy paths.
+  Examples: duplicate username rejection, permission-denied on admin commands,
+  cursor advancement after poll.


### PR DESCRIPTION
## Summary

- Adds `docs/testing.md`
- Running tests + pre-push checklist
- Test structure (unit vs integration)
- `TestBroker`, `TestClient`, and token auth helpers with examples
- Full annotated example for writing a new integration test
- Tips on unique room IDs, draining join events, `recv_until`
- Test coverage targets

Closes #89