### PR TITLE
docs: add per-crate CHANGELOG.md files

### DIFF
--- a/crates/room-cli/CHANGELOG.md
+++ b/crates/room-cli/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to `room-cli` will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+For changes prior to the workspace restructure (v0.1.2 through v1.0.2), see the
+[root CHANGELOG](../../CHANGELOG.md).
+
+## [Unreleased]
+
+## [2.0.1] - 2026-03-06
+
+### Added
+
+- TUI: version displayed in window border title. (#210)
+- TUI: tagline and build date shown under splash logo. (#210)
+- Crate-level README for crates.io. (#217)
+
+## [2.0.0] - 2026-03-06
+
+### Changed
+
+- Renamed package from `agentroom` to `room-cli`. Binary remains `room`. (#198, #205)
+- Extracted wire format types into `room-protocol` crate. `room-cli` depends on
+  `room-protocol` for message types. (#197, #204)
+- Moved source from `src/` to `crates/room-cli/src/` as part of workspace
+  restructure.
+
+### Added
+
+- All existing functionality from `agentroom` 1.0.2: broker, TUI, one-shot
+  subcommands (`join`, `send`, `poll`, `watch`, `list`), WebSocket/REST transport,
+  plugin system (`/help`, `/stats`), admin commands, DMs, agent mode.
+- 312 tests (236 unit + 71 integration + 5 smoke).
+
+[Unreleased]: https://github.com/knoxio/room/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/knoxio/room/compare/v2.0.0...v2.0.1
+[2.0.0]: https://github.com/knoxio/room/releases/tag/v2.0.0

--- a/crates/room-protocol/CHANGELOG.md
+++ b/crates/room-protocol/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to `room-protocol` will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.0.1] - 2026-03-06
+
+### Added
+
+- Crate-level README for crates.io. (#216)
+
+## [2.0.0] - 2026-03-06
+
+### Added
+
+- Initial release as a standalone crate extracted from the `agentroom` monolith.
+- `Message` enum with variants: `Join`, `Leave`, `Message`, `Reply`, `Command`,
+  `System`, `DirectMessage`.
+- Constructors: `make_join`, `make_leave`, `make_message`, `make_reply`,
+  `make_command`, `make_system`, `make_dm`.
+- `parse_client_line` — parse raw client input (plain text or JSON envelope).
+- Flat internally-tagged serde serialization (`#[serde(tag = "type")]`).
+- 20 unit tests.
+
+### Changed
+
+- Extracted from `agentroom` crate into `room-protocol` as part of the workspace
+  restructure. (#197, #204)
+
+[Unreleased]: https://github.com/knoxio/room/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/knoxio/room/compare/v2.0.0...v2.0.1
+[2.0.0]: https://github.com/knoxio/room/releases/tag/v2.0.0

--- a/crates/room-ralph/CHANGELOG.md
+++ b/crates/room-ralph/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to `room-ralph` will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0] - 2026-03-06
+
+### Added
+
+- `--allow-tools <tools>` flag — comma-separated tool allow list passed through
+  as `--allowedTools` to the claude subprocess. (#213)
+- `--personality <file>` flag — file contents prepended before all prompt content,
+  enabling per-agent personality without replacing the default system prompt. (#215)
+- Integration tests with mock binaries. (#211)
+- Crate-level README for crates.io. (#218)
+
+### Fixed
+
+- `-v` (lowercase) now works as an alias for `--version`, matching `-V`. (#214)
+
+## [0.1.0] - 2026-03-06
+
+### Added
+
+- Initial release as a Rust port of the `ralph-room.sh` shell script. (#199, #206)
+- Autonomous agent loop: join room, poll messages, build prompt, spawn `claude -p`,
+  monitor token usage, restart on context exhaustion.
+- Context monitoring with configurable threshold (`CONTEXT_THRESHOLD`, default 80%)
+  and limit (`CONTEXT_LIMIT`, default 200k tokens).
+- Progress file persistence at `/tmp/room-progress-<issue>.md` for cross-session
+  state recovery.
+- `--tmux` flag to run in a detached tmux session.
+- `--dry-run` flag to print the prompt and exit without spawning claude.
+- `--model`, `--issue`, `--max-iter`, `--cooldown`, `--prompt`, `--add-dir` flags.
+- Logging to stderr and `/tmp/ralph-room-<username>.log`.
+- 81 unit tests + 8 integration tests.
+
+[Unreleased]: https://github.com/knoxio/room/compare/v2.0.1...HEAD
+[0.2.0]: https://github.com/knoxio/room/compare/v2.0.0...v2.0.1
+[0.1.0]: https://github.com/knoxio/room/releases/tag/v2.0.0


### PR DESCRIPTION
## Summary

- Creates `crates/room-protocol/CHANGELOG.md` with entries for 2.0.0 and 2.0.1
- Creates `crates/room-cli/CHANGELOG.md` with entries for 2.0.0 and 2.0.1, linking to root CHANGELOG for pre-workspace history
- Creates `crates/room-ralph/CHANGELOG.md` with entries for 0.1.0 and 0.2.0
- All use [Keep a Changelog](https://keepachangelog.com/) format

## Test plan

- [x] `cargo check` passes
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — all 421 tests pass
- [ ] Review changelog entries for accuracy
