### PR TITLE
fix(tui): normalize paste line endings and exit cleanly on Ctrl-C

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -239,11 +239,14 @@ async fn run_join(
         };
         client.run().await?;
 
-        // The local client has disconnected, but the broker should keep serving
-        // other clients until a signal arrives.  Without this, the tokio runtime
-        // shuts down immediately and cancels any in-flight spawn_blocking tasks
-        // (e.g. file writes).
-        tokio::signal::ctrl_c().await.ok();
+        if agent {
+            // In agent mode the broker should keep serving other clients until
+            // a signal arrives.  Without this, the tokio runtime shuts down
+            // immediately and cancels any in-flight spawn_blocking tasks.
+            tokio::signal::ctrl_c().await.ok();
+        }
+        // In TUI mode the user already pressed Ctrl-C to quit — exit
+        // immediately so the shell prompt returns without a second keypress.
     } else {
         eprintln!("[room] connecting to existing room '{room_id}'");
         let client = Client {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -378,8 +378,10 @@ pub async fn run(
                     }
                 }
                 Event::Paste(text) => {
-                    state.input.insert_str(state.cursor_pos, &text);
-                    state.cursor_pos += text.len();
+                    // Normalize line endings: \r\n → \n, stray \r → \n.
+                    let clean = text.replace("\r\n", "\n").replace('\r', "\n");
+                    state.input.insert_str(state.cursor_pos, &clean);
+                    state.cursor_pos += clean.len();
                     state.mention.active = false;
                 }
                 Event::Resize(_, _) => {}


### PR DESCRIPTION
## Summary
- Normalize \r\n to \n and stray \r to \n in bracketed paste content to prevent display artifacts from Windows-style line endings
- Only block on tokio::signal::ctrl_c() in agent mode; TUI mode exits immediately after Ctrl-C (first press consumed by crossterm as a key event)

Closes #170, closes #171

## Test plan
- [x] cargo check/fmt/clippy/test — 320 tests pass
- [ ] Manual: paste multiline text with CRLF line endings into TUI input
- [ ] Manual: Ctrl-C exits TUI and returns shell prompt on first press