### PR TITLE
feat(scripts): context monitoring for ralph-room wrapper

### DIFF
--- a/scripts/context-monitor.sh
+++ b/scripts/context-monitor.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# context-monitor.sh — Token usage monitoring for ralph-room.sh
+#
+# Source this file in ralph-room.sh to get context monitoring functions.
+# Parses --output-format json output from claude -p and detects when
+# the session is approaching the model's context window limit.
+#
+# Usage:
+#   source scripts/context-monitor.sh
+#
+#   output=$(claude -p --output-format json "$prompt")
+#   tokens=$(parse_usage "$output")
+#   if should_restart "$tokens"; then
+#     log_usage "$tokens" "$progress_file"
+#     # restart with fresh context
+#   fi
+#
+# Environment variables:
+#   CONTEXT_LIMIT       — model context window size (default: 200000)
+#   CONTEXT_THRESHOLD   — restart threshold as percentage (default: 80)
+#   CONTEXT_LOG_FILE    — optional separate log file for usage history
+#
+# Dependencies: jq
+
+# Default model context limits (tokens).
+# Override with CONTEXT_LIMIT env var for custom models.
+readonly DEFAULT_CONTEXT_LIMIT=200000
+readonly DEFAULT_CONTEXT_THRESHOLD=80
+
+# ── Public API ──────────────────────────────────────────────────────
+
+# parse_usage <json_output>
+#
+# Extract input_tokens from claude -p --output-format json output.
+# Tries multiple JSON paths to handle format variations:
+#   .usage.input_tokens
+#   .result.usage.input_tokens
+#   .statistics.input_tokens
+#
+# Prints the token count to stdout. Prints 0 if not found.
+parse_usage() {
+  local json="$1"
+  if [ -z "$json" ]; then
+    printf '0'
+    return 0
+  fi
+
+  local tokens
+  tokens=$(printf '%s' "$json" | jq -r '
+    if .usage.input_tokens? then .usage.input_tokens
+    elif (.result | type) == "object" and .result.usage.input_tokens? then .result.usage.input_tokens
+    elif .statistics.input_tokens? then .statistics.input_tokens
+    else 0 end
+  ' 2>/dev/null)
+
+  if [ -z "$tokens" ] || [ "$tokens" = "null" ]; then
+    tokens=0
+  fi
+
+  printf '%s' "$tokens"
+}
+
+# parse_output_tokens <json_output>
+#
+# Extract output_tokens from claude -p --output-format json output.
+# Same path-probing strategy as parse_usage.
+parse_output_tokens() {
+  local json="$1"
+  if [ -z "$json" ]; then
+    printf '0'
+    return 0
+  fi
+
+  local tokens
+  tokens=$(printf '%s' "$json" | jq -r '
+    if .usage.output_tokens? then .usage.output_tokens
+    elif (.result | type) == "object" and .result.usage.output_tokens? then .result.usage.output_tokens
+    elif .statistics.output_tokens? then .statistics.output_tokens
+    else 0 end
+  ' 2>/dev/null)
+
+  if [ -z "$tokens" ] || [ "$tokens" = "null" ]; then
+    tokens=0
+  fi
+
+  printf '%s' "$tokens"
+}
+
+# parse_cost <json_output>
+#
+# Extract total cost (USD) if present. Returns "0" if not found.
+parse_cost() {
+  local json="$1"
+  if [ -z "$json" ]; then
+    printf '0'
+    return 0
+  fi
+
+  local cost
+  cost=$(printf '%s' "$json" | jq -r '
+    if .usage.total_cost? then .usage.total_cost
+    elif (.result | type) == "object" and .result.usage.total_cost? then .result.usage.total_cost
+    elif .cost_usd? then .cost_usd
+    elif .total_cost? then .total_cost
+    else 0 end
+  ' 2>/dev/null)
+
+  if [ -z "$cost" ] || [ "$cost" = "null" ]; then
+    cost=0
+  fi
+
+  printf '%s' "$cost"
+}
+
+# get_context_limit
+#
+# Return the effective context window size.
+# Uses CONTEXT_LIMIT env var if set, otherwise DEFAULT_CONTEXT_LIMIT.
+get_context_limit() {
+  printf '%s' "${CONTEXT_LIMIT:-$DEFAULT_CONTEXT_LIMIT}"
+}
+
+# get_threshold_tokens
+#
+# Return the token count at which a restart should be triggered.
+# Computed as (limit * threshold_pct / 100).
+get_threshold_tokens() {
+  local limit="${CONTEXT_LIMIT:-$DEFAULT_CONTEXT_LIMIT}"
+  local pct="${CONTEXT_THRESHOLD:-$DEFAULT_CONTEXT_THRESHOLD}"
+  printf '%s' $(( limit * pct / 100 ))
+}
+
+# should_restart <input_tokens>
+#
+# Returns 0 (true) if input_tokens >= threshold, 1 (false) otherwise.
+# Use in conditionals: if should_restart "$tokens"; then ...
+should_restart() {
+  local tokens="${1:-0}"
+  local threshold
+  threshold=$(get_threshold_tokens)
+
+  if [ "$tokens" -ge "$threshold" ] 2>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
+# context_usage_pct <input_tokens>
+#
+# Print the percentage of context window used (integer).
+context_usage_pct() {
+  local tokens="${1:-0}"
+  local limit
+  limit=$(get_context_limit)
+
+  if [ "$limit" -eq 0 ] 2>/dev/null; then
+    printf '0'
+    return 0
+  fi
+
+  printf '%s' $(( tokens * 100 / limit ))
+}
+
+# log_usage <input_tokens> <progress_file> [output_tokens] [iteration]
+#
+# Append a usage entry to the progress file's Context Usage section.
+# Creates the section if it doesn't exist.
+log_usage() {
+  local input_tokens="${1:-0}"
+  local progress_file="$2"
+  local output_tokens="${3:-0}"
+  local iteration="${4:-}"
+
+  if [ -z "$progress_file" ]; then
+    return 1
+  fi
+
+  local pct
+  pct=$(context_usage_pct "$input_tokens")
+  local threshold
+  threshold=$(get_threshold_tokens)
+  local limit
+  limit=$(get_context_limit)
+  local ts
+  ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+
+  local iter_str=""
+  if [ -n "$iteration" ]; then
+    iter_str=" iter=$iteration"
+  fi
+
+  local restart_note=""
+  if should_restart "$input_tokens"; then
+    restart_note=" **RESTART TRIGGERED**"
+  fi
+
+  local entry="- ${ts}:${iter_str} input=${input_tokens}/${limit} (${pct}%) output=${output_tokens} threshold=${threshold}${restart_note}"
+
+  # Append to Context Usage section, creating it if needed
+  if [ -f "$progress_file" ] && grep -q '## Context Usage' "$progress_file" 2>/dev/null; then
+    printf '%s\n' "$entry" >> "$progress_file"
+  else
+    printf '\n## Context Usage\n%s\n' "$entry" >> "$progress_file"
+  fi
+
+  # Also log to separate file if configured
+  if [ -n "${CONTEXT_LOG_FILE:-}" ]; then
+    printf '%s\n' "$entry" >> "$CONTEXT_LOG_FILE"
+  fi
+}
+
+# format_usage_summary <input_tokens> [output_tokens]
+#
+# Print a human-readable one-line usage summary to stdout.
+format_usage_summary() {
+  local input_tokens="${1:-0}"
+  local output_tokens="${2:-0}"
+  local pct
+  pct=$(context_usage_pct "$input_tokens")
+  local limit
+  limit=$(get_context_limit)
+  local threshold
+  threshold=$(get_threshold_tokens)
+
+  printf 'context: %s/%s (%s%%) threshold: %s' \
+    "$input_tokens" "$limit" "$pct" "$threshold"
+
+  if should_restart "$input_tokens"; then
+    printf ' [RESTART]'
+  fi
+  printf '\n'
+}

--- a/scripts/test-context-monitor.sh
+++ b/scripts/test-context-monitor.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# test-context-monitor.sh — Tests for context-monitor.sh functions
+#
+# Run: bash scripts/test-context-monitor.sh
+# All tests use mock JSON data — no live claude CLI required.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=context-monitor.sh
+source "$SCRIPT_DIR/context-monitor.sh"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  TOTAL=$((TOTAL + 1))
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    printf 'FAIL: %s — expected "%s", got "%s"\n' "$label" "$expected" "$actual" >&2
+  fi
+}
+
+assert_exit() {
+  local label="$1" expected_exit="$2"
+  shift 2
+  TOTAL=$((TOTAL + 1))
+  local actual_exit=0
+  "$@" || actual_exit=$?
+  if [ "$expected_exit" -eq "$actual_exit" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    printf 'FAIL: %s — expected exit %d, got %d\n' "$label" "$expected_exit" "$actual_exit" >&2
+  fi
+}
+
+# ── Mock JSON payloads ──────────────────────────────────────────────
+
+# Format 1: usage at top level
+JSON_TOP='{"result":"hello","usage":{"input_tokens":150000,"output_tokens":2000}}'
+
+# Format 2: usage nested under result
+JSON_NESTED='{"result":{"content":"hello","usage":{"input_tokens":95000,"output_tokens":1500}}}'
+
+# Format 3: usage under statistics
+JSON_STATS='{"result":"hello","statistics":{"input_tokens":180000,"output_tokens":3000}}'
+
+# Format 4: no usage info at all
+JSON_NONE='{"result":"hello"}'
+
+# Format 5: usage with cost
+JSON_COST='{"result":"hello","usage":{"input_tokens":100000,"output_tokens":2000,"total_cost":0.42}}'
+
+# ── parse_usage tests ──────────────────────────────────────────────
+
+assert_eq "parse_usage: top-level usage" \
+  "150000" "$(parse_usage "$JSON_TOP")"
+
+assert_eq "parse_usage: nested usage" \
+  "95000" "$(parse_usage "$JSON_NESTED")"
+
+assert_eq "parse_usage: statistics path" \
+  "180000" "$(parse_usage "$JSON_STATS")"
+
+assert_eq "parse_usage: no usage returns 0" \
+  "0" "$(parse_usage "$JSON_NONE")"
+
+assert_eq "parse_usage: empty string returns 0" \
+  "0" "$(parse_usage "")"
+
+# ── parse_output_tokens tests ──────────────────────────────────────
+
+assert_eq "parse_output_tokens: top-level" \
+  "2000" "$(parse_output_tokens "$JSON_TOP")"
+
+assert_eq "parse_output_tokens: nested" \
+  "1500" "$(parse_output_tokens "$JSON_NESTED")"
+
+assert_eq "parse_output_tokens: none returns 0" \
+  "0" "$(parse_output_tokens "$JSON_NONE")"
+
+# ── parse_cost tests ───────────────────────────────────────────────
+
+assert_eq "parse_cost: with cost" \
+  "0.42" "$(parse_cost "$JSON_COST")"
+
+assert_eq "parse_cost: without cost" \
+  "0" "$(parse_cost "$JSON_TOP")"
+
+# ── get_context_limit tests ────────────────────────────────────────
+
+unset CONTEXT_LIMIT 2>/dev/null || true
+assert_eq "get_context_limit: default" \
+  "200000" "$(get_context_limit)"
+
+CONTEXT_LIMIT=128000
+assert_eq "get_context_limit: custom" \
+  "128000" "$(get_context_limit)"
+unset CONTEXT_LIMIT
+
+# ── get_threshold_tokens tests ─────────────────────────────────────
+
+unset CONTEXT_LIMIT CONTEXT_THRESHOLD 2>/dev/null || true
+assert_eq "get_threshold_tokens: default (200K * 80%)" \
+  "160000" "$(get_threshold_tokens)"
+
+CONTEXT_LIMIT=100000
+assert_eq "get_threshold_tokens: custom limit (100K * 80%)" \
+  "80000" "$(get_threshold_tokens)"
+
+CONTEXT_THRESHOLD=90
+assert_eq "get_threshold_tokens: custom threshold (100K * 90%)" \
+  "90000" "$(get_threshold_tokens)"
+unset CONTEXT_LIMIT CONTEXT_THRESHOLD
+
+# ── should_restart tests ───────────────────────────────────────────
+
+unset CONTEXT_LIMIT CONTEXT_THRESHOLD 2>/dev/null || true
+
+assert_exit "should_restart: under threshold (100K < 160K)" \
+  1 should_restart 100000
+
+assert_exit "should_restart: at threshold (160K = 160K)" \
+  0 should_restart 160000
+
+assert_exit "should_restart: over threshold (180K > 160K)" \
+  0 should_restart 180000
+
+assert_exit "should_restart: zero tokens" \
+  1 should_restart 0
+
+assert_exit "should_restart: empty defaults to 0" \
+  1 should_restart ""
+
+# Custom threshold
+CONTEXT_LIMIT=100000
+CONTEXT_THRESHOLD=50
+assert_exit "should_restart: custom 50K threshold, 60K tokens" \
+  0 should_restart 60000
+
+assert_exit "should_restart: custom 50K threshold, 40K tokens" \
+  1 should_restart 40000
+unset CONTEXT_LIMIT CONTEXT_THRESHOLD
+
+# ── context_usage_pct tests ────────────────────────────────────────
+
+unset CONTEXT_LIMIT 2>/dev/null || true
+assert_eq "context_usage_pct: 50%" \
+  "50" "$(context_usage_pct 100000)"
+
+assert_eq "context_usage_pct: 75%" \
+  "75" "$(context_usage_pct 150000)"
+
+assert_eq "context_usage_pct: 100%" \
+  "100" "$(context_usage_pct 200000)"
+
+assert_eq "context_usage_pct: 0 tokens" \
+  "0" "$(context_usage_pct 0)"
+
+CONTEXT_LIMIT=100000
+assert_eq "context_usage_pct: custom limit 60%" \
+  "60" "$(context_usage_pct 60000)"
+unset CONTEXT_LIMIT
+
+# ── log_usage tests ────────────────────────────────────────────────
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+# Test: creates Context Usage section in new file
+progress="$tmpdir/progress.md"
+log_usage 150000 "$progress" 2000 3
+assert_eq "log_usage: creates file" "0" "$([ -f "$progress" ] && printf '0' || printf '1')"
+
+content=$(cat "$progress")
+assert_eq "log_usage: has Context Usage header" \
+  "1" "$(printf '%s' "$content" | grep -c '## Context Usage' | tr -d ' ')"
+
+assert_eq "log_usage: has input tokens" \
+  "1" "$(printf '%s' "$content" | grep -c 'input=150000' | tr -d ' ')"
+
+assert_eq "log_usage: has output tokens" \
+  "1" "$(printf '%s' "$content" | grep -c 'output=2000' | tr -d ' ')"
+
+assert_eq "log_usage: has iteration" \
+  "1" "$(printf '%s' "$content" | grep -c 'iter=3' | tr -d ' ')"
+
+# Test: appends to existing section
+log_usage 170000 "$progress" 2500 4
+line_count=$(grep -c 'input=' "$progress" | tr -d ' ')
+assert_eq "log_usage: appends second entry" \
+  "2" "$line_count"
+
+# Test: restart annotation
+unset CONTEXT_LIMIT CONTEXT_THRESHOLD 2>/dev/null || true
+restart_progress="$tmpdir/restart.md"
+log_usage 180000 "$restart_progress" 3000 5
+assert_eq "log_usage: restart annotation at 180K" \
+  "1" "$(grep -c 'RESTART TRIGGERED' "$restart_progress" | tr -d ' ')"
+
+# Test: no file returns error
+assert_exit "log_usage: empty path returns 1" \
+  1 log_usage 1000 ""
+
+# Test: CONTEXT_LOG_FILE
+log_file="$tmpdir/usage.log"
+CONTEXT_LOG_FILE="$log_file"
+log_progress="$tmpdir/log-test.md"
+log_usage 120000 "$log_progress" 1000
+assert_eq "log_usage: writes to CONTEXT_LOG_FILE" \
+  "0" "$([ -f "$log_file" ] && printf '0' || printf '1')"
+assert_eq "log_usage: log file has entry" \
+  "1" "$(grep -c 'input=120000' "$log_file" | tr -d ' ')"
+unset CONTEXT_LOG_FILE
+
+# ── format_usage_summary tests ─────────────────────────────────────
+
+unset CONTEXT_LIMIT CONTEXT_THRESHOLD 2>/dev/null || true
+summary=$(format_usage_summary 100000 2000)
+assert_eq "format_usage_summary: contains tokens" \
+  "1" "$(printf '%s' "$summary" | grep -c '100000/200000' | tr -d ' ')"
+
+assert_eq "format_usage_summary: contains percentage" \
+  "1" "$(printf '%s' "$summary" | grep -c '50%' | tr -d ' ')"
+
+assert_eq "format_usage_summary: no restart marker under threshold" \
+  "0" "$(printf '%s' "$summary" | grep -c 'RESTART' | tr -d ' ')"
+
+restart_summary=$(format_usage_summary 180000 3000)
+assert_eq "format_usage_summary: restart marker over threshold" \
+  "1" "$(printf '%s' "$restart_summary" | grep -c 'RESTART' | tr -d ' ')"
+
+# ── Results ─────────────────────────────────────────────────────────
+
+printf '\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
+printf 'context-monitor tests: %d passed, %d failed, %d total\n' "$PASS" "$FAIL" "$TOTAL"
+printf '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Shell function library (`scripts/context-monitor.sh`) for parsing `claude -p --output-format json` output and detecting context window exhaustion
- Provides `parse_usage`, `should_restart`, `log_usage`, `format_usage_summary` and related helpers
- Designed to be sourced by `ralph-room.sh` (Track 2A, #186) for auto-restart on context death
- 41 shell tests with mock JSON data covering all functions and edge cases

## Integration
Source from ralph-room.sh:
```bash
source scripts/context-monitor.sh
output=$(claude -p --output-format json "$prompt")
tokens=$(parse_usage "$output")
if should_restart "$tokens"; then
  log_usage "$tokens" "$progress_file"
  # restart with fresh context
fi
```

## Test plan
- [x] 41 shell tests pass (`bash scripts/test-context-monitor.sh`)
- [x] 327 Rust tests pass (no regressions)
- [x] All pre-push checks green (check/fmt/clippy/test)
- [ ] Integration test with live `claude -p --output-format json` (needs manual verification outside Claude)

Closes #188
