### PR TITLE
feat(ci): add shell test and shellcheck job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,17 @@ jobs:
         run: cargo clippy -- -D warnings
       - name: Tests
         run: cargo test
+
+  scripts:
+    name: Shell Scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install shellcheck
+        run: sudo apt-get install -y shellcheck
+      - name: Shellcheck
+        run: shellcheck --exclude=SC1091 scripts/*.sh
+      - name: Shell tests
+        run: |
+          bash scripts/test-context-monitor.sh
+          bash scripts/test-ralph-room.sh

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -44,4 +44,4 @@ step "cargo test"
 cargo test 2>&1 || fail "cargo test"
 pass "cargo test"
 
-printf "\n${GREEN}${BOLD}[pre-push] All checks passed.${RESET}\n"
+printf '\n%s%s[pre-push] All checks passed.%s\n' "$GREEN" "$BOLD" "$RESET"

--- a/scripts/test-context-monitor.sh
+++ b/scripts/test-context-monitor.sh
@@ -137,8 +137,8 @@ assert_exit "should_restart: empty defaults to 0" \
   1 should_restart ""
 
 # Custom threshold
-CONTEXT_LIMIT=100000
-CONTEXT_THRESHOLD=50
+export CONTEXT_LIMIT=100000
+export CONTEXT_THRESHOLD=50
 assert_exit "should_restart: custom 50K threshold, 60K tokens" \
   0 should_restart 60000
 
@@ -161,7 +161,7 @@ assert_eq "context_usage_pct: 100%" \
 assert_eq "context_usage_pct: 0 tokens" \
   "0" "$(context_usage_pct 0)"
 
-CONTEXT_LIMIT=100000
+export CONTEXT_LIMIT=100000
 assert_eq "context_usage_pct: custom limit 60%" \
   "60" "$(context_usage_pct 60000)"
 unset CONTEXT_LIMIT
@@ -208,7 +208,7 @@ assert_exit "log_usage: empty path returns 1" \
 
 # Test: CONTEXT_LOG_FILE
 log_file="$tmpdir/usage.log"
-CONTEXT_LOG_FILE="$log_file"
+export CONTEXT_LOG_FILE="$log_file"
 log_progress="$tmpdir/log-test.md"
 log_usage 120000 "$log_progress" 1000
 assert_eq "log_usage: writes to CONTEXT_LOG_FILE" \


### PR DESCRIPTION
## Summary
- Add new `scripts` CI job that runs shellcheck and shell test suites on every push/PR
- Fix shellcheck warnings in pre-push.sh (SC2059: printf format string) and test-context-monitor.sh (SC2034: export env vars for sourced functions)
- SC1091 excluded globally (dynamic source paths can't be resolved at static analysis time)

## Changes
- `.github/workflows/ci.yml`: new `scripts` job with shellcheck + test execution
- `scripts/pre-push.sh`: fix printf format string (SC2059)
- `scripts/test-context-monitor.sh`: export CONTEXT_THRESHOLD, CONTEXT_LIMIT, CONTEXT_LOG_FILE (SC2034)

## Test plan
- [x] shellcheck passes locally with `--exclude=SC1091`
- [x] 41 context-monitor tests pass
- [x] 46 ralph-room tests pass
- [x] 327 Rust tests pass (no regressions)

Closes #196