### PR TITLE
feat(broker): WebSocket + REST transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,14 +7,19 @@ name = "agentroom"
 version = "0.8.0"
 dependencies = [
  "anyhow",
+ "axum",
  "chrono",
  "clap",
  "crossterm",
+ "futures-util",
  "ratatui",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",
  "tokio",
+ "tokio-tungstenite",
+ "tower-http",
  "unicode-width",
  "uuid",
 ]
@@ -109,10 +114,93 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "base64",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
+ "sync_wrapper",
+ "tokio",
+ "tokio-tungstenite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "base64"
@@ -190,8 +278,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -260,10 +356,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "compact_str"
@@ -286,6 +401,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -385,6 +520,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +573,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,10 +593,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equivalent"
@@ -535,6 +702,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,14 +781,29 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -567,6 +817,25 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -602,6 +871,115 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "windows-registry",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,6 +1004,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,6 +1095,27 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -672,6 +1152,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,6 +1187,38 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -753,6 +1281,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
 name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,6 +1317,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "mac_address"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,6 +1331,12 @@ dependencies = [
  "nix",
  "winapi",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -812,6 +1358,12 @@ checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -902,6 +1454,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,6 +1490,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
@@ -1003,7 +1567,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1035,16 +1599,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -1063,6 +1651,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1092,7 +1736,27 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1100,6 +1764,15 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "ratatui"
@@ -1225,6 +1898,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1247,6 +1980,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1259,10 +2067,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1311,6 +2160,40 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1368,6 +2251,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1382,6 +2271,12 @@ dependencies = [
  "libc",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -1417,6 +2312,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1436,6 +2337,47 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1576,6 +2518,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1601,6 +2568,130 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
 ]
 
 [[package]]
@@ -1651,6 +2742,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1681,6 +2802,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -1718,6 +2858,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1784,6 +2938,35 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1875,6 +3058,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1922,6 +3114,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1941,11 +3144,29 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -1959,20 +3180,63 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1982,9 +3246,33 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1994,9 +3282,27 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2006,15 +3312,51 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2108,6 +3450,115 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,11 @@ ratatui = "0.30"
 crossterm = "0.29"
 anyhow = "1"
 unicode-width = "0.2"
+axum = { version = "0.8.8", features = ["ws"] }
+tower-http = { version = "0.6.8", features = ["cors"] }
+futures-util = { version = "=0.3.31", features = ["sink"] }
 
 [dev-dependencies]
+reqwest = { version = "0.13.2", features = ["json"] }
 tempfile = "3"
+tokio-tungstenite = "0.28"

--- a/src/broker/mod.rs
+++ b/src/broker/mod.rs
@@ -2,11 +2,15 @@ pub(crate) mod auth;
 pub(crate) mod commands;
 pub(crate) mod fanout;
 pub(crate) mod state;
+pub(crate) mod ws;
 
 use std::{
     collections::HashMap,
     path::PathBuf,
-    sync::{atomic::AtomicU64, Arc},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
 };
 
 use crate::{
@@ -30,14 +34,21 @@ pub struct Broker {
     room_id: String,
     chat_path: PathBuf,
     socket_path: PathBuf,
+    ws_port: Option<u16>,
 }
 
 impl Broker {
-    pub fn new(room_id: &str, chat_path: PathBuf, socket_path: PathBuf) -> Self {
+    pub fn new(
+        room_id: &str,
+        chat_path: PathBuf,
+        socket_path: PathBuf,
+        ws_port: Option<u16>,
+    ) -> Self {
         Self {
             room_id: room_id.to_owned(),
             chat_path,
             socket_path,
+            ws_port,
         }
     }
 
@@ -63,14 +74,29 @@ impl Broker {
             shutdown: Arc::new(shutdown_tx),
             seq_counter: Arc::new(AtomicU64::new(0)),
         });
-        let mut next_id: u64 = 0;
+        let next_client_id = Arc::new(AtomicU64::new(0));
+
+        // Start WebSocket/REST server if a port was configured.
+        if let Some(port) = self.ws_port {
+            let ws_state = ws::WsAppState {
+                room_state: state.clone(),
+                next_client_id: next_client_id.clone(),
+            };
+            let app = ws::create_router(ws_state);
+            let tcp = tokio::net::TcpListener::bind(("0.0.0.0", port)).await?;
+            eprintln!("[broker] WebSocket/REST listening on port {port}");
+            tokio::spawn(async move {
+                if let Err(e) = axum::serve(tcp, app).await {
+                    eprintln!("[broker] WS server error: {e}");
+                }
+            });
+        }
 
         loop {
             tokio::select! {
                 accept = listener.accept() => {
                     let (stream, _) = accept?;
-                    next_id += 1;
-                    let cid = next_id;
+                    let cid = next_client_id.fetch_add(1, Ordering::SeqCst) + 1;
 
                     let (tx, _) = broadcast::channel::<String>(256);
                     // Insert with empty username; handle_client updates it after handshake.

--- a/src/broker/ws.rs
+++ b/src/broker/ws.rs
@@ -1,0 +1,606 @@
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
+
+use axum::{
+    extract::{
+        ws::{Message as WsMessage, WebSocket},
+        Path, Query, State, WebSocketUpgrade,
+    },
+    http::{HeaderMap, StatusCode},
+    response::IntoResponse,
+    routing::{get, post},
+    Json, Router,
+};
+use futures_util::{SinkExt, StreamExt};
+use serde::Deserialize;
+use tokio::sync::{broadcast, Mutex};
+
+use crate::{
+    history,
+    message::{make_dm, make_join, make_leave, make_message, parse_client_line, Message},
+};
+
+use super::{
+    auth::{issue_token, validate_token},
+    commands::{route_command, CommandResult},
+    fanout::{broadcast_and_persist, dm_and_persist},
+    state::RoomState,
+};
+
+/// Shared state for axum handlers.
+#[derive(Clone)]
+pub(crate) struct WsAppState {
+    pub(crate) room_state: Arc<RoomState>,
+    pub(crate) next_client_id: Arc<AtomicU64>,
+}
+
+/// Build the axum router with WebSocket and REST routes.
+pub(crate) fn create_router(state: WsAppState) -> Router {
+    Router::new()
+        .route("/ws/{room_id}", get(ws_upgrade_handler))
+        .route("/api/{room_id}/join", post(api_join))
+        .route("/api/{room_id}/send", post(api_send))
+        .route("/api/{room_id}/poll", get(api_poll))
+        .route("/api/health", get(api_health))
+        .with_state(state)
+}
+
+// ── WebSocket upgrade ───────────────────────────────────────────────────
+
+async fn ws_upgrade_handler(
+    ws: WebSocketUpgrade,
+    Path(room_id): Path<String>,
+    State(state): State<WsAppState>,
+) -> impl IntoResponse {
+    if room_id != *state.room_state.room_id {
+        return (StatusCode::NOT_FOUND, "room not found").into_response();
+    }
+    ws.on_upgrade(move |socket| async move {
+        if let Err(e) = handle_ws_client(socket, state).await {
+            eprintln!("[broker/ws] error: {e:#}");
+        }
+    })
+}
+
+// ── WebSocket client lifecycle ──────────────────────────────────────────
+
+async fn handle_ws_client(ws: WebSocket, app_state: WsAppState) -> anyhow::Result<()> {
+    let state = app_state.room_state.clone();
+    let cid = app_state.next_client_id.fetch_add(1, Ordering::SeqCst) + 1;
+
+    let (tx, _) = broadcast::channel::<String>(256);
+    state
+        .clients
+        .lock()
+        .await
+        .insert(cid, (String::new(), tx.clone()));
+
+    let result = run_ws_session(cid, ws, tx, &state).await;
+    state.clients.lock().await.remove(&cid);
+    result
+}
+
+async fn run_ws_session(
+    cid: u64,
+    ws: WebSocket,
+    own_tx: broadcast::Sender<String>,
+    state: &Arc<RoomState>,
+) -> anyhow::Result<()> {
+    let (mut ws_tx, mut ws_rx) = ws.split();
+
+    // Read first frame: handshake (same protocol as UDS).
+    let first_frame = match ws_rx.next().await {
+        Some(Ok(WsMessage::Text(text))) => text.trim().to_owned(),
+        Some(Ok(WsMessage::Close(_))) | None => return Ok(()),
+        Some(Ok(_)) => return Ok(()),
+        Some(Err(e)) => return Err(e.into()),
+    };
+
+    // One-shot: JOIN — register username, return token, close.
+    if let Some(join_user) = first_frame.strip_prefix("JOIN:") {
+        return ws_oneshot_join(join_user, &mut ws_tx, state).await;
+    }
+
+    // One-shot: SEND — legacy unauthenticated send.
+    if let Some(send_user) = first_frame.strip_prefix("SEND:") {
+        return ws_oneshot_send(send_user.to_owned(), &mut ws_rx, &mut ws_tx, state).await;
+    }
+
+    // One-shot: TOKEN — authenticated send.
+    if let Some(token) = first_frame.strip_prefix("TOKEN:") {
+        return match validate_token(token, &state.token_map).await {
+            Some(u) => ws_oneshot_send(u, &mut ws_rx, &mut ws_tx, state).await,
+            None => {
+                let err = serde_json::json!({"type":"error","code":"invalid_token"});
+                let _ = ws_tx.send(WsMessage::Text(err.to_string().into())).await;
+                Ok(())
+            }
+        };
+    }
+
+    // Interactive join — first_frame is the username.
+    let username = first_frame;
+    if username.is_empty() {
+        return Ok(());
+    }
+
+    // Register username in client map.
+    {
+        let mut map = state.clients.lock().await;
+        if let Some(entry) = map.get_mut(&cid) {
+            entry.0 = username.clone();
+        }
+    }
+
+    // First interactive join becomes host.
+    {
+        let mut host = state.host_user.lock().await;
+        if host.is_none() {
+            *host = Some(username.clone());
+        }
+    }
+
+    eprintln!("[broker/ws] {username} joined (cid={cid})");
+
+    state
+        .status_map
+        .lock()
+        .await
+        .insert(username.clone(), String::new());
+
+    // Subscribe before sending history so we don't miss concurrent messages.
+    let mut rx = own_tx.subscribe();
+
+    // Send chat history, filtering DMs the client is not party to.
+    let host_name = state.host_user.lock().await.clone();
+    let is_host = host_name.as_deref() == Some(username.as_str());
+    let history = history::load(&state.chat_path).await.unwrap_or_default();
+    for msg in &history {
+        let visible = match msg {
+            Message::DirectMessage { user, to, .. } => {
+                is_host || user == &username || to == &username
+            }
+            _ => true,
+        };
+        if visible {
+            let line = serde_json::to_string(msg)?;
+            if ws_tx.send(WsMessage::Text(line.into())).await.is_err() {
+                return Ok(());
+            }
+        }
+    }
+
+    // Broadcast join event.
+    let join_msg = make_join(&state.room_id, &username);
+    if let Err(e) = broadcast_and_persist(
+        &join_msg,
+        &state.clients,
+        &state.chat_path,
+        &state.seq_counter,
+    )
+    .await
+    {
+        eprintln!("[broker/ws] broadcast_and_persist(join) failed: {e:#}");
+        return Ok(());
+    }
+
+    // Wrap sender for shared use by outbound and shutdown paths.
+    let ws_tx = Arc::new(Mutex::new(ws_tx));
+
+    // Outbound: forward broadcast channel messages to the WebSocket.
+    let ws_tx_out = ws_tx.clone();
+    let mut shutdown_rx = state.shutdown.subscribe();
+    let outbound = tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                result = rx.recv() => {
+                    match result {
+                        Ok(line) => {
+                            let trimmed = line.trim_end().to_owned();
+                            if ws_tx_out.lock().await.send(WsMessage::Text(trimmed.into())).await.is_err() {
+                                break;
+                            }
+                        }
+                        Err(broadcast::error::RecvError::Lagged(n)) => {
+                            eprintln!("[broker/ws] cid={cid} lagged by {n}");
+                        }
+                        Err(broadcast::error::RecvError::Closed) => break,
+                    }
+                }
+                _ = shutdown_rx.changed() => {
+                    while let Ok(line) = rx.try_recv() {
+                        let trimmed = line.trim_end().to_owned();
+                        let _ = ws_tx_out.lock().await.send(WsMessage::Text(trimmed.into())).await;
+                    }
+                    let _ = ws_tx_out.lock().await.send(WsMessage::Close(None)).await;
+                    break;
+                }
+            }
+        }
+    });
+
+    // Inbound: read text frames, parse, and route.
+    let username_in = username.clone();
+    let room_id_in = state.room_id.clone();
+    let ws_tx_in = ws_tx.clone();
+    let state_in = state.clone();
+    let inbound = tokio::spawn(async move {
+        while let Some(frame) = ws_rx.next().await {
+            match frame {
+                Ok(WsMessage::Text(text)) => {
+                    let trimmed = text.trim();
+                    if trimmed.is_empty() {
+                        continue;
+                    }
+                    match parse_client_line(trimmed, &room_id_in, &username_in) {
+                        Ok(msg) => match route_command(msg, &username_in, &state_in).await {
+                            Ok(CommandResult::Handled) => {}
+                            Ok(CommandResult::Reply(json)) => {
+                                let _ = ws_tx_in
+                                    .lock()
+                                    .await
+                                    .send(WsMessage::Text(json.into()))
+                                    .await;
+                            }
+                            Ok(CommandResult::Shutdown) => break,
+                            Ok(CommandResult::Passthrough(msg)) => {
+                                let result = match &msg {
+                                    Message::DirectMessage { to, .. } => {
+                                        dm_and_persist(
+                                            &msg,
+                                            &username_in,
+                                            to,
+                                            &state_in.host_user,
+                                            &state_in.clients,
+                                            &state_in.chat_path,
+                                            &state_in.seq_counter,
+                                        )
+                                        .await
+                                    }
+                                    _ => {
+                                        broadcast_and_persist(
+                                            &msg,
+                                            &state_in.clients,
+                                            &state_in.chat_path,
+                                            &state_in.seq_counter,
+                                        )
+                                        .await
+                                    }
+                                };
+                                if let Err(e) = result {
+                                    eprintln!("[broker/ws] persist error: {e:#}");
+                                }
+                            }
+                            Err(e) => eprintln!("[broker/ws] route error: {e:#}"),
+                        },
+                        Err(e) => eprintln!("[broker/ws] bad message from {username_in}: {e}"),
+                    }
+                }
+                Ok(WsMessage::Close(_)) => break,
+                Ok(_) => {} // ping/pong handled automatically, binary ignored
+                Err(_) => break,
+            }
+        }
+    });
+
+    tokio::select! {
+        _ = outbound => {},
+        _ = inbound => {},
+    }
+
+    // Cleanup.
+    state.status_map.lock().await.remove(&username);
+    let leave_msg = make_leave(&state.room_id, &username);
+    let _ = broadcast_and_persist(
+        &leave_msg,
+        &state.clients,
+        &state.chat_path,
+        &state.seq_counter,
+    )
+    .await;
+    eprintln!("[broker/ws] {username} left (cid={cid})");
+
+    Ok(())
+}
+
+// ── WebSocket one-shot handlers ─────────────────────────────────────────
+
+type WsSink = futures_util::stream::SplitSink<WebSocket, WsMessage>;
+type WsStream = futures_util::stream::SplitStream<WebSocket>;
+
+async fn ws_oneshot_join(
+    username: &str,
+    ws_tx: &mut WsSink,
+    state: &Arc<RoomState>,
+) -> anyhow::Result<()> {
+    match issue_token(username, &state.token_map).await {
+        Ok(token) => {
+            let resp = serde_json::json!({"type":"token","token": token, "username": username});
+            let _ = ws_tx.send(WsMessage::Text(resp.to_string().into())).await;
+        }
+        Err(_) => {
+            let err = serde_json::json!({
+                "type":"error","code":"username_taken","username": username
+            });
+            let _ = ws_tx.send(WsMessage::Text(err.to_string().into())).await;
+        }
+    }
+    let _ = ws_tx.send(WsMessage::Close(None)).await;
+    Ok(())
+}
+
+async fn ws_oneshot_send(
+    username: String,
+    ws_rx: &mut WsStream,
+    ws_tx: &mut WsSink,
+    state: &Arc<RoomState>,
+) -> anyhow::Result<()> {
+    // Read the message frame.
+    let text = match ws_rx.next().await {
+        Some(Ok(WsMessage::Text(t))) => t,
+        _ => return Ok(()),
+    };
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return Ok(());
+    }
+    let msg = parse_client_line(trimmed, &state.room_id, &username)?;
+    match route_command(msg, &username, state).await? {
+        CommandResult::Handled | CommandResult::Shutdown => {}
+        CommandResult::Reply(json) => {
+            let _ = ws_tx.send(WsMessage::Text(json.into())).await;
+        }
+        CommandResult::Passthrough(msg) => {
+            let seq_msg = match &msg {
+                Message::DirectMessage { to, .. } => {
+                    dm_and_persist(
+                        &msg,
+                        &username,
+                        to,
+                        &state.host_user,
+                        &state.clients,
+                        &state.chat_path,
+                        &state.seq_counter,
+                    )
+                    .await?
+                }
+                _ => {
+                    broadcast_and_persist(
+                        &msg,
+                        &state.clients,
+                        &state.chat_path,
+                        &state.seq_counter,
+                    )
+                    .await?
+                }
+            };
+            let echo = serde_json::to_string(&seq_msg)?;
+            let _ = ws_tx.send(WsMessage::Text(echo.into())).await;
+        }
+    }
+    Ok(())
+}
+
+// ── REST endpoints ──────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct JoinRequest {
+    username: String,
+}
+
+async fn api_join(
+    Path(room_id): Path<String>,
+    State(state): State<WsAppState>,
+    Json(body): Json<JoinRequest>,
+) -> impl IntoResponse {
+    if room_id != *state.room_state.room_id {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"type":"error","code":"room_not_found"})),
+        )
+            .into_response();
+    }
+    match issue_token(&body.username, &state.room_state.token_map).await {
+        Ok(token) => {
+            let resp = serde_json::json!({
+                "type":"token","token": token, "username": body.username
+            });
+            (StatusCode::OK, Json(resp)).into_response()
+        }
+        Err(_) => {
+            let err = serde_json::json!({
+                "type":"error","code":"username_taken","username": body.username
+            });
+            (StatusCode::CONFLICT, Json(err)).into_response()
+        }
+    }
+}
+
+fn extract_bearer_token(headers: &HeaderMap) -> Option<&str> {
+    headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "))
+}
+
+#[derive(Deserialize)]
+struct SendRequest {
+    content: String,
+    to: Option<String>,
+}
+
+async fn api_send(
+    Path(room_id): Path<String>,
+    State(state): State<WsAppState>,
+    headers: HeaderMap,
+    Json(body): Json<SendRequest>,
+) -> impl IntoResponse {
+    if room_id != *state.room_state.room_id {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"type":"error","code":"room_not_found"})),
+        )
+            .into_response();
+    }
+
+    let token = match extract_bearer_token(&headers) {
+        Some(t) => t,
+        None => {
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({"type":"error","code":"missing_token"})),
+            )
+                .into_response()
+        }
+    };
+
+    let username = match validate_token(token, &state.room_state.token_map).await {
+        Some(u) => u,
+        None => {
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({"type":"error","code":"invalid_token"})),
+            )
+                .into_response()
+        }
+    };
+
+    let rs = &state.room_state;
+    let msg = if let Some(ref to) = body.to {
+        make_dm(&rs.room_id, &username, to, &body.content)
+    } else {
+        make_message(&rs.room_id, &username, &body.content)
+    };
+
+    match route_command(msg, &username, rs).await {
+        Ok(CommandResult::Handled) => {
+            (StatusCode::OK, Json(serde_json::json!({"type":"ok"}))).into_response()
+        }
+        Ok(CommandResult::Reply(json)) => {
+            let v: serde_json::Value =
+                serde_json::from_str(&json).unwrap_or(serde_json::json!({"reply": json}));
+            (StatusCode::OK, Json(v)).into_response()
+        }
+        Ok(CommandResult::Shutdown) => {
+            (StatusCode::OK, Json(serde_json::json!({"type":"shutdown"}))).into_response()
+        }
+        Ok(CommandResult::Passthrough(msg)) => {
+            let result = match &msg {
+                Message::DirectMessage { to, .. } => {
+                    dm_and_persist(
+                        &msg,
+                        &username,
+                        to,
+                        &rs.host_user,
+                        &rs.clients,
+                        &rs.chat_path,
+                        &rs.seq_counter,
+                    )
+                    .await
+                }
+                _ => broadcast_and_persist(&msg, &rs.clients, &rs.chat_path, &rs.seq_counter).await,
+            };
+            match result {
+                Ok(seq_msg) => {
+                    let json = serde_json::to_value(&seq_msg).unwrap_or_default();
+                    (StatusCode::OK, Json(json)).into_response()
+                }
+                Err(e) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"type":"error","code":"persist_error","message": e.to_string()})),
+                )
+                    .into_response(),
+            }
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"type":"error","code":"route_error","message": e.to_string()})),
+        )
+            .into_response(),
+    }
+}
+
+#[derive(Deserialize)]
+struct PollQuery {
+    since: Option<String>,
+}
+
+async fn api_poll(
+    Path(room_id): Path<String>,
+    State(state): State<WsAppState>,
+    headers: HeaderMap,
+    Query(query): Query<PollQuery>,
+) -> impl IntoResponse {
+    if room_id != *state.room_state.room_id {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"type":"error","code":"room_not_found"})),
+        )
+            .into_response();
+    }
+
+    let token = match extract_bearer_token(&headers) {
+        Some(t) => t,
+        None => {
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({"type":"error","code":"missing_token"})),
+            )
+                .into_response()
+        }
+    };
+
+    let username = match validate_token(token, &state.room_state.token_map).await {
+        Some(u) => u,
+        None => {
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({"type":"error","code":"invalid_token"})),
+            )
+                .into_response()
+        }
+    };
+
+    let rs = &state.room_state;
+    let history = history::load(&rs.chat_path).await.unwrap_or_default();
+    let host_name = rs.host_user.lock().await.clone();
+    let is_host = host_name.as_deref() == Some(username.as_str());
+
+    // Filter messages after the `since` ID (stateless — no server-side cursor).
+    let mut found_since = query.since.is_none();
+    let messages: Vec<serde_json::Value> = history
+        .into_iter()
+        .filter(|msg| {
+            if !found_since {
+                if msg.id() == query.since.as_deref().unwrap_or_default() {
+                    found_since = true;
+                }
+                return false;
+            }
+            match msg {
+                Message::DirectMessage { user, to, .. } => {
+                    is_host || user == &username || to == &username
+                }
+                _ => true,
+            }
+        })
+        .filter_map(|msg| serde_json::to_value(&msg).ok())
+        .collect();
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({ "messages": messages })),
+    )
+        .into_response()
+}
+
+async fn api_health(State(state): State<WsAppState>) -> impl IntoResponse {
+    let users = state.room_state.status_map.lock().await.len();
+    Json(serde_json::json!({
+        "status": "ok",
+        "room": *state.room_state.room_id,
+        "users": users
+    }))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,6 +105,10 @@ struct Args {
     #[arg(long)]
     agent: bool,
 
+    /// Enable WebSocket/REST transport on this port (e.g. --ws-port 4200)
+    #[arg(long)]
+    ws_port: Option<u16>,
+
     #[command(subcommand)]
     command: Option<Cmd>,
 }
@@ -165,6 +169,7 @@ async fn main() -> anyhow::Result<()> {
                 args.history_lines,
                 args.chat_file,
                 args.agent,
+                args.ws_port,
             )
             .await?;
         }
@@ -179,6 +184,7 @@ async fn run_join(
     history_lines: usize,
     chat_file: Option<PathBuf>,
     agent: bool,
+    ws_port: Option<u16>,
 ) -> anyhow::Result<()> {
     let socket_path = PathBuf::from(format!("/tmp/room-{}.sock", room_id));
     let meta_path = PathBuf::from(format!("/tmp/room-{}.meta", room_id));
@@ -208,7 +214,7 @@ async fn run_join(
             resolved_chat_path.display()
         );
 
-        let broker = Broker::new(&room_id, resolved_chat_path, socket_path.clone());
+        let broker = Broker::new(&room_id, resolved_chat_path, socket_path.clone(), ws_port);
 
         tokio::spawn(async move {
             if let Err(e) = broker.run().await {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4,6 +4,7 @@
 /// Unix-socket clients, and verifies behaviour at the wire level.
 use std::{path::PathBuf, time::Duration};
 
+use futures_util::{SinkExt, StreamExt};
 use room::{
     broker::Broker,
     history,
@@ -15,6 +16,7 @@ use tokio::{
     net::UnixStream,
     time::timeout,
 };
+use tokio_tungstenite::{connect_async, tungstenite::Message as TungsteniteMsg};
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -28,11 +30,39 @@ struct TestBroker {
 impl TestBroker {
     /// Start a broker and wait until the socket is ready.
     async fn start(room_id: &str) -> Self {
+        Self::start_inner(room_id, None).await
+    }
+
+    /// Start a broker with both UDS and WebSocket/REST transport.
+    /// Returns (TestBroker, ws_port).
+    async fn start_with_ws(room_id: &str) -> (Self, u16) {
+        // Bind to port 0 to get a free ephemeral port, then release it.
+        let tmp = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = tmp.local_addr().unwrap().port();
+        drop(tmp);
+
+        let broker = Self::start_inner(room_id, Some(port)).await;
+
+        // Wait for the HTTP server to be ready.
+        for _ in 0..100 {
+            if tokio::net::TcpStream::connect(("127.0.0.1", port))
+                .await
+                .is_ok()
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        (broker, port)
+    }
+
+    async fn start_inner(room_id: &str, ws_port: Option<u16>) -> Self {
         let dir = tempfile::tempdir().unwrap();
         let socket_path = dir.path().join(format!("{room_id}.sock"));
         let chat_path = dir.path().join(format!("{room_id}.chat"));
 
-        let broker = Broker::new(room_id, chat_path.clone(), socket_path.clone());
+        let broker = Broker::new(room_id, chat_path.clone(), socket_path.clone(), ws_port);
         tokio::spawn(async move {
             broker.run().await.ok();
         });
@@ -440,7 +470,7 @@ async fn pre_existing_history_is_replayed() {
         history::append(&chat_path, m).await.unwrap();
     }
 
-    let broker = Broker::new("pre", chat_path.clone(), socket_path.clone());
+    let broker = Broker::new("pre", chat_path.clone(), socket_path.clone(), None);
     tokio::spawn(async move { broker.run().await.ok() });
     for _ in 0..100 {
         if socket_path.exists() {
@@ -481,7 +511,7 @@ async fn stale_socket_is_cleaned_up() {
     assert!(socket_path.exists());
 
     // Broker should remove the stale file and bind
-    let broker = Broker::new("stale", chat_path, socket_path.clone());
+    let broker = Broker::new("stale", chat_path, socket_path.clone(), None);
     tokio::spawn(async move { broker.run().await.ok() });
 
     for _ in 0..100 {
@@ -1099,7 +1129,7 @@ async fn history_replay_filters_dm_for_non_party() {
     let dm = room::message::make_dm("replay_dm", "bob", "carol", "for bob and carol only");
     room::history::append(&chat_path, &dm).await.unwrap();
 
-    let broker = Broker::new("replay_dm", chat_path, socket_path.clone());
+    let broker = Broker::new("replay_dm", chat_path, socket_path.clone(), None);
     tokio::spawn(async move { broker.run().await.ok() });
     for _ in 0..100 {
         if socket_path.exists() {
@@ -2089,4 +2119,487 @@ async fn history_without_seq_parses_as_none() {
             "old messages without seq should deserialize to seq=None"
         );
     }
+}
+
+// ── WebSocket / REST integration tests ───────────────────────────────────────
+
+/// Helper: connect a WebSocket client and perform the username handshake.
+/// Returns the split (sink, stream) after sending the first frame.
+async fn ws_connect(
+    port: u16,
+    room_id: &str,
+    first_frame: &str,
+) -> (
+    futures_util::stream::SplitSink<
+        tokio_tungstenite::WebSocketStream<
+            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+        >,
+        TungsteniteMsg,
+    >,
+    futures_util::stream::SplitStream<
+        tokio_tungstenite::WebSocketStream<
+            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+        >,
+    >,
+) {
+    let url = format!("ws://127.0.0.1:{port}/ws/{room_id}");
+    let (ws, _) = connect_async(&url).await.expect("WS connect failed");
+    let (mut tx, rx) = ws.split();
+    tx.send(TungsteniteMsg::Text(first_frame.into()))
+        .await
+        .unwrap();
+    (tx, rx)
+}
+
+/// Read the next text frame as raw JSON Value.
+async fn ws_recv_json(
+    rx: &mut futures_util::stream::SplitStream<
+        tokio_tungstenite::WebSocketStream<
+            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+        >,
+    >,
+) -> serde_json::Value {
+    let deadline = Duration::from_secs(2);
+    match timeout(deadline, rx.next()).await {
+        Ok(Some(Ok(TungsteniteMsg::Text(text)))) => {
+            serde_json::from_str(&text).expect("WS broker sent invalid JSON value")
+        }
+        Ok(Some(Ok(other))) => panic!("unexpected WS frame: {other:?}"),
+        Ok(Some(Err(e))) => panic!("WS read error: {e}"),
+        Ok(None) => panic!("WS stream ended unexpectedly"),
+        Err(_) => panic!("timed out waiting for WS message"),
+    }
+}
+
+/// Drain WS frames until predicate matches a Message, or panic after 2s.
+async fn ws_recv_until<F: Fn(&Message) -> bool>(
+    rx: &mut futures_util::stream::SplitStream<
+        tokio_tungstenite::WebSocketStream<
+            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+        >,
+    >,
+    pred: F,
+) -> Message {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    loop {
+        let remaining = deadline
+            .checked_duration_since(tokio::time::Instant::now())
+            .unwrap_or_default();
+        if remaining.is_zero() {
+            panic!("timed out waiting for expected WS message");
+        }
+        match timeout(remaining, rx.next()).await {
+            Ok(Some(Ok(TungsteniteMsg::Text(text)))) => {
+                if let Ok(msg) = serde_json::from_str::<Message>(&text) {
+                    if pred(&msg) {
+                        return msg;
+                    }
+                }
+            }
+            Ok(Some(Ok(_))) => continue,
+            _ => panic!("WS stream ended or errored while waiting for message"),
+        }
+    }
+}
+
+// ── WS: interactive session ─────────────────────────────────────────────────
+
+#[tokio::test]
+async fn ws_interactive_join_and_message() {
+    let (tb, port) = TestBroker::start_with_ws("ws_join").await;
+    let _ = &tb.chat_path; // keep broker alive
+
+    let (mut tx, mut rx) = ws_connect(port, "ws_join", "alice").await;
+
+    // Should receive the join event for alice.
+    let join = ws_recv_until(
+        &mut rx,
+        |m| matches!(m, Message::Join { user, .. } if user == "alice"),
+    )
+    .await;
+    assert!(matches!(join, Message::Join { user, .. } if user == "alice"));
+
+    // Send a message.
+    tx.send(TungsteniteMsg::Text("hello from ws".into()))
+        .await
+        .unwrap();
+
+    // Should receive the broadcast back.
+    let msg = ws_recv_until(
+        &mut rx,
+        |m| matches!(m, Message::Message { content, .. } if content == "hello from ws"),
+    )
+    .await;
+    assert!(matches!(msg, Message::Message { content, .. } if content == "hello from ws"));
+
+    // Verify it was persisted.
+    let history = history::load(&tb.chat_path).await.unwrap();
+    assert!(
+        history
+            .iter()
+            .any(|m| matches!(m, Message::Message { content, .. } if content == "hello from ws")),
+        "WS message should be persisted to chat file"
+    );
+}
+
+#[tokio::test]
+async fn ws_oneshot_join_returns_token() {
+    let (_tb, port) = TestBroker::start_with_ws("ws_osjoin").await;
+
+    let (mut _tx, mut rx) = ws_connect(port, "ws_osjoin", "JOIN:bob").await;
+
+    let v = ws_recv_json(&mut rx).await;
+    assert_eq!(v["type"], "token");
+    assert_eq!(v["username"], "bob");
+    assert!(
+        v["token"].as_str().unwrap().len() > 10,
+        "token should be a UUID"
+    );
+}
+
+#[tokio::test]
+async fn ws_oneshot_join_duplicate_returns_error() {
+    let (_tb, port) = TestBroker::start_with_ws("ws_osjdup").await;
+
+    // First join succeeds.
+    let (_tx1, mut rx1) = ws_connect(port, "ws_osjdup", "JOIN:carol").await;
+    let v1 = ws_recv_json(&mut rx1).await;
+    assert_eq!(v1["type"], "token");
+
+    // Second join with same username fails.
+    let (_tx2, mut rx2) = ws_connect(port, "ws_osjdup", "JOIN:carol").await;
+    let v2 = ws_recv_json(&mut rx2).await;
+    assert_eq!(v2["type"], "error");
+    assert_eq!(v2["code"], "username_taken");
+}
+
+#[tokio::test]
+async fn ws_oneshot_send_with_token() {
+    let (tb, port) = TestBroker::start_with_ws("ws_ossend").await;
+
+    // First, get a token via JOIN.
+    let (_tx_j, mut rx_j) = ws_connect(port, "ws_ossend", "JOIN:dave").await;
+    let token_resp = ws_recv_json(&mut rx_j).await;
+    let token = token_resp["token"].as_str().unwrap();
+
+    // Use TOKEN: prefix to send a one-shot message.
+    let first_frame = format!("TOKEN:{token}");
+    let (mut tx_s, mut rx_s) = ws_connect(port, "ws_ossend", &first_frame).await;
+
+    // Send the actual message content as the second frame.
+    tx_s.send(TungsteniteMsg::Text("one-shot hello".into()))
+        .await
+        .unwrap();
+
+    // Should get the echo back.
+    let echo = ws_recv_json(&mut rx_s).await;
+    assert_eq!(echo["type"], "message");
+    assert_eq!(echo["content"], "one-shot hello");
+    assert_eq!(echo["user"], "dave");
+    assert!(
+        echo["seq"].as_u64().is_some(),
+        "echo should have a seq number"
+    );
+
+    // Verify persistence.
+    let history = history::load(&tb.chat_path).await.unwrap();
+    assert!(history
+        .iter()
+        .any(|m| matches!(m, Message::Message { content, .. } if content == "one-shot hello")));
+}
+
+#[tokio::test]
+async fn ws_invalid_token_returns_error() {
+    let (_tb, port) = TestBroker::start_with_ws("ws_badtok").await;
+
+    let (_tx, mut rx) = ws_connect(port, "ws_badtok", "TOKEN:not-a-real-token").await;
+
+    let v = ws_recv_json(&mut rx).await;
+    assert_eq!(v["type"], "error");
+    assert_eq!(v["code"], "invalid_token");
+}
+
+#[tokio::test]
+async fn ws_wrong_room_returns_not_found() {
+    let (_tb, port) = TestBroker::start_with_ws("ws_room404").await;
+
+    let url = format!("ws://127.0.0.1:{port}/ws/nonexistent");
+    // The server should reject the upgrade. connect_async may get an HTTP error.
+    let result = connect_async(&url).await;
+    assert!(result.is_err(), "connecting to wrong room should fail");
+}
+
+// ── WS ↔ UDS cross-transport ───────────────────────────────────────────────
+
+#[tokio::test]
+async fn cross_transport_uds_sees_ws_message() {
+    let (tb, port) = TestBroker::start_with_ws("ws_cross1").await;
+
+    // UDS client connects first.
+    let mut uds = TestClient::connect(&tb.socket_path, "uds_user").await;
+    // Drain the join event for uds_user.
+    uds.recv_until(|m| matches!(m, Message::Join { user, .. } if user == "uds_user"))
+        .await;
+
+    // WS client connects.
+    let (mut ws_tx, _ws_rx) = ws_connect(port, "ws_cross1", "ws_user").await;
+
+    // UDS client should see ws_user's join.
+    uds.recv_until(|m| matches!(m, Message::Join { user, .. } if user == "ws_user"))
+        .await;
+
+    // WS client sends a message.
+    ws_tx
+        .send(TungsteniteMsg::Text("from websocket".into()))
+        .await
+        .unwrap();
+
+    // UDS client should receive it.
+    let msg = uds
+        .recv_until(
+            |m| matches!(m, Message::Message { content, .. } if content == "from websocket"),
+        )
+        .await;
+    assert!(
+        matches!(msg, Message::Message { user, content, .. } if user == "ws_user" && content == "from websocket")
+    );
+}
+
+#[tokio::test]
+async fn cross_transport_ws_sees_uds_message() {
+    let (tb, port) = TestBroker::start_with_ws("ws_cross2").await;
+
+    // WS client connects first.
+    let (_ws_tx, mut ws_rx) = ws_connect(port, "ws_cross2", "ws_user2").await;
+
+    // Drain ws_user2's own join.
+    ws_recv_until(
+        &mut ws_rx,
+        |m| matches!(m, Message::Join { user, .. } if user == "ws_user2"),
+    )
+    .await;
+
+    // UDS client connects.
+    let mut uds = TestClient::connect(&tb.socket_path, "uds_user2").await;
+
+    // WS should see uds_user2's join.
+    ws_recv_until(
+        &mut ws_rx,
+        |m| matches!(m, Message::Join { user, .. } if user == "uds_user2"),
+    )
+    .await;
+
+    // UDS client sends a message.
+    uds.send_text("from unix socket").await;
+
+    // WS client should receive it.
+    let msg = ws_recv_until(
+        &mut ws_rx,
+        |m| matches!(m, Message::Message { content, .. } if content == "from unix socket"),
+    )
+    .await;
+    assert!(
+        matches!(msg, Message::Message { user, content, .. } if user == "uds_user2" && content == "from unix socket")
+    );
+}
+
+// ── REST API tests ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn rest_health_returns_ok() {
+    let (_tb, port) = TestBroker::start_with_ws("ws_health").await;
+
+    let resp = reqwest::get(format!("http://127.0.0.1:{port}/api/health"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["status"], "ok");
+    assert_eq!(body["room"], "ws_health");
+}
+
+#[tokio::test]
+async fn rest_join_send_poll_lifecycle() {
+    let (_tb, port) = TestBroker::start_with_ws("ws_rest").await;
+    let base = format!("http://127.0.0.1:{port}");
+    let client = reqwest::Client::new();
+
+    // JOIN via REST.
+    let join_resp = client
+        .post(format!("{base}/api/ws_rest/join"))
+        .json(&serde_json::json!({"username": "rest_user"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(join_resp.status(), 200);
+    let join_body: serde_json::Value = join_resp.json().await.unwrap();
+    assert_eq!(join_body["type"], "token");
+    let token = join_body["token"].as_str().unwrap();
+
+    // SEND via REST.
+    let send_resp = client
+        .post(format!("{base}/api/ws_rest/send"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!({"content": "hello from REST"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(send_resp.status(), 200);
+    let send_body: serde_json::Value = send_resp.json().await.unwrap();
+    assert_eq!(send_body["type"], "message");
+    assert_eq!(send_body["content"], "hello from REST");
+    assert_eq!(send_body["user"], "rest_user");
+    let msg_id = send_body["id"].as_str().unwrap().to_owned();
+
+    // POLL via REST — no since param, should get the message.
+    let poll_resp = client
+        .get(format!("{base}/api/ws_rest/poll"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(poll_resp.status(), 200);
+    let poll_body: serde_json::Value = poll_resp.json().await.unwrap();
+    let messages = poll_body["messages"].as_array().unwrap();
+    assert!(
+        messages.iter().any(|m| m["content"] == "hello from REST"),
+        "poll should contain the sent message"
+    );
+
+    // POLL with since= the message ID — should return empty.
+    let poll2_resp = client
+        .get(format!("{base}/api/ws_rest/poll?since={msg_id}"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .unwrap();
+    let poll2_body: serde_json::Value = poll2_resp.json().await.unwrap();
+    let messages2 = poll2_body["messages"].as_array().unwrap();
+    assert!(
+        messages2.is_empty(),
+        "poll with since=last_id should return no messages"
+    );
+}
+
+#[tokio::test]
+async fn rest_send_without_token_returns_401() {
+    let (_tb, port) = TestBroker::start_with_ws("ws_noauth").await;
+    let base = format!("http://127.0.0.1:{port}");
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(format!("{base}/api/ws_noauth/send"))
+        .json(&serde_json::json!({"content": "should fail"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 401);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["code"], "missing_token");
+}
+
+#[tokio::test]
+async fn rest_send_with_invalid_token_returns_401() {
+    let (_tb, port) = TestBroker::start_with_ws("ws_badauth").await;
+    let base = format!("http://127.0.0.1:{port}");
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(format!("{base}/api/ws_badauth/send"))
+        .header("Authorization", "Bearer fake-token-123")
+        .json(&serde_json::json!({"content": "should fail"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 401);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["code"], "invalid_token");
+}
+
+#[tokio::test]
+async fn rest_wrong_room_returns_404() {
+    let (_tb, port) = TestBroker::start_with_ws("ws_404room").await;
+    let base = format!("http://127.0.0.1:{port}");
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(format!("{base}/api/wrong_room/join"))
+        .json(&serde_json::json!({"username": "nobody"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["code"], "room_not_found");
+}
+
+#[tokio::test]
+async fn rest_duplicate_join_returns_409() {
+    let (_tb, port) = TestBroker::start_with_ws("ws_dupjoin").await;
+    let base = format!("http://127.0.0.1:{port}");
+    let client = reqwest::Client::new();
+
+    // First join succeeds.
+    let r1 = client
+        .post(format!("{base}/api/ws_dupjoin/join"))
+        .json(&serde_json::json!({"username": "dup_user"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r1.status(), 200);
+
+    // Second join with same name returns 409.
+    let r2 = client
+        .post(format!("{base}/api/ws_dupjoin/join"))
+        .json(&serde_json::json!({"username": "dup_user"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r2.status(), 409);
+    let body: serde_json::Value = r2.json().await.unwrap();
+    assert_eq!(body["code"], "username_taken");
+}
+
+#[tokio::test]
+async fn rest_send_dm_is_persisted() {
+    let (tb, port) = TestBroker::start_with_ws("ws_restdm").await;
+    let base = format!("http://127.0.0.1:{port}");
+    let client = reqwest::Client::new();
+
+    // Join sender.
+    let r1 = client
+        .post(format!("{base}/api/ws_restdm/join"))
+        .json(&serde_json::json!({"username": "sender"}))
+        .send()
+        .await
+        .unwrap();
+    let t1: serde_json::Value = r1.json().await.unwrap();
+    let token = t1["token"].as_str().unwrap();
+
+    // Join recipient (so the name is registered).
+    let _r2 = client
+        .post(format!("{base}/api/ws_restdm/join"))
+        .json(&serde_json::json!({"username": "recipient"}))
+        .send()
+        .await
+        .unwrap();
+
+    // Send DM.
+    let send_resp = client
+        .post(format!("{base}/api/ws_restdm/send"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!({"content": "secret DM", "to": "recipient"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(send_resp.status(), 200);
+    let send_body: serde_json::Value = send_resp.json().await.unwrap();
+    assert_eq!(send_body["type"], "dm");
+    assert_eq!(send_body["to"], "recipient");
+
+    // Verify persisted.
+    let history = history::load(&tb.chat_path).await.unwrap();
+    assert!(history
+        .iter()
+        .any(|m| matches!(m, Message::DirectMessage { content, to, .. } if content == "secret DM" && to == "recipient")));
 }


### PR DESCRIPTION
## Summary

- Add HTTP/WebSocket transport alongside existing Unix domain socket transport via `--ws-port <port>` flag
- WebSocket endpoint at `/ws/{room_id}` with identical handshake protocol (interactive, JOIN:, TOKEN:, SEND:)
- REST endpoints: `POST /api/{room_id}/join`, `POST /api/{room_id}/send`, `GET /api/{room_id}/poll`, `GET /api/health`
- Both transports share the same `RoomState`, broadcast channel, and command routing — zero changes to existing UDS code path
- 15 new integration tests covering WS sessions, one-shot ops, cross-transport UDS↔WS, REST lifecycle, auth errors, DM persistence

## Architecture

The parallel handler approach keeps existing UDS code completely untouched. A shared `Arc<AtomicU64>` client ID counter ensures unique IDs across both transports. `axum 0.8.8` provides WS + REST + middleware in one framework.

```
                    ┌─────────────────────┐
                    │     RoomState        │
                    │  (ClientMap, etc.)   │
                    └──────┬──────────────┘
                           │
              ┌────────────┴────────────┐
              │                         │
     ┌────────┴────────┐      ┌────────┴────────┐
     │   UDS listener  │      │  axum (HTTP/WS) │
     │  (unchanged)    │      │   --ws-port      │
     └─────────────────┘      └─────────────────┘
```

## Files changed

| File | Change |
|------|--------|
| `src/broker/ws.rs` | **NEW** — WS upgrade, interactive sessions, one-shot handlers, REST endpoints (~600 lines) |
| `src/broker/mod.rs` | Shared `AtomicU64` client ID, spawn WS server in `Broker::run()` |
| `src/main.rs` | `--ws-port` CLI flag, pass to `Broker::new()` |
| `Cargo.toml` | `axum`, `tower-http`, `futures-util`, `reqwest` (dev) |
| `tests/integration.rs` | 15 new tests, `TestBroker::start_with_ws()` helper |

## Test plan

- [x] All 195 unit tests pass
- [x] All 71 integration tests pass (56 existing + 15 new)
- [x] `cargo check && cargo fmt --check && cargo clippy -- -D warnings && cargo test`
- [x] WS interactive join + message broadcast
- [x] WS one-shot JOIN/TOKEN/SEND
- [x] WS invalid token / wrong room errors
- [x] Cross-transport: UDS client sees WS messages and vice versa
- [x] REST join → send → poll lifecycle with Bearer auth
- [x] REST 401 (missing/invalid token), 404 (wrong room), 409 (duplicate join)
- [x] REST DM persistence

Closes #154