### PR TITLE
fix(ci): trigger CI on master branch pushes, not main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary
- Fix ci.yml to trigger on `master` branch pushes instead of `main`
- Our default branch is `master`, but CI was configured for `main` — meaning post-merge CI verification was silently skipped on all direct master pushes

## Test plan
- [x] Verify ci.yml has `branches: [master]`
- [ ] After merge, push to master and confirm CI triggers

Closes #195