### PR TITLE
docs: update codebase overview and test structure for module splits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,16 +160,29 @@ room send myroom -t $TOKEN "opening PR for #42"
 
 ```
 src/
-  main.rs      — CLI parsing, subcommand dispatch (join / send / poll / watch)
-  broker.rs    — Unix socket server, message fanout, persistence
-  client.rs    — Connects to broker, runs TUI or agent mode
-  tui.rs       — ratatui split-pane interface
-  message.rs   — Wire format enum, constructors, parse_client_line
-  history.rs   — NDJSON load/append
-  oneshot.rs   — send_message / poll_messages (no persistent connection)
-  lib.rs       — Re-exports all modules (required for integration tests)
+  main.rs              — CLI parsing, subcommand dispatch (join / send / poll / watch)
+  lib.rs               — Re-exports all modules (required for integration tests)
+  client.rs            — Connects to broker, runs TUI or agent mode
+  message.rs           — Wire format enum, constructors, parse_client_line
+  history.rs           — NDJSON load/append
+  broker/
+    mod.rs             — Accept loop, handle_client, handle_oneshot_send
+    state.rs           — RoomState struct and type aliases (ClientMap, StatusMap, etc.)
+    auth.rs            — Token issuance (issue_token) and validation (validate_token)
+    commands.rs        — Unified command routing (route_command, handle_admin_cmd)
+    fanout.rs          — broadcast_and_persist, dm_and_persist
+  oneshot/
+    mod.rs             — Re-exports and subcommand dispatch
+    transport.rs       — Socket connect, send_message, send_message_with_token
+    token.rs           — Token file I/O, cursor read/write, cmd_join
+    poll.rs            — poll_messages, pull_messages, cmd_poll, cmd_pull, cmd_watch
+  tui/
+    mod.rs             — Main run() loop and TUI state
+    input.rs           — InputState, handle_key, Action enum
+    render.rs          — format_message, wrap_words, rendering helpers
+    widgets.rs         — CommandPalette, MentionPicker
 tests/
-  integration.rs — 55 integration tests against a live broker
+  integration.rs       — Integration tests against a live broker
 ```
 
 Key invariants to preserve:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -42,9 +42,13 @@ cargo test broadcast
 
 ```
 src/
-  tui.rs           — unit tests for wrap_words, cursor, palette, mention picker
   message.rs       — unit tests for Message serde round-trips
   history.rs       — unit tests for NDJSON load/append
+  tui/input.rs     — unit tests for handle_key, cursor, key bindings
+  tui/render.rs    — unit tests for wrap_words, format_message
+  tui/widgets.rs   — unit tests for CommandPalette, MentionPicker
+  oneshot/token.rs — unit tests for token file I/O, cursor read/write
+  oneshot/poll.rs  — unit tests for DM filter, cursor advancement
 tests/
   integration.rs   — integration tests against a live broker
 ```


### PR DESCRIPTION
## Summary
- Update CLAUDE.md codebase overview table to reflect the new module directory structure after the SR refactor sprint (broker/, oneshot/, tui/)
- Update docs/testing.md test structure table to list unit test locations in the new sub-modules

## Test plan
- [x] `cargo check` clean
- [x] `cargo fmt` no changes
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test` — 190 tests green

Closes #128
