### PR TITLE
fix(tui): palette filter ranking and picker reactivation on backspace

### DIFF
--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -170,31 +170,8 @@ pub(super) fn handle_key(
             if word_start < state.cursor_pos {
                 state.input.drain(word_start..state.cursor_pos);
                 state.cursor_pos = word_start;
-                // Sync mention/palette after deletion.
-                if state.mention.active {
-                    if let Some((at_byte, query)) = find_at_context(&state.input, state.cursor_pos)
-                    {
-                        state.mention.at_byte = at_byte;
-                        state.mention.update_filter(online_users, query);
-                        if state.mention.filtered.is_empty() {
-                            state.mention.deactivate();
-                        }
-                    } else {
-                        state.mention.deactivate();
-                    }
-                }
-                if state.palette.active {
-                    if state.input.is_empty() {
-                        state.palette.deactivate();
-                    } else if let Some(query) = state.input.strip_prefix('/') {
-                        state.palette.update_filter(query);
-                        if state.palette.filtered.is_empty() {
-                            state.palette.deactivate();
-                        }
-                    } else {
-                        state.palette.deactivate();
-                    }
-                }
+                sync_mention_after_delete(state, online_users);
+                sync_palette_after_delete(state);
             }
         }
         KeyCode::Char(c) => {
@@ -234,32 +211,8 @@ pub(super) fn handle_key(
                     .unwrap_or(0);
                 state.input.remove(prev);
                 state.cursor_pos = prev;
-                // Sync mention picker after deletion.
-                if state.mention.active {
-                    if let Some((at_byte, query)) = find_at_context(&state.input, state.cursor_pos)
-                    {
-                        state.mention.at_byte = at_byte;
-                        state.mention.update_filter(online_users, query);
-                        if state.mention.filtered.is_empty() {
-                            state.mention.deactivate();
-                        }
-                    } else {
-                        state.mention.deactivate();
-                    }
-                }
-                // Sync palette state after deletion.
-                if state.palette.active {
-                    if state.input.is_empty() {
-                        state.palette.deactivate();
-                    } else if let Some(query) = state.input.strip_prefix('/') {
-                        state.palette.update_filter(query);
-                        if state.palette.filtered.is_empty() {
-                            state.palette.deactivate();
-                        }
-                    } else {
-                        state.palette.deactivate();
-                    }
-                }
+                sync_mention_after_delete(state, online_users);
+                sync_palette_after_delete(state);
             }
         }
         KeyCode::Left if key.modifiers.contains(KeyModifiers::ALT) => {
@@ -456,6 +409,54 @@ fn sync_mention_after_cursor_move(state: &mut InputState, online_users: &[String
         }
     } else {
         state.mention.deactivate();
+    }
+}
+
+/// Re-evaluate the mention picker after a deletion (Backspace / Alt+Backspace).
+///
+/// If the picker is active, updates the filter or deactivates if the `@` context
+/// is gone. If the picker is inactive, reactivates it when the cursor is inside
+/// a valid `@` context with at least one match — this handles the case where the
+/// picker was auto-dismissed because all matches disappeared, and a subsequent
+/// deletion restores a matching prefix.
+fn sync_mention_after_delete(state: &mut InputState, online_users: &[String]) {
+    if let Some((at_byte, query)) = find_at_context(&state.input, state.cursor_pos) {
+        if state.mention.active {
+            state.mention.at_byte = at_byte;
+            state.mention.update_filter(online_users, query);
+            if state.mention.filtered.is_empty() {
+                state.mention.deactivate();
+            }
+        } else {
+            state.mention.activate(at_byte, online_users, query);
+            if state.mention.filtered.is_empty() {
+                state.mention.deactivate();
+            }
+        }
+    } else {
+        state.mention.deactivate();
+    }
+}
+
+/// Re-evaluate the command palette after a deletion (Backspace / Alt+Backspace).
+///
+/// If the palette is active, updates the filter or deactivates. If inactive,
+/// reactivates when input starts with `/` and the query matches at least one
+/// command — this handles the case where the palette was auto-dismissed and a
+/// backspace restores a matching query.
+fn sync_palette_after_delete(state: &mut InputState) {
+    if state.input.is_empty() {
+        state.palette.deactivate();
+    } else if let Some(query) = state.input.strip_prefix('/') {
+        state.palette.update_filter(query);
+        if state.palette.filtered.is_empty() {
+            state.palette.deactivate();
+        } else if !state.palette.active {
+            state.palette.active = true;
+            state.palette.selected = 0;
+        }
+    } else {
+        state.palette.deactivate();
     }
 }
 
@@ -1588,6 +1589,105 @@ mod tests {
         );
         // Cursor is now at the '@' position (byte 3). find_at_context with cursor
         // at '@' returns None (no query between '@' and cursor).
+        assert!(!state.mention.active);
+    }
+
+    // ── Palette reactivation on backspace (#172) ─────────────────────────────
+
+    #[test]
+    fn palette_reactivates_on_backspace_after_auto_dismiss() {
+        let mut state = InputState::new();
+        // Type "/he" — palette activates and filters.
+        for c in "/he".chars() {
+            handle_key(make_key(KeyCode::Char(c)), &mut state, &[], 10, 80);
+        }
+        assert!(state.palette.active);
+        // Type "zzz" — no matches, palette auto-dismisses.
+        for c in "zzz".chars() {
+            handle_key(make_key(KeyCode::Char(c)), &mut state, &[], 10, 80);
+        }
+        assert!(!state.palette.active);
+        assert_eq!(state.input, "/hezzz");
+        // Backspace 3 times to get back to "/he" — palette should reactivate.
+        for _ in 0..3 {
+            handle_key(make_key(KeyCode::Backspace), &mut state, &[], 10, 80);
+        }
+        assert_eq!(state.input, "/he");
+        assert!(
+            state.palette.active,
+            "palette should reactivate when backspace restores a matching query"
+        );
+        assert!(
+            !state.palette.filtered.is_empty(),
+            "palette should have matches for 'he'"
+        );
+    }
+
+    #[test]
+    fn palette_stays_dismissed_when_backspace_query_has_no_matches() {
+        let mut state = InputState::new();
+        // Type "/zzz" — no matches, palette dismissed.
+        for c in "/zzz".chars() {
+            handle_key(make_key(KeyCode::Char(c)), &mut state, &[], 10, 80);
+        }
+        assert!(!state.palette.active);
+        // Backspace to "/zz" — still no matches, stays dismissed.
+        handle_key(make_key(KeyCode::Backspace), &mut state, &[], 10, 80);
+        assert!(!state.palette.active);
+    }
+
+    #[test]
+    fn palette_deactivates_when_slash_is_deleted() {
+        let mut state = InputState::new();
+        // Type "/" — palette activates.
+        handle_key(make_key(KeyCode::Char('/')), &mut state, &[], 10, 80);
+        assert!(state.palette.active);
+        // Backspace removes "/" — palette deactivates.
+        handle_key(make_key(KeyCode::Backspace), &mut state, &[], 10, 80);
+        assert!(state.input.is_empty());
+        assert!(!state.palette.active);
+    }
+
+    // ── Mention picker reactivation on backspace (#172) ──────────────────────
+
+    #[test]
+    fn mention_picker_reactivates_on_backspace_after_auto_dismiss() {
+        let mut state = InputState::new();
+        let users = vec!["alice".to_owned()];
+        // Type "@ali" — picker activates, "alice" matches.
+        for c in "@ali".chars() {
+            handle_key(make_key(KeyCode::Char(c)), &mut state, &users, 10, 80);
+        }
+        assert!(state.mention.active);
+        // Type "zzz" — no matches, picker auto-dismisses.
+        for c in "zzz".chars() {
+            handle_key(make_key(KeyCode::Char(c)), &mut state, &users, 10, 80);
+        }
+        assert!(!state.mention.active);
+        assert_eq!(state.input, "@alizzz");
+        // Backspace 3 times to get back to "@ali" — picker should reactivate.
+        for _ in 0..3 {
+            handle_key(make_key(KeyCode::Backspace), &mut state, &users, 10, 80);
+        }
+        assert_eq!(state.input, "@ali");
+        assert!(
+            state.mention.active,
+            "mention picker should reactivate when backspace restores a matching query"
+        );
+        assert_eq!(state.mention.filtered, vec!["alice".to_owned()]);
+    }
+
+    #[test]
+    fn mention_picker_stays_dismissed_when_no_user_matches() {
+        let mut state = InputState::new();
+        let users = vec!["alice".to_owned()];
+        // Type "@zzz" — no matches, picker dismissed.
+        for c in "@zzz".chars() {
+            handle_key(make_key(KeyCode::Char(c)), &mut state, &users, 10, 80);
+        }
+        assert!(!state.mention.active);
+        // Backspace to "@zz" — still no user matches "zz".
+        handle_key(make_key(KeyCode::Backspace), &mut state, &users, 10, 80);
         assert!(!state.mention.active);
     }
 }

--- a/src/tui/widgets.rs
+++ b/src/tui/widgets.rs
@@ -101,18 +101,22 @@ impl CommandPalette {
     }
 
     /// Update the filtered list based on the query typed after the trigger character.
+    ///
+    /// Command-name prefix matches are ranked above description-only matches so
+    /// that e.g. `/help` appears before `/who` when the user types "he".
     pub(super) fn update_filter(&mut self, query: &str) {
         let q = query.to_ascii_lowercase();
-        self.filtered = self
-            .commands
-            .iter()
-            .enumerate()
-            .filter(|(_, item)| {
-                item.cmd.starts_with(q.as_str())
-                    || item.description.to_ascii_lowercase().contains(q.as_str())
-            })
-            .map(|(i, _)| i)
-            .collect();
+        let mut prefix_matches: Vec<usize> = Vec::new();
+        let mut desc_matches: Vec<usize> = Vec::new();
+        for (i, item) in self.commands.iter().enumerate() {
+            if item.cmd.starts_with(q.as_str()) {
+                prefix_matches.push(i);
+            } else if item.description.to_ascii_lowercase().contains(q.as_str()) {
+                desc_matches.push(i);
+            }
+        }
+        prefix_matches.extend(desc_matches);
+        self.filtered = prefix_matches;
         if self.selected >= self.filtered.len() {
             self.selected = self.filtered.len().saturating_sub(1);
         }
@@ -399,6 +403,70 @@ mod tests {
         // All commands use / prefix
         let usage = p.selected_usage().unwrap();
         assert!(usage.starts_with('/'));
+    }
+
+    // ── Filter ranking tests (#172) ────────────────────────────────────────────
+
+    #[test]
+    fn palette_filter_ranks_prefix_before_description() {
+        // "se" matches "set_status" by cmd prefix AND "dm" by description ("Send a private message").
+        // Prefix matches must appear first in the filtered list.
+        let mut p = CommandPalette::new(PALETTE_COMMANDS);
+        p.update_filter("se");
+        assert!(
+            p.filtered.len() >= 2,
+            "expected at least 2 matches for 'se', got {}",
+            p.filtered.len()
+        );
+        // First match must be the cmd-prefix match (set_status).
+        let first_cmd = p.commands[p.filtered[0]].cmd;
+        assert_eq!(
+            first_cmd, "set_status",
+            "first match should be 'set_status' (prefix), not '{}'",
+            first_cmd
+        );
+        // Description-only matches (like "dm" whose description starts with "Send") come after.
+        let prefix_count = p
+            .filtered
+            .iter()
+            .filter(|&&i| p.commands[i].cmd.starts_with("se"))
+            .count();
+        for (pos, &i) in p.filtered.iter().enumerate() {
+            if !p.commands[i].cmd.starts_with("se") {
+                assert!(
+                    pos >= prefix_count,
+                    "description-only match '{}' at position {} should come after {} prefix matches",
+                    p.commands[i].cmd,
+                    pos,
+                    prefix_count
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn palette_filter_description_match_appears_after_all_prefix_matches() {
+        // "re" matches "reply" and "reauth" by prefix. It also matches "set_status" by description
+        // ("Set your presence status"). Prefix matches must come first.
+        let mut p = CommandPalette::new(PALETTE_COMMANDS);
+        p.update_filter("re");
+        let prefix_count = p
+            .filtered
+            .iter()
+            .filter(|&&i| p.commands[i].cmd.starts_with("re"))
+            .count();
+        assert!(prefix_count >= 2, "expected at least reply + reauth");
+        for (pos, &i) in p.filtered.iter().enumerate() {
+            if !p.commands[i].cmd.starts_with("re") {
+                assert!(
+                    pos >= prefix_count,
+                    "description-only match '{}' at position {} should come after {} prefix matches",
+                    p.commands[i].cmd,
+                    pos,
+                    prefix_count
+                );
+            }
+        }
     }
 
     // ── MentionPicker tests ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Filter ranking**: `update_filter` now places command-name prefix matches before description-only matches. Previously typing "he" showed `/who` first (matched "the" in description) before `/help` (prefix match). Now prefix matches always rank first.
- **Picker reactivation on backspace**: When the command palette or mention picker was auto-dismissed (zero filter matches), pressing backspace to shorten the query now reactivates the popup if the shorter query produces matches. Previously the popup stayed dead until the user deleted back to `/` or `@` and started over.
- Extracted `sync_mention_after_delete` and `sync_palette_after_delete` helpers to consolidate deletion sync logic (used by Backspace handler).

## Files modified

- `src/tui/widgets.rs` — `update_filter` ranking logic
- `src/tui/input.rs` — Backspace handler refactored to use new sync helpers with reactivation

## Test plan

- [x] 7 new unit tests covering ranking and reactivation scenarios
- [x] All 258 tests pass (202 unit + 56 integration)
- [x] `cargo check && cargo fmt && cargo clippy -- -D warnings && cargo test` all clean

Closes #172