### PR TITLE
fix(tui): scroll clamping uses layout-derived height (#150)

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -169,10 +169,16 @@ pub async fn run(
         }
 
         let content_width = term_area.width.saturating_sub(2) as usize;
-        let visible_count = term_area
-            .height
-            .saturating_sub(input_box_height)
-            .saturating_sub(2) as usize;
+        // Compute visible message lines by pre-computing the layout split.
+        // This must match the Layout used in the draw closure so scroll
+        // clamping and viewport computation use the same height.
+        let msg_area_height = {
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Min(3), Constraint::Length(input_box_height)])
+                .split(Rect::new(0, 0, term_area.width, term_area.height));
+            chunks[0].height.saturating_sub(2) as usize
+        };
 
         let msg_texts: Vec<Text<'static>> = messages
             .iter()
@@ -185,7 +191,7 @@ pub async fn run(
         // Clamp scroll offset so it can't exceed scrollable range
         state.scroll_offset = state
             .scroll_offset
-            .min(total_lines.saturating_sub(visible_count));
+            .min(total_lines.saturating_sub(msg_area_height));
 
         terminal.draw(|f| {
             let chunks = Layout::default()
@@ -193,11 +199,8 @@ pub async fn run(
                 .constraints([Constraint::Min(3), Constraint::Length(input_box_height)])
                 .split(f.area());
 
-            // actual visible rows from layout (overrides approximation)
-            let actual_visible = chunks[0].height.saturating_sub(2) as usize;
-
             let view_bottom = total_lines.saturating_sub(state.scroll_offset);
-            let view_top = view_bottom.saturating_sub(actual_visible);
+            let view_top = view_bottom.saturating_sub(msg_area_height);
 
             let (start_msg_idx, skip_first) = find_view_start(&heights, view_top);
 
@@ -358,7 +361,7 @@ pub async fn run(
                         key,
                         &mut state,
                         &online_users,
-                        visible_count,
+                        msg_area_height,
                         input_content_width,
                     ) {
                         Some(Action::Send(payload)) => {

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -541,4 +541,96 @@ mod tests {
         });
         assert_eq!(c, PALETTE[hash % PALETTE.len()]);
     }
+
+    // ── find_view_start tests ────────────────────────────────────────────────
+
+    #[test]
+    fn find_view_start_single_line_messages() {
+        // 5 messages, each 1 line tall
+        let heights = [1, 1, 1, 1, 1];
+        assert_eq!(find_view_start(&heights, 0), (0, 0));
+        assert_eq!(find_view_start(&heights, 2), (2, 0));
+        assert_eq!(find_view_start(&heights, 4), (4, 0));
+    }
+
+    #[test]
+    fn find_view_start_multi_line_message_partial() {
+        // msg0: 1 line, msg1: 5 lines, msg2: 1 line = 7 total
+        let heights = [1, 5, 1];
+        // view_top=0 → start at msg0, skip 0
+        assert_eq!(find_view_start(&heights, 0), (0, 0));
+        // view_top=1 → start at msg1 (line 1 is first line of msg1), skip 0
+        assert_eq!(find_view_start(&heights, 1), (1, 0));
+        // view_top=2 → start at msg1, skip 1 line (show lines 2-5 of msg1)
+        assert_eq!(find_view_start(&heights, 2), (1, 1));
+        // view_top=3 → start at msg1, skip 2 lines
+        assert_eq!(find_view_start(&heights, 3), (1, 2));
+        // view_top=5 → start at msg1, skip 4 lines (show only last line of msg1)
+        assert_eq!(find_view_start(&heights, 5), (1, 4));
+        // view_top=6 → start at msg2, skip 0
+        assert_eq!(find_view_start(&heights, 6), (2, 0));
+    }
+
+    #[test]
+    fn find_view_start_past_end_returns_len() {
+        let heights = [1, 2];
+        // view_top=3 is exactly total_lines → past end
+        assert_eq!(find_view_start(&heights, 3), (2, 0));
+        // view_top=10 → way past end
+        assert_eq!(find_view_start(&heights, 10), (2, 0));
+    }
+
+    #[test]
+    fn find_view_start_empty_heights() {
+        let heights: [usize; 0] = [];
+        assert_eq!(find_view_start(&heights, 0), (0, 0));
+    }
+
+    #[test]
+    fn find_view_start_scroll_through_tall_message_line_by_line() {
+        // Simulate scrolling through a 10-line message with a 3-line viewport
+        let heights = [2, 10, 2]; // total = 14
+        let viewport = 3;
+
+        // scroll_offset goes from 0 to total-viewport = 11
+        // For each offset, verify the view start advances line by line
+        let expected: Vec<(usize, usize)> = vec![
+            // scroll_offset=0: vb=14, vt=11 → msg1 skip 9 (last line of 10-line msg)
+            (1, 9),
+            // scroll_offset=1: vb=13, vt=10 → msg1 skip 8
+            (1, 8),
+            // scroll_offset=2: vb=12, vt=9 → msg1 skip 7
+            (1, 7),
+            // scroll_offset=3: vb=11, vt=8 → msg1 skip 6
+            (1, 6),
+            // scroll_offset=4: vb=10, vt=7 → msg1 skip 5
+            (1, 5),
+            // scroll_offset=5: vb=9, vt=6 → msg1 skip 4
+            (1, 4),
+            // scroll_offset=6: vb=8, vt=5 → msg1 skip 3
+            (1, 3),
+            // scroll_offset=7: vb=7, vt=4 → msg1 skip 2
+            (1, 2),
+            // scroll_offset=8: vb=6, vt=3 → msg1 skip 1
+            (1, 1),
+            // scroll_offset=9: vb=5, vt=2 → msg1 skip 0
+            (1, 0),
+            // scroll_offset=10: vb=4, vt=1 → msg0 skip 1
+            (0, 1),
+            // scroll_offset=11: vb=3, vt=0 → msg0 skip 0
+            (0, 0),
+        ];
+
+        let total_lines: usize = heights.iter().sum();
+        for (offset, &(exp_msg, exp_skip)) in expected.iter().enumerate() {
+            let view_bottom = total_lines.saturating_sub(offset);
+            let view_top = view_bottom.saturating_sub(viewport);
+            let result = find_view_start(&heights, view_top);
+            assert_eq!(
+                result,
+                (exp_msg, exp_skip),
+                "scroll_offset={offset}, view_top={view_top}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Fix scroll offset clamping to use the real layout-derived message area height instead of an approximation from terminal size
- When the approximate `visible_count` exceeded the actual visible area (due to layout rounding), the top lines of the conversation became permanently unreachable
- Add 5 tests for `find_view_start()` verifying line-by-line scroll math for multi-line messages

## Root cause
`visible_count` was computed as `terminal_height - input_height - 2` outside the draw closure. `actual_visible` was computed as `layout_chunk_height - 2` inside the draw closure. If they diverged (e.g., by 1-2 lines due to layout constraints), scroll_offset was under-clamped, making the top of the conversation inaccessible.

## Fix
Pre-compute the layout split outside the draw closure using the same constraints, so both the clamping and viewport use the identical height value.

## Test plan
- [x] 5 new tests for `find_view_start()` including line-by-line scroll simulation
- [x] All 256 tests pass (200 unit + 56 integration)
- [x] cargo check + fmt + clippy + test all green

Closes #150