### PR TITLE
ci(release): multi-binary workspace builds (#201)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,15 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
             artifact: room-macos-arm64
+            suffix: macos-arm64
           - os: macos-latest
             target: x86_64-apple-darwin
             artifact: room-macos-x86_64
+            suffix: macos-x86_64
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             artifact: room-linux-x86_64
+            suffix: linux-x86_64
 
     steps:
       - uses: actions/checkout@v4
@@ -38,13 +41,17 @@ jobs:
         with:
           key: ${{ matrix.target }}
       - name: Build
-        run: cargo build --release --target ${{ matrix.target }}
-      - name: Stage artifact
-        run: cp target/${{ matrix.target }}/release/room ${{ matrix.artifact }}
+        run: cargo build --release --workspace --target ${{ matrix.target }}
+      - name: Stage artifacts
+        run: |
+          cp target/${{ matrix.target }}/release/room ${{ matrix.artifact }}
+          cp target/${{ matrix.target }}/release/room-ralph room-ralph-${{ matrix.suffix }}
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}
-          path: ${{ matrix.artifact }}
+          path: |
+            ${{ matrix.artifact }}
+            room-ralph-${{ matrix.suffix }}
 
   release:
     name: Publish release
@@ -69,6 +76,9 @@ jobs:
             artifacts/room-macos-arm64
             artifacts/room-macos-x86_64
             artifacts/room-linux-x86_64
+            artifacts/room-ralph-macos-arm64
+            artifacts/room-ralph-macos-x86_64
+            artifacts/room-ralph-linux-x86_64
             artifacts/SHA256SUMS
           generate_release_notes: true
 
@@ -82,5 +92,13 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Publish
-        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --allow-dirty
+      - name: Publish room-protocol
+        run: cargo publish -p room-protocol --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --allow-dirty
+      - name: Wait for crates.io index
+        run: sleep 30
+      - name: Publish room-cli
+        run: cargo publish -p room-cli --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --allow-dirty
+      - name: Wait for crates.io index
+        run: sleep 30
+      - name: Publish room-ralph
+        run: cargo publish -p room-ralph --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --allow-dirty


### PR DESCRIPTION
## Summary

- Updates release.yml to build and release both `room` and `room-ralph` binaries for all 3 targets (aarch64-apple-darwin, x86_64-apple-darwin, x86_64-unknown-linux-gnu)
- Publishes all 3 workspace crates to crates.io in dependency order: `room-protocol` -> `room-cli` -> `room-ralph`
- Adds 30s delay between crate publishes for index propagation

## Changes

- `cargo build --release --workspace --target` builds all workspace binaries
- Each matrix entry gets a `suffix` field for room-ralph artifact naming
- Stage step copies both `room` and `room-ralph` per target
- GitHub release now includes 6 binaries + SHA256SUMS (was 3 + checksums)
- Publish step split into 3 ordered `cargo publish -p` commands

## Test plan

- [x] All 400 workspace tests pass (231 room-cli unit + 71 integration + 5 smoke + 20 room-protocol + 73 room-ralph)
- [x] cargo check / fmt / clippy clean
- [ ] Verify on next release tag push that CI builds both binaries
- [ ] Verify crates.io publish order works (room-protocol before dependents)

Closes #201