### PR TITLE
feat(cli): add room list command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,11 @@ enum Cmd {
         #[arg(long, default_value_t = 5)]
         interval: u64,
     },
+    /// List active rooms with running brokers.
+    ///
+    /// Scans `/tmp` for `room-*.sock` files and probes each to verify the broker
+    /// is alive. Prints one NDJSON line per active room. No token required.
+    List,
 }
 
 #[derive(Parser, Debug)]
@@ -141,6 +146,9 @@ async fn main() -> anyhow::Result<()> {
             interval,
         }) => {
             oneshot::cmd_watch(&room_id, &token, interval).await?;
+        }
+        Some(Cmd::List) => {
+            oneshot::cmd_list().await?;
         }
         None => {
             let room_id = args.room_id.unwrap_or_else(|| {

--- a/src/oneshot/list.rs
+++ b/src/oneshot/list.rs
@@ -1,0 +1,196 @@
+use std::path::{Path, PathBuf};
+
+use tokio::net::UnixStream;
+use tokio::time::{timeout, Duration};
+
+/// Information about a discovered room with a live broker.
+#[derive(serde::Serialize)]
+struct RoomInfo {
+    room: String,
+    socket: PathBuf,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    chat_path: Option<String>,
+}
+
+/// Scan `/tmp` for `room-*.sock` files, verify each broker is alive via a
+/// short connect attempt, and print one NDJSON line per active room.
+pub async fn cmd_list() -> anyhow::Result<()> {
+    let rooms = discover_rooms(Path::new("/tmp")).await?;
+
+    for info in &rooms {
+        println!("{}", serde_json::to_string(info)?);
+    }
+
+    Ok(())
+}
+
+/// Scan `dir` for `room-*.sock` files and return info for each live broker.
+async fn discover_rooms(dir: &Path) -> anyhow::Result<Vec<RoomInfo>> {
+    let mut rooms: Vec<RoomInfo> = Vec::new();
+
+    let entries = std::fs::read_dir(dir)?;
+    for entry in entries {
+        let entry = entry?;
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+
+        let Some(room_id) = name_str
+            .strip_prefix("room-")
+            .and_then(|s| s.strip_suffix(".sock"))
+        else {
+            continue;
+        };
+
+        let socket_path = entry.path();
+        // Short connect timeout to filter stale sockets without blocking.
+        let alive = timeout(
+            Duration::from_millis(200),
+            UnixStream::connect(&socket_path),
+        )
+        .await
+        .is_ok_and(|r| r.is_ok());
+
+        if !alive {
+            continue;
+        }
+
+        let meta_path = dir.join(format!("room-{room_id}.meta"));
+        let chat_path = read_chat_path_from_meta(&meta_path);
+
+        rooms.push(RoomInfo {
+            room: room_id.to_string(),
+            socket: socket_path,
+            chat_path,
+        });
+    }
+
+    rooms.sort_by(|a, b| a.room.cmp(&b.room));
+    Ok(rooms)
+}
+
+fn read_chat_path_from_meta(meta_path: &Path) -> Option<String> {
+    let data = std::fs::read_to_string(meta_path).ok()?;
+    let v: serde_json::Value = serde_json::from_str(&data).ok()?;
+    v["chat_path"].as_str().map(String::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_chat_path_from_valid_meta() {
+        let dir = tempfile::tempdir().unwrap();
+        let meta = dir.path().join("room-test.meta");
+        std::fs::write(&meta, r#"{"chat_path":"/tmp/test.ndjson"}"#).unwrap();
+        assert_eq!(
+            read_chat_path_from_meta(&meta),
+            Some("/tmp/test.ndjson".to_string())
+        );
+    }
+
+    #[test]
+    fn read_chat_path_missing_file_returns_none() {
+        let path = Path::new("/tmp/nonexistent-meta-file-bumblebee-test.meta");
+        assert_eq!(read_chat_path_from_meta(path), None);
+    }
+
+    #[test]
+    fn read_chat_path_invalid_json_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let meta = dir.path().join("room-bad.meta");
+        std::fs::write(&meta, "not json").unwrap();
+        assert_eq!(read_chat_path_from_meta(&meta), None);
+    }
+
+    #[test]
+    fn read_chat_path_missing_key_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let meta = dir.path().join("room-nokey.meta");
+        std::fs::write(&meta, r#"{"other":"value"}"#).unwrap();
+        assert_eq!(read_chat_path_from_meta(&meta), None);
+    }
+
+    #[tokio::test]
+    async fn discover_rooms_empty_dir_returns_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let rooms = discover_rooms(dir.path()).await.unwrap();
+        assert!(rooms.is_empty());
+    }
+
+    #[tokio::test]
+    async fn discover_rooms_skips_non_socket_files() {
+        let dir = tempfile::tempdir().unwrap();
+        // Create a file that matches the naming pattern but isn't a real socket.
+        std::fs::write(dir.path().join("room-fake.sock"), "").unwrap();
+        let rooms = discover_rooms(dir.path()).await.unwrap();
+        assert!(
+            rooms.is_empty(),
+            "regular file should not be listed as live"
+        );
+    }
+
+    #[tokio::test]
+    async fn discover_rooms_with_live_broker() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("room-testroom.sock");
+
+        // Start a listener to simulate a live broker.
+        let listener = tokio::net::UnixListener::bind(&socket_path).unwrap();
+
+        // Write a meta file so chat_path is included.
+        let meta_path = dir.path().join("room-testroom.meta");
+        std::fs::write(&meta_path, r#"{"chat_path":"/tmp/testroom.ndjson"}"#).unwrap();
+
+        // Spawn a task to accept (and immediately drop) the probe connection.
+        tokio::spawn(async move {
+            let _ = listener.accept().await;
+        });
+
+        let rooms = discover_rooms(dir.path()).await.unwrap();
+        assert_eq!(rooms.len(), 1);
+        assert_eq!(rooms[0].room, "testroom");
+        assert_eq!(rooms[0].chat_path.as_deref(), Some("/tmp/testroom.ndjson"));
+    }
+
+    #[tokio::test]
+    async fn discover_rooms_without_meta_omits_chat_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("room-nometa.sock");
+
+        let listener = tokio::net::UnixListener::bind(&socket_path).unwrap();
+        tokio::spawn(async move {
+            let _ = listener.accept().await;
+        });
+
+        let rooms = discover_rooms(dir.path()).await.unwrap();
+        assert_eq!(rooms.len(), 1);
+        assert_eq!(rooms[0].room, "nometa");
+        assert!(rooms[0].chat_path.is_none());
+    }
+
+    #[tokio::test]
+    async fn discover_rooms_sorts_alphabetically() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let mut listeners = Vec::new();
+        for name in ["room-zebra.sock", "room-alpha.sock", "room-mid.sock"] {
+            let path = dir.path().join(name);
+            let listener = tokio::net::UnixListener::bind(&path).unwrap();
+            listeners.push(listener);
+        }
+
+        // Accept probe connections from all listeners.
+        for listener in listeners {
+            tokio::spawn(async move {
+                loop {
+                    let _ = listener.accept().await;
+                }
+            });
+        }
+
+        let rooms = discover_rooms(dir.path()).await.unwrap();
+        let names: Vec<&str> = rooms.iter().map(|r| r.room.as_str()).collect();
+        assert_eq!(names, vec!["alpha", "mid", "zebra"]);
+    }
+}

--- a/src/oneshot/mod.rs
+++ b/src/oneshot/mod.rs
@@ -1,7 +1,9 @@
+pub mod list;
 pub mod poll;
 pub mod token;
 pub mod transport;
 
+pub use list::cmd_list;
 pub use poll::{cmd_poll, cmd_pull, cmd_watch, poll_messages, pull_messages};
 pub use token::{cmd_join, token_file_path, username_from_token};
 pub use transport::{join_session, send_message, send_message_with_token};


### PR DESCRIPTION
## Summary

- Add `room list` subcommand that discovers active rooms by scanning `/tmp/room-*.sock`
- Each socket is probed with a 200ms connect timeout to filter stale sockets
- Prints one NDJSON line per active room: `{"room":"<id>","socket":"<path>","chat_path":"<path>"}`
- `chat_path` is read from the `.meta` file; omitted when no meta file exists
- No token required — listing rooms is unauthenticated
- No wire protocol changes

## Files changed

- `src/main.rs` — new `Cmd::List` variant + dispatch
- `src/oneshot/list.rs` — new module with `cmd_list`, `discover_rooms`, `read_chat_path_from_meta`
- `src/oneshot/mod.rs` — module declaration + re-export

## Test plan

- [x] `cargo check` passes
- [x] `cargo fmt` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] All 221 tests pass (165 unit + 56 integration)
- [x] 9 new unit tests: meta parsing (4), discover_rooms (5 — empty dir, fake socket, live broker, no meta, sort order)
- [x] Manual: `cargo run -- list` against live broker shows 3 active rooms with correct NDJSON output

Closes #138