### PR TITLE
docs(protocol): add README.md for room-protocol crate

### DIFF
--- a/crates/room-protocol/README.md
+++ b/crates/room-protocol/README.md
@@ -1,0 +1,62 @@
+# room-protocol
+
+Wire format types for the [room](https://github.com/knoxio/room) multi-user chat system.
+
+This crate defines the `Message` enum and constructor functions shared by all room components (broker, TUI, agent wrappers, future UIs). It contains no transport or IO logic — just types and serialization.
+
+## Installation
+
+```toml
+[dependencies]
+room-protocol = "2.0.0"
+```
+
+## Message types
+
+All messages use a flat, internally-tagged JSON format (`#[serde(tag = "type")]`):
+
+| Type | Description | Key fields |
+|------|-------------|------------|
+| `join` | User joined the room | `user` |
+| `leave` | User left the room | `user` |
+| `message` | Chat message | `user`, `content` |
+| `reply` | Reply to a specific message | `user`, `reply_to`, `content` |
+| `command` | Slash command | `user`, `cmd`, `params` |
+| `system` | Broker system message | `user`, `content` |
+| `direct_message` | Private message | `user`, `to`, `content` |
+
+Every variant carries `id` (UUID), `room`, `user`, `ts` (UTC timestamp), and an optional `seq` (sequence number).
+
+## Usage
+
+```rust
+use room_protocol::{Message, make_message, parse_client_line};
+
+// Create a message
+let msg = make_message("myroom", "alice", "hello world");
+
+// Serialize to JSON (NDJSON wire format)
+let json = serde_json::to_string(&msg).unwrap();
+
+// Deserialize from JSON
+let parsed: Message = serde_json::from_str(&json).unwrap();
+
+// Parse raw client input (plain text or JSON envelope)
+let msg = parse_client_line("hello", "myroom", "bob").unwrap();
+```
+
+## Public API
+
+- `Message` — enum with variants for all wire format types
+- `make_join`, `make_leave`, `make_message`, `make_reply`, `make_command`, `make_system`, `make_dm` — constructors
+- `parse_client_line` — parse raw client input (plain text becomes a `Message`, JSON envelopes are deserialized)
+
+## Design constraints
+
+- **No `#[serde(flatten)]`** with `#[serde(tag)]` — this combination breaks deserialization in serde. Each variant carries its own fields.
+- **No transport logic** — this crate is types-only. Consumers handle their own IO.
+- **Stable wire format** — changes to the `Message` enum are breaking changes that require coordination.
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary
- Create README.md for room-protocol crate
- Covers: what room-protocol is, message types table, usage example with code, public API surface, design constraints (no serde flatten, no transport logic, stable wire format)

## Test plan
- [x] No code changes — docs only
- [x] `cargo check && cargo fmt --check && cargo clippy -- -D warnings && cargo test` clean (421 Rust tests pass)