### PR TITLE
feat(plugin): compile-time plugin system with /help and /stats

### DIFF
--- a/src/broker/commands.rs
+++ b/src/broker/commands.rs
@@ -1,4 +1,7 @@
-use crate::message::{make_system, Message};
+use crate::{
+    message::{make_system, Message},
+    plugin::{ChatWriter, CommandContext, HistoryReader, PluginResult, RoomMetadata},
+};
 
 use super::{fanout::broadcast_and_persist, state::RoomState};
 
@@ -97,9 +100,86 @@ pub(crate) async fn route_command(
             }
             return Ok(CommandResult::Handled);
         }
+
+        // Plugin dispatch — check registry before falling through to Passthrough.
+        if let Some(plugin) = state.plugin_registry.resolve(cmd) {
+            let plugin_name = plugin.name().to_owned();
+            match dispatch_plugin(plugin, &msg, username, state).await {
+                Ok(result) => return Ok(result),
+                Err(e) => {
+                    // Plugin errors are sent as private replies, never swallowed.
+                    let err_msg = format!("plugin:{plugin_name} error: {e}");
+                    let sys = make_system(&state.room_id, "broker", err_msg);
+                    let json = serde_json::to_string(&sys)?;
+                    return Ok(CommandResult::Reply(json));
+                }
+            }
+        }
     }
 
     Ok(CommandResult::Passthrough(msg))
+}
+
+/// Build a [`CommandContext`] and call a plugin's `handle` method, translating
+/// the [`PluginResult`] into a [`CommandResult`] the broker understands.
+async fn dispatch_plugin(
+    plugin: &dyn crate::plugin::Plugin,
+    msg: &Message,
+    username: &str,
+    state: &RoomState,
+) -> anyhow::Result<CommandResult> {
+    let (cmd, params, id, ts) = match msg {
+        Message::Command {
+            cmd,
+            params,
+            id,
+            ts,
+            ..
+        } => (cmd, params, id, ts),
+        _ => return Ok(CommandResult::Passthrough(msg.clone())),
+    };
+
+    let history = HistoryReader::new(&state.chat_path, username);
+    let writer = ChatWriter::new(
+        &state.clients,
+        &state.chat_path,
+        &state.room_id,
+        &state.seq_counter,
+        plugin.name(),
+    );
+    let metadata =
+        RoomMetadata::snapshot(&state.status_map, &state.host_user, &state.chat_path).await;
+    let available_commands = state.plugin_registry.all_commands();
+
+    let ctx = CommandContext {
+        command: cmd.clone(),
+        params: params.clone(),
+        sender: username.to_owned(),
+        room_id: state.room_id.as_ref().clone(),
+        message_id: id.clone(),
+        timestamp: *ts,
+        history,
+        writer,
+        metadata,
+        available_commands,
+    };
+
+    let result = plugin.handle(ctx).await?;
+
+    Ok(match result {
+        PluginResult::Reply(text) => {
+            let sys = make_system(&state.room_id, &format!("plugin:{}", plugin.name()), text);
+            let json = serde_json::to_string(&sys)?;
+            CommandResult::Reply(json)
+        }
+        PluginResult::Broadcast(text) => {
+            let sys = make_system(&state.room_id, &format!("plugin:{}", plugin.name()), text);
+            broadcast_and_persist(&sys, &state.clients, &state.chat_path, &state.seq_counter)
+                .await?;
+            CommandResult::Handled
+        }
+        PluginResult::Handled => CommandResult::Handled,
+    })
 }
 
 /// Dispatch a `\command [arg]` line sent from a connected client.
@@ -254,6 +334,7 @@ mod tests {
             room_id: Arc::new("test-room".to_owned()),
             shutdown: Arc::new(shutdown_tx),
             seq_counter: Arc::new(AtomicU64::new(0)),
+            plugin_registry: Arc::new(crate::plugin::PluginRegistry::new()),
         })
     }
 

--- a/src/broker/mod.rs
+++ b/src/broker/mod.rs
@@ -16,6 +16,7 @@ use std::{
 use crate::{
     history,
     message::{make_join, make_leave, parse_client_line, Message},
+    plugin::{self, PluginRegistry},
 };
 use auth::{handle_oneshot_join, validate_token};
 use commands::{route_command, CommandResult};
@@ -64,6 +65,11 @@ impl Broker {
         eprintln!("[broker] listening on {}", self.socket_path.display());
 
         let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
+
+        let mut registry = PluginRegistry::new();
+        registry.register(Box::new(plugin::help::HelpPlugin))?;
+        registry.register(Box::new(plugin::stats::StatsPlugin))?;
+
         let state = Arc::new(RoomState {
             clients: Arc::new(Mutex::new(HashMap::new())),
             status_map: Arc::new(Mutex::new(HashMap::new())),
@@ -73,6 +79,7 @@ impl Broker {
             room_id: Arc::new(self.room_id.clone()),
             shutdown: Arc::new(shutdown_tx),
             seq_counter: Arc::new(AtomicU64::new(0)),
+            plugin_registry: Arc::new(registry),
         });
         let next_client_id = Arc::new(AtomicU64::new(0));
 

--- a/src/broker/state.rs
+++ b/src/broker/state.rs
@@ -6,6 +6,8 @@ use std::{
 
 use tokio::sync::{broadcast, watch, Mutex};
 
+use crate::plugin::PluginRegistry;
+
 /// Maps client ID → (username, broadcast sender).
 /// Username is set after the handshake completes.
 pub(crate) type ClientMap = Arc<Mutex<HashMap<u64, (String, broadcast::Sender<String>)>>>;
@@ -37,4 +39,6 @@ pub(crate) struct RoomState {
     /// Monotonically-increasing sequence counter. Incremented for every message
     /// broadcast or persisted by the broker, starting at 1.
     pub(crate) seq_counter: Arc<AtomicU64>,
+    /// Plugin registry for dispatching `/` commands to plugins.
+    pub(crate) plugin_registry: Arc<PluginRegistry>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,4 +3,5 @@ pub mod client;
 pub mod history;
 pub mod message;
 pub mod oneshot;
+pub mod plugin;
 pub mod tui;

--- a/src/plugin/help.rs
+++ b/src/plugin/help.rs
@@ -1,0 +1,204 @@
+use super::{BoxFuture, CommandContext, CommandInfo, Plugin, PluginResult};
+
+/// Built-in `/help` plugin. Lists all available commands or shows details
+/// for a specific command. Dogfoods the plugin API — uses
+/// `ctx.available_commands` to enumerate the registry without holding a
+/// reference to it.
+pub struct HelpPlugin;
+
+impl Plugin for HelpPlugin {
+    fn name(&self) -> &str {
+        "help"
+    }
+
+    fn commands(&self) -> Vec<CommandInfo> {
+        vec![CommandInfo {
+            name: "help".to_owned(),
+            description: "List available commands or get help for a specific command".to_owned(),
+            usage: "/help [command]".to_owned(),
+            completions: vec![],
+        }]
+    }
+
+    fn handle(&self, ctx: CommandContext) -> BoxFuture<'_, anyhow::Result<PluginResult>> {
+        Box::pin(async move {
+            if let Some(target) = ctx.params.first() {
+                // Show help for a specific command
+                let target = target.strip_prefix('/').unwrap_or(target);
+                if let Some(cmd) = ctx.available_commands.iter().find(|c| c.name == target) {
+                    let text = format!("{}\n  {}", cmd.usage, cmd.description);
+                    return Ok(PluginResult::Reply(text));
+                }
+                // Also check built-in commands
+                let builtin = builtin_help(target);
+                if let Some(text) = builtin {
+                    return Ok(PluginResult::Reply(text));
+                }
+                return Ok(PluginResult::Reply(format!("unknown command: /{target}")));
+            }
+
+            // List all commands: built-ins first, then plugins
+            let mut lines = vec![
+                "available commands:".to_owned(),
+                "  /who — show online users".to_owned(),
+                "  /set_status <status> — set your status".to_owned(),
+                "  /kick <user> — kick a user (host only)".to_owned(),
+                "  /reauth <user> — clear a user's token (host only)".to_owned(),
+                "  /clear-tokens — clear all tokens (host only)".to_owned(),
+                "  /clear — clear chat history (host only)".to_owned(),
+                "  /exit — shut down the room (host only)".to_owned(),
+            ];
+            for cmd in &ctx.available_commands {
+                lines.push(format!("  {} — {}", cmd.usage, cmd.description));
+            }
+
+            Ok(PluginResult::Reply(lines.join("\n")))
+        })
+    }
+}
+
+fn builtin_help(cmd: &str) -> Option<String> {
+    match cmd {
+        "who" => Some("/who\n  Show online users and their status".to_owned()),
+        "set_status" => {
+            Some("/set_status <status>\n  Set your status (visible in /who)".to_owned())
+        }
+        "kick" => Some(
+            "/kick <username>\n  Kick a user and invalidate their token (host only)".to_owned(),
+        ),
+        "reauth" => Some(
+            "/reauth <username>\n  Clear a user's token so they can rejoin (host only)".to_owned(),
+        ),
+        "clear-tokens" => {
+            Some("/clear-tokens\n  Clear all tokens; all users must rejoin (host only)".to_owned())
+        }
+        "clear" => Some("/clear\n  Truncate chat history (host only)".to_owned()),
+        "exit" => Some("/exit\n  Shut down the room (host only)".to_owned()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugin::{ChatWriter, Completion, HistoryReader, RoomMetadata, UserInfo};
+    use chrono::Utc;
+    use std::sync::{atomic::AtomicU64, Arc};
+    use tempfile::NamedTempFile;
+    use tokio::sync::Mutex;
+
+    fn make_test_context(params: Vec<String>, commands: Vec<CommandInfo>) -> CommandContext {
+        let tmp = NamedTempFile::new().unwrap();
+        let clients = Arc::new(Mutex::new(std::collections::HashMap::new()));
+        let chat_path = Arc::new(tmp.path().to_path_buf());
+        let room_id = Arc::new("test".to_owned());
+        let seq = Arc::new(AtomicU64::new(0));
+
+        CommandContext {
+            command: "help".to_owned(),
+            params,
+            sender: "alice".to_owned(),
+            room_id: "test".to_owned(),
+            message_id: "msg-1".to_owned(),
+            timestamp: Utc::now(),
+            history: HistoryReader::new(tmp.path(), "alice"),
+            writer: ChatWriter::new(&clients, &chat_path, &room_id, &seq, "help"),
+            metadata: RoomMetadata {
+                online_users: vec![UserInfo {
+                    username: "alice".to_owned(),
+                    status: String::new(),
+                }],
+                host: Some("alice".to_owned()),
+                message_count: 0,
+            },
+            available_commands: commands,
+        }
+    }
+
+    #[tokio::test]
+    async fn help_no_args_lists_all_commands() {
+        let commands = vec![
+            CommandInfo {
+                name: "stats".to_owned(),
+                description: "Show stats".to_owned(),
+                usage: "/stats [N]".to_owned(),
+                completions: vec![],
+            },
+            CommandInfo {
+                name: "help".to_owned(),
+                description: "Show help".to_owned(),
+                usage: "/help [cmd]".to_owned(),
+                completions: vec![],
+            },
+        ];
+        let ctx = make_test_context(vec![], commands);
+        let result = HelpPlugin.handle(ctx).await.unwrap();
+        let PluginResult::Reply(text) = result else {
+            panic!("expected Reply");
+        };
+        assert!(text.contains("available commands:"));
+        assert!(text.contains("/who"));
+        assert!(text.contains("/stats"));
+        assert!(text.contains("/help"));
+    }
+
+    #[tokio::test]
+    async fn help_specific_plugin_command() {
+        let commands = vec![CommandInfo {
+            name: "stats".to_owned(),
+            description: "Show stats".to_owned(),
+            usage: "/stats [N]".to_owned(),
+            completions: vec![],
+        }];
+        let ctx = make_test_context(vec!["stats".to_owned()], commands);
+        let result = HelpPlugin.handle(ctx).await.unwrap();
+        let PluginResult::Reply(text) = result else {
+            panic!("expected Reply");
+        };
+        assert!(text.contains("/stats [N]"));
+        assert!(text.contains("Show stats"));
+    }
+
+    #[tokio::test]
+    async fn help_specific_builtin_command() {
+        let ctx = make_test_context(vec!["who".to_owned()], vec![]);
+        let result = HelpPlugin.handle(ctx).await.unwrap();
+        let PluginResult::Reply(text) = result else {
+            panic!("expected Reply");
+        };
+        assert!(text.contains("/who"));
+        assert!(text.contains("Show online users"));
+    }
+
+    #[tokio::test]
+    async fn help_unknown_command() {
+        let ctx = make_test_context(vec!["nonexistent".to_owned()], vec![]);
+        let result = HelpPlugin.handle(ctx).await.unwrap();
+        let PluginResult::Reply(text) = result else {
+            panic!("expected Reply");
+        };
+        assert!(text.contains("unknown command: /nonexistent"));
+    }
+
+    #[tokio::test]
+    async fn help_strips_leading_slash_from_arg() {
+        let commands = vec![CommandInfo {
+            name: "stats".to_owned(),
+            description: "Show stats".to_owned(),
+            usage: "/stats [N]".to_owned(),
+            completions: vec![Completion {
+                position: 0,
+                values: vec!["10".to_owned()],
+            }],
+        }];
+        let ctx = make_test_context(vec!["/stats".to_owned()], commands);
+        let result = HelpPlugin.handle(ctx).await.unwrap();
+        let PluginResult::Reply(text) = result else {
+            panic!("expected Reply");
+        };
+        assert!(
+            text.contains("/stats [N]"),
+            "should find stats even with leading /"
+        );
+    }
+}

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -1,0 +1,574 @@
+pub mod help;
+pub mod stats;
+
+use std::{
+    collections::HashMap,
+    future::Future,
+    path::{Path, PathBuf},
+    pin::Pin,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+};
+
+use chrono::{DateTime, Utc};
+
+use crate::{
+    broker::{
+        fanout::broadcast_and_persist,
+        state::{ClientMap, StatusMap},
+    },
+    history,
+    message::{make_system, Message},
+};
+
+/// Boxed future type used by [`Plugin::handle`] for dyn compatibility.
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+// ── Plugin trait ────────────────────────────────────────────────────────────
+
+/// A plugin that handles one or more `/` commands.
+///
+/// Implement this trait and register it with [`PluginRegistry`] to add
+/// custom commands to a room broker. The broker dispatches matching
+/// `Message::Command` messages to the plugin's [`handle`](Plugin::handle)
+/// method.
+pub trait Plugin: Send + Sync {
+    /// Unique identifier for this plugin (e.g. `"stats"`, `"help"`).
+    fn name(&self) -> &str;
+
+    /// Commands this plugin handles. Each entry drives `/help` output
+    /// and TUI autocomplete.
+    fn commands(&self) -> Vec<CommandInfo>;
+
+    /// Handle an invocation of one of this plugin's commands.
+    ///
+    /// Returns a boxed future for dyn compatibility (required because the
+    /// registry stores `Box<dyn Plugin>`).
+    fn handle(&self, ctx: CommandContext) -> BoxFuture<'_, anyhow::Result<PluginResult>>;
+}
+
+// ── CommandInfo ─────────────────────────────────────────────────────────────
+
+/// Describes a single command for `/help` and autocomplete.
+#[derive(Debug, Clone)]
+pub struct CommandInfo {
+    /// Command name without the leading `/`.
+    pub name: String,
+    /// One-line description shown in `/help` and autocomplete.
+    pub description: String,
+    /// Usage string (e.g. `"/stats [last N]"`).
+    pub usage: String,
+    /// Static argument completions for autocomplete.
+    pub completions: Vec<Completion>,
+}
+
+/// A static autocomplete hint for a command argument.
+#[derive(Debug, Clone)]
+pub struct Completion {
+    /// Argument position (0-indexed).
+    pub position: usize,
+    /// Possible values. Empty means freeform.
+    pub values: Vec<String>,
+}
+
+// ── CommandContext ───────────────────────────────────────────────────────────
+
+/// Context passed to a plugin's `handle` method.
+pub struct CommandContext {
+    /// The command name that was invoked (without `/`).
+    pub command: String,
+    /// Arguments passed after the command name.
+    pub params: Vec<String>,
+    /// Username of the invoker.
+    pub sender: String,
+    /// Room ID.
+    pub room_id: String,
+    /// Message ID that triggered this command.
+    pub message_id: String,
+    /// Timestamp of the triggering message.
+    pub timestamp: DateTime<Utc>,
+    /// Scoped handle for reading chat history.
+    pub history: HistoryReader,
+    /// Scoped handle for writing back to the chat.
+    pub writer: ChatWriter,
+    /// Snapshot of room metadata.
+    pub metadata: RoomMetadata,
+    /// All registered commands (so `/help` can list them without
+    /// holding a reference to the registry).
+    pub available_commands: Vec<CommandInfo>,
+}
+
+// ── PluginResult ────────────────────────────────────────────────────────────
+
+/// What the broker should do after a plugin handles a command.
+pub enum PluginResult {
+    /// Send a private reply only to the invoker.
+    Reply(String),
+    /// Broadcast a message to the entire room.
+    Broadcast(String),
+    /// Command handled silently (side effects already done via [`ChatWriter`]).
+    Handled,
+}
+
+// ── HistoryReader ───────────────────────────────────────────────────────────
+
+/// Scoped read-only handle to a room's chat history.
+///
+/// Respects DM visibility — a plugin invoked by user X will not see DMs
+/// between Y and Z.
+pub struct HistoryReader {
+    chat_path: PathBuf,
+    viewer: String,
+}
+
+impl HistoryReader {
+    pub(crate) fn new(chat_path: &Path, viewer: &str) -> Self {
+        Self {
+            chat_path: chat_path.to_owned(),
+            viewer: viewer.to_owned(),
+        }
+    }
+
+    /// Load all messages (filtered by DM visibility).
+    pub async fn all(&self) -> anyhow::Result<Vec<Message>> {
+        let all = history::load(&self.chat_path).await?;
+        Ok(self.filter_dms(all))
+    }
+
+    /// Load the last `n` messages (filtered by DM visibility).
+    pub async fn tail(&self, n: usize) -> anyhow::Result<Vec<Message>> {
+        let all = history::tail(&self.chat_path, n).await?;
+        Ok(self.filter_dms(all))
+    }
+
+    /// Load messages after the one with the given ID (filtered by DM visibility).
+    pub async fn since(&self, message_id: &str) -> anyhow::Result<Vec<Message>> {
+        let all = history::load(&self.chat_path).await?;
+        let start = all
+            .iter()
+            .position(|m| m.id() == message_id)
+            .map(|i| i + 1)
+            .unwrap_or(0);
+        Ok(self.filter_dms(all[start..].to_vec()))
+    }
+
+    /// Count total messages in the chat.
+    pub async fn count(&self) -> anyhow::Result<usize> {
+        let all = history::load(&self.chat_path).await?;
+        Ok(all.len())
+    }
+
+    fn filter_dms(&self, messages: Vec<Message>) -> Vec<Message> {
+        messages
+            .into_iter()
+            .filter(|m| match m {
+                Message::DirectMessage { user, to, .. } => {
+                    user == &self.viewer || to == &self.viewer
+                }
+                _ => true,
+            })
+            .collect()
+    }
+}
+
+// ── ChatWriter ──────────────────────────────────────────────────────────────
+
+/// Short-lived scoped handle for a plugin to write messages to the chat.
+///
+/// Posts as `plugin:<name>` — plugins cannot impersonate users. The writer
+/// is valid only for the duration of [`Plugin::handle`].
+pub struct ChatWriter {
+    clients: ClientMap,
+    chat_path: Arc<PathBuf>,
+    room_id: Arc<String>,
+    seq_counter: Arc<AtomicU64>,
+    /// Identity the writer posts as (e.g. `"plugin:stats"`).
+    identity: String,
+}
+
+impl ChatWriter {
+    pub(crate) fn new(
+        clients: &ClientMap,
+        chat_path: &Arc<PathBuf>,
+        room_id: &Arc<String>,
+        seq_counter: &Arc<AtomicU64>,
+        plugin_name: &str,
+    ) -> Self {
+        Self {
+            clients: clients.clone(),
+            chat_path: chat_path.clone(),
+            room_id: room_id.clone(),
+            seq_counter: seq_counter.clone(),
+            identity: format!("plugin:{plugin_name}"),
+        }
+    }
+
+    /// Broadcast a system message to all connected clients and persist to history.
+    pub async fn broadcast(&self, content: &str) -> anyhow::Result<()> {
+        let msg = make_system(&self.room_id, &self.identity, content);
+        broadcast_and_persist(&msg, &self.clients, &self.chat_path, &self.seq_counter).await?;
+        Ok(())
+    }
+
+    /// Send a private system message only to a specific user.
+    pub async fn reply_to(&self, username: &str, content: &str) -> anyhow::Result<()> {
+        let msg = make_system(&self.room_id, &self.identity, content);
+        let seq = self.seq_counter.fetch_add(1, Ordering::SeqCst) + 1;
+        let mut msg = msg;
+        msg.set_seq(seq);
+        history::append(&self.chat_path, &msg).await?;
+
+        let line = format!("{}\n", serde_json::to_string(&msg)?);
+        let map = self.clients.lock().await;
+        for (uname, tx) in map.values() {
+            if uname == username {
+                let _ = tx.send(line.clone());
+            }
+        }
+        Ok(())
+    }
+}
+
+// ── RoomMetadata ────────────────────────────────────────────────────────────
+
+/// Frozen snapshot of room state for plugin consumption.
+pub struct RoomMetadata {
+    /// Users currently online with their status.
+    pub online_users: Vec<UserInfo>,
+    /// Username of the room host.
+    pub host: Option<String>,
+    /// Total messages in the chat file.
+    pub message_count: usize,
+}
+
+/// A user's online presence.
+pub struct UserInfo {
+    pub username: String,
+    pub status: String,
+}
+
+impl RoomMetadata {
+    pub(crate) async fn snapshot(
+        status_map: &StatusMap,
+        host_user: &Arc<tokio::sync::Mutex<Option<String>>>,
+        chat_path: &Path,
+    ) -> Self {
+        let map = status_map.lock().await;
+        let online_users: Vec<UserInfo> = map
+            .iter()
+            .map(|(u, s)| UserInfo {
+                username: u.clone(),
+                status: s.clone(),
+            })
+            .collect();
+        drop(map);
+
+        let host = host_user.lock().await.clone();
+
+        let message_count = history::load(chat_path)
+            .await
+            .map(|msgs| msgs.len())
+            .unwrap_or(0);
+
+        Self {
+            online_users,
+            host,
+            message_count,
+        }
+    }
+}
+
+// ── PluginRegistry ──────────────────────────────────────────────────────────
+
+/// Built-in command names that plugins may not override.
+const RESERVED_COMMANDS: &[&str] = &[
+    "set_status",
+    "who",
+    "kick",
+    "reauth",
+    "clear-tokens",
+    "exit",
+    "clear",
+];
+
+/// Central registry of plugins. The broker uses this to dispatch `/` commands.
+pub struct PluginRegistry {
+    plugins: Vec<Box<dyn Plugin>>,
+    /// command_name → index into `plugins`.
+    command_map: HashMap<String, usize>,
+}
+
+impl PluginRegistry {
+    pub fn new() -> Self {
+        Self {
+            plugins: Vec::new(),
+            command_map: HashMap::new(),
+        }
+    }
+
+    /// Register a plugin. Returns an error if any command name collides with
+    /// a built-in command or another plugin's command.
+    pub fn register(&mut self, plugin: Box<dyn Plugin>) -> anyhow::Result<()> {
+        let idx = self.plugins.len();
+        for cmd in plugin.commands() {
+            if RESERVED_COMMANDS.contains(&cmd.name.as_str()) {
+                anyhow::bail!(
+                    "plugin '{}' cannot register command '{}': reserved by built-in",
+                    plugin.name(),
+                    cmd.name
+                );
+            }
+            if let Some(&existing_idx) = self.command_map.get(&cmd.name) {
+                anyhow::bail!(
+                    "plugin '{}' cannot register command '{}': already registered by '{}'",
+                    plugin.name(),
+                    cmd.name,
+                    self.plugins[existing_idx].name()
+                );
+            }
+            self.command_map.insert(cmd.name.clone(), idx);
+        }
+        self.plugins.push(plugin);
+        Ok(())
+    }
+
+    /// Look up which plugin handles a command name.
+    pub fn resolve(&self, command: &str) -> Option<&dyn Plugin> {
+        self.command_map
+            .get(command)
+            .map(|&idx| self.plugins[idx].as_ref())
+    }
+
+    /// All registered commands across all plugins.
+    pub fn all_commands(&self) -> Vec<CommandInfo> {
+        self.plugins.iter().flat_map(|p| p.commands()).collect()
+    }
+
+    /// Static completions for a specific command at a given argument position.
+    pub fn completions_for(&self, command: &str, arg_pos: usize) -> Vec<String> {
+        self.all_commands()
+            .iter()
+            .find(|c| c.name == command)
+            .map(|c| {
+                c.completions
+                    .iter()
+                    .filter(|comp| comp.position == arg_pos)
+                    .flat_map(|comp| comp.values.clone())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+}
+
+impl Default for PluginRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct DummyPlugin {
+        name: &'static str,
+        cmd: &'static str,
+    }
+
+    impl Plugin for DummyPlugin {
+        fn name(&self) -> &str {
+            self.name
+        }
+
+        fn commands(&self) -> Vec<CommandInfo> {
+            vec![CommandInfo {
+                name: self.cmd.to_owned(),
+                description: "dummy".to_owned(),
+                usage: format!("/{}", self.cmd),
+                completions: vec![],
+            }]
+        }
+
+        fn handle(&self, _ctx: CommandContext) -> BoxFuture<'_, anyhow::Result<PluginResult>> {
+            Box::pin(async { Ok(PluginResult::Reply("dummy".to_owned())) })
+        }
+    }
+
+    #[test]
+    fn registry_register_and_resolve() {
+        let mut reg = PluginRegistry::new();
+        reg.register(Box::new(DummyPlugin {
+            name: "test",
+            cmd: "foo",
+        }))
+        .unwrap();
+        assert!(reg.resolve("foo").is_some());
+        assert!(reg.resolve("bar").is_none());
+    }
+
+    #[test]
+    fn registry_rejects_reserved_command() {
+        let mut reg = PluginRegistry::new();
+        let result = reg.register(Box::new(DummyPlugin {
+            name: "bad",
+            cmd: "kick",
+        }));
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("reserved by built-in"));
+    }
+
+    #[test]
+    fn registry_rejects_duplicate_command() {
+        let mut reg = PluginRegistry::new();
+        reg.register(Box::new(DummyPlugin {
+            name: "first",
+            cmd: "foo",
+        }))
+        .unwrap();
+        let result = reg.register(Box::new(DummyPlugin {
+            name: "second",
+            cmd: "foo",
+        }));
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("already registered by 'first'"));
+    }
+
+    #[test]
+    fn registry_all_commands_lists_everything() {
+        let mut reg = PluginRegistry::new();
+        reg.register(Box::new(DummyPlugin {
+            name: "a",
+            cmd: "alpha",
+        }))
+        .unwrap();
+        reg.register(Box::new(DummyPlugin {
+            name: "b",
+            cmd: "beta",
+        }))
+        .unwrap();
+        let cmds = reg.all_commands();
+        let names: Vec<&str> = cmds.iter().map(|c| c.name.as_str()).collect();
+        assert!(names.contains(&"alpha"));
+        assert!(names.contains(&"beta"));
+        assert_eq!(names.len(), 2);
+    }
+
+    #[test]
+    fn registry_completions_for_returns_values() {
+        let mut reg = PluginRegistry::new();
+        reg.register(Box::new({
+            struct CompPlugin;
+            impl Plugin for CompPlugin {
+                fn name(&self) -> &str {
+                    "comp"
+                }
+                fn commands(&self) -> Vec<CommandInfo> {
+                    vec![CommandInfo {
+                        name: "test".to_owned(),
+                        description: "test".to_owned(),
+                        usage: "/test".to_owned(),
+                        completions: vec![Completion {
+                            position: 0,
+                            values: vec!["10".to_owned(), "20".to_owned()],
+                        }],
+                    }]
+                }
+                fn handle(
+                    &self,
+                    _ctx: CommandContext,
+                ) -> BoxFuture<'_, anyhow::Result<PluginResult>> {
+                    Box::pin(async { Ok(PluginResult::Handled) })
+                }
+            }
+            CompPlugin
+        }))
+        .unwrap();
+        let completions = reg.completions_for("test", 0);
+        assert_eq!(completions, vec!["10", "20"]);
+        assert!(reg.completions_for("test", 1).is_empty());
+        assert!(reg.completions_for("nonexistent", 0).is_empty());
+    }
+
+    #[test]
+    fn registry_rejects_all_reserved_commands() {
+        for &reserved in RESERVED_COMMANDS {
+            let mut reg = PluginRegistry::new();
+            let result = reg.register(Box::new(DummyPlugin {
+                name: "bad",
+                cmd: reserved,
+            }));
+            assert!(
+                result.is_err(),
+                "should reject reserved command '{reserved}'"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn history_reader_filters_dms() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = tmp.path();
+
+        // Write a DM between alice and bob, and a public message
+        let dm = crate::message::make_dm("r", "alice", "bob", "secret");
+        let public = crate::message::make_message("r", "carol", "hello all");
+        history::append(path, &dm).await.unwrap();
+        history::append(path, &public).await.unwrap();
+
+        // alice sees both
+        let reader_alice = HistoryReader::new(path, "alice");
+        let msgs = reader_alice.all().await.unwrap();
+        assert_eq!(msgs.len(), 2);
+
+        // carol sees only the public message
+        let reader_carol = HistoryReader::new(path, "carol");
+        let msgs = reader_carol.all().await.unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].user(), "carol");
+    }
+
+    #[tokio::test]
+    async fn history_reader_tail_and_count() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = tmp.path();
+
+        for i in 0..5 {
+            history::append(
+                path,
+                &crate::message::make_message("r", "u", format!("msg {i}")),
+            )
+            .await
+            .unwrap();
+        }
+
+        let reader = HistoryReader::new(path, "u");
+        assert_eq!(reader.count().await.unwrap(), 5);
+
+        let tail = reader.tail(3).await.unwrap();
+        assert_eq!(tail.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn history_reader_since() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = tmp.path();
+
+        let msg1 = crate::message::make_message("r", "u", "first");
+        let msg2 = crate::message::make_message("r", "u", "second");
+        let msg3 = crate::message::make_message("r", "u", "third");
+        let id1 = msg1.id().to_owned();
+        history::append(path, &msg1).await.unwrap();
+        history::append(path, &msg2).await.unwrap();
+        history::append(path, &msg3).await.unwrap();
+
+        let reader = HistoryReader::new(path, "u");
+        let since = reader.since(&id1).await.unwrap();
+        assert_eq!(since.len(), 2);
+    }
+}

--- a/src/plugin/stats.rs
+++ b/src/plugin/stats.rs
@@ -1,0 +1,184 @@
+use std::collections::HashMap;
+
+use crate::message::Message;
+
+use super::{BoxFuture, CommandContext, CommandInfo, Completion, Plugin, PluginResult};
+
+/// Example `/stats` plugin. Shows a statistical summary of recent chat
+/// activity: message count, participant count, time range, most active user.
+///
+/// `/summarise` is reserved for LLM-powered v2 — the core binary does not
+/// depend on any LLM SDK.
+pub struct StatsPlugin;
+
+impl Plugin for StatsPlugin {
+    fn name(&self) -> &str {
+        "stats"
+    }
+
+    fn commands(&self) -> Vec<CommandInfo> {
+        vec![CommandInfo {
+            name: "stats".to_owned(),
+            description: "Show statistical summary of recent chat activity".to_owned(),
+            usage: "/stats [last N messages, default 50]".to_owned(),
+            completions: vec![Completion {
+                position: 0,
+                values: vec![
+                    "10".to_owned(),
+                    "25".to_owned(),
+                    "50".to_owned(),
+                    "100".to_owned(),
+                ],
+            }],
+        }]
+    }
+
+    fn handle(&self, ctx: CommandContext) -> BoxFuture<'_, anyhow::Result<PluginResult>> {
+        Box::pin(async move {
+            let n: usize = ctx
+                .params
+                .first()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(50);
+
+            let messages = ctx.history.tail(n).await?;
+            let summary = build_summary(&messages);
+            ctx.writer.broadcast(&summary).await?;
+            Ok(PluginResult::Handled)
+        })
+    }
+}
+
+fn build_summary(messages: &[Message]) -> String {
+    if messages.is_empty() {
+        return "stats: no messages in the requested range".to_owned();
+    }
+
+    let total = messages.len();
+
+    // Count messages per user (only Message variants, not join/leave/system)
+    let mut user_counts: HashMap<&str, usize> = HashMap::new();
+    for msg in messages {
+        if matches!(msg, Message::Message { .. } | Message::DirectMessage { .. }) {
+            *user_counts.entry(msg.user()).or_insert(0) += 1;
+        }
+    }
+    let participant_count = user_counts.len();
+
+    let most_active = user_counts
+        .iter()
+        .max_by_key(|(_, count)| *count)
+        .map(|(user, count)| format!("{user} ({count} msgs)"))
+        .unwrap_or_else(|| "none".to_owned());
+
+    let time_range = match (messages.first(), messages.last()) {
+        (Some(first), Some(last)) => {
+            format!(
+                "{} to {}",
+                first.ts().format("%H:%M UTC"),
+                last.ts().format("%H:%M UTC")
+            )
+        }
+        _ => "unknown".to_owned(),
+    };
+
+    format!(
+        "stats (last {total} events): {participant_count} participants, \
+         most active: {most_active}, time range: {time_range}"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message::{make_join, make_message, make_system};
+
+    #[test]
+    fn build_summary_empty() {
+        let summary = build_summary(&[]);
+        assert!(summary.contains("no messages"));
+    }
+
+    #[test]
+    fn build_summary_counts_only_chat_messages() {
+        let msgs = vec![
+            make_join("r", "alice"),
+            make_message("r", "alice", "hello"),
+            make_message("r", "bob", "hi"),
+            make_message("r", "alice", "how are you"),
+            make_system("r", "broker", "system notice"),
+        ];
+        let summary = build_summary(&msgs);
+        // 5 events total, but only 2 participants (alice, bob) in chat messages
+        assert!(summary.contains("5 events"));
+        assert!(summary.contains("2 participants"));
+        assert!(summary.contains("alice (2 msgs)"));
+    }
+
+    #[test]
+    fn build_summary_single_user() {
+        let msgs = vec![
+            make_message("r", "alice", "one"),
+            make_message("r", "alice", "two"),
+        ];
+        let summary = build_summary(&msgs);
+        assert!(summary.contains("1 participants"));
+        assert!(summary.contains("alice (2 msgs)"));
+    }
+
+    #[tokio::test]
+    async fn stats_plugin_broadcasts_summary() {
+        use crate::plugin::{ChatWriter, HistoryReader, RoomMetadata, UserInfo};
+        use chrono::Utc;
+        use std::collections::HashMap;
+        use std::sync::{atomic::AtomicU64, Arc};
+        use tempfile::NamedTempFile;
+        use tokio::sync::{broadcast, Mutex};
+
+        let tmp = NamedTempFile::new().unwrap();
+        let path = tmp.path();
+
+        // Write some messages
+        for i in 0..3 {
+            crate::history::append(path, &make_message("r", "alice", format!("msg {i}")))
+                .await
+                .unwrap();
+        }
+
+        let (tx, mut rx) = broadcast::channel::<String>(64);
+        let mut client_map = HashMap::new();
+        client_map.insert(1u64, ("alice".to_owned(), tx));
+        let clients = Arc::new(Mutex::new(client_map));
+        let chat_path = Arc::new(path.to_path_buf());
+        let room_id = Arc::new("r".to_owned());
+        let seq = Arc::new(AtomicU64::new(0));
+
+        let ctx = super::super::CommandContext {
+            command: "stats".to_owned(),
+            params: vec!["10".to_owned()],
+            sender: "alice".to_owned(),
+            room_id: "r".to_owned(),
+            message_id: "msg-1".to_owned(),
+            timestamp: Utc::now(),
+            history: HistoryReader::new(path, "alice"),
+            writer: ChatWriter::new(&clients, &chat_path, &room_id, &seq, "stats"),
+            metadata: RoomMetadata {
+                online_users: vec![UserInfo {
+                    username: "alice".to_owned(),
+                    status: String::new(),
+                }],
+                host: Some("alice".to_owned()),
+                message_count: 3,
+            },
+            available_commands: vec![],
+        };
+
+        let result = StatsPlugin.handle(ctx).await.unwrap();
+        assert!(matches!(result, PluginResult::Handled));
+
+        // The broadcast should have sent a message
+        let broadcast_msg = rx.try_recv().unwrap();
+        assert!(broadcast_msg.contains("stats"));
+        assert!(broadcast_msg.contains("alice"));
+    }
+}

--- a/src/tui/widgets.rs
+++ b/src/tui/widgets.rs
@@ -32,6 +32,17 @@ pub(super) const PALETTE_COMMANDS: &[PaletteItem] = &[
         usage: "/who",
         description: "List users in the room",
     },
+    // Plugin commands
+    PaletteItem {
+        cmd: "help",
+        usage: "/help [command]",
+        description: "List available commands or get help for a specific command",
+    },
+    PaletteItem {
+        cmd: "stats",
+        usage: "/stats [last N]",
+        description: "Show statistical summary of recent chat activity",
+    },
     // Admin commands
     PaletteItem {
         cmd: "kick",


### PR DESCRIPTION
## Summary

- Adds `Plugin` trait with `BoxFuture` for dyn compatibility (Rust 1.93, no `async-trait` crate needed)
- `PluginRegistry` with collision prevention against built-in commands (`who`, `kick`, `set_status`, etc.)
- Single insertion point in `route_command` — plugin errors become private replies, never swallowed
- `CommandContext` provides scoped `HistoryReader` (DM-filtered), `ChatWriter` (posts as `plugin:<name>`), `RoomMetadata` snapshot, and full command list for introspection
- `/help` plugin dogfoods the API — lists built-ins + plugins, or shows details for a specific command
- `/stats` plugin — message count, participants, time range, most active user
- Both added to TUI command palette for autocomplete

## Files

**New:** `src/plugin/mod.rs`, `src/plugin/help.rs`, `src/plugin/stats.rs`
**Modified:** `src/lib.rs`, `src/broker/state.rs`, `src/broker/commands.rs`, `src/broker/mod.rs`, `src/tui/widgets.rs`

## Test plan

- [x] 16 new unit tests (registry, collision, help variants, stats summary, broadcast)
- [x] All 269 tests pass (213 unit + 56 integration)
- [x] `cargo check && cargo fmt && cargo clippy -- -D warnings && cargo test` clean

Closes #155