### PR TITLE
fix(tui): enable bracketed paste for multiline input

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,7 +1,7 @@
 use std::io;
 
 use crossterm::{
-    event::{self, Event},
+    event::{self, DisableBracketedPaste, EnableBracketedPaste, Event},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -89,7 +89,7 @@ pub async fn run(
     // Setup terminal
     enable_raw_mode()?;
     let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen)?;
+    execute!(stdout, EnterAlternateScreen, EnableBracketedPaste)?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
@@ -358,6 +358,11 @@ pub async fn run(
                         None => {}
                     }
                 }
+                Event::Paste(text) => {
+                    state.input.insert_str(state.cursor_pos, &text);
+                    state.cursor_pos += text.len();
+                    state.mention.active = false;
+                }
                 Event::Resize(_, _) => {}
                 _ => {}
             }
@@ -394,7 +399,11 @@ pub async fn run(
     }
 
     disable_raw_mode()?;
-    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    execute!(
+        terminal.backend_mut(),
+        DisableBracketedPaste,
+        LeaveAlternateScreen
+    )?;
     terminal.show_cursor()?;
 
     result


### PR DESCRIPTION
## Summary

- Enable crossterm bracketed paste mode so pasted text arrives as a single `Event::Paste(text)` instead of individual key events
- Each newline in a paste no longer triggers `Action::Send` — the full block is inserted at `cursor_pos` with newlines preserved
- Mention picker is reset on paste since bulk insertion disrupts any in-progress @-completion

## Changes

`src/tui/mod.rs` only:
1. `EnableBracketedPaste` added to terminal setup (alongside `EnterAlternateScreen`)
2. `Event::Paste(text)` match arm inserts full pasted text at cursor
3. `DisableBracketedPaste` added to terminal cleanup (alongside `LeaveAlternateScreen`)

## Test plan

- [x] `cargo check` passes
- [x] `cargo fmt` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] All 190 tests pass (134 unit + 56 integration)
- [ ] Manual: paste multiline text into TUI input — should appear as single block, not fire individual sends

Closes #133