### PR TITLE
feat(dx): add pre-push.sh and baseline test count

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,11 +214,19 @@ Run all four in order before every `git push`. CI enforces all of them and will 
 step is skipped. Run them in this order — each step can invalidate the previous one.
 
 ```bash
+bash scripts/pre-push.sh     # runs all four steps below in order
+```
+
+Or manually:
+
+```bash
 cargo check                  # catches syntax/type errors incl. unresolved conflict markers
 cargo fmt                    # reformats code; commit the result if anything changed
 cargo clippy -- -D warnings  # fix root causes, never suppress
 cargo test                   # all tests must pass
 ```
+
+To install as a git hook: `ln -sf ../../scripts/pre-push.sh .git/hooks/pre-push`
 
 - `cargo check` must come first — it catches unresolved merge conflict markers (`<<<<<<<`)
   and type errors that `fmt` and `clippy` will not report cleanly.
@@ -233,6 +241,14 @@ cargo test
 ```
 
 All tests must remain green. Add tests for any new behaviour.
+
+## Baseline test count
+
+**Current baseline: 251 tests (195 unit + 56 integration)**
+
+Every PR that adds functionality must also add tests. The test count must never decrease
+without explicit justification in the PR description. If you remove tests, explain why
+and ensure coverage is not regressed.
 
 ## Release process
 

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# pre-push.sh — Run before every push to ensure CI will pass.
+# Install as a git hook:  ln -sf ../../scripts/pre-push.sh .git/hooks/pre-push
+# Or run manually:        bash scripts/pre-push.sh
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+step() {
+  printf "${BOLD}[pre-push]${RESET} %s\n" "$1"
+}
+
+fail() {
+  printf "${RED}[pre-push] FAILED:${RESET} %s\n" "$1" >&2
+  exit 1
+}
+
+pass() {
+  printf "${GREEN}[pre-push] PASSED:${RESET} %s\n" "$1"
+}
+
+# Order matters — each step can invalidate the previous one.
+# 1. cargo check catches syntax/type errors and conflict markers first.
+# 2. cargo fmt reformats; if it changes anything, you have uncommitted diffs.
+# 3. cargo clippy catches lint issues.
+# 4. cargo test runs the full suite.
+
+step "cargo check"
+cargo check 2>&1 || fail "cargo check"
+pass "cargo check"
+
+step "cargo fmt --check"
+cargo fmt -- --check 2>&1 || fail "cargo fmt (run 'cargo fmt' to fix)"
+pass "cargo fmt"
+
+step "cargo clippy -- -D warnings"
+cargo clippy -- -D warnings 2>&1 || fail "cargo clippy"
+pass "cargo clippy"
+
+step "cargo test"
+cargo test 2>&1 || fail "cargo test"
+pass "cargo test"
+
+printf "\n${GREEN}${BOLD}[pre-push] All checks passed.${RESET}\n"


### PR DESCRIPTION
## Summary
- Add `scripts/pre-push.sh` — runs cargo check, fmt, clippy, test in order with colored output
- Add baseline test count convention to CLAUDE.md (251 tests: 195 unit + 56 integration)
- Reference pre-push.sh in CLAUDE.md pre-push checklist section

DX epic items #3 and #6.

## Install as git hook
```bash
ln -sf ../../scripts/pre-push.sh .git/hooks/pre-push
```

## Test plan
- [x] Script runs successfully with all 251 tests passing
- [x] Script exits early on first failure (set -e)
- [x] Colored output works in terminal
- [x] CLAUDE.md correctly documents baseline count and script usage