### PR TITLE
feat(ralph): add default tool set and RALPH_ALLOWED_TOOLS env var

### DIFF
--- a/crates/room-ralph/src/claude.rs
+++ b/crates/room-ralph/src/claude.rs
@@ -1,6 +1,50 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+/// Safe default tools that ralph passes to claude when no explicit
+/// --allow-tools flag or RALPH_ALLOWED_TOOLS env var is set.
+pub const DEFAULT_ALLOWED_TOOLS: &[&str] = &[
+    "Read",
+    "Glob",
+    "Grep",
+    "WebSearch",
+    "Bash(room *)",
+    "Bash(git status)",
+    "Bash(git log)",
+    "Bash(git diff)",
+];
+
+/// Resolve the effective allowed-tools list.
+///
+/// Precedence: CLI --allow-tools > RALPH_ALLOWED_TOOLS env > defaults.
+/// Special value "none" (case-insensitive) disables tool restrictions entirely.
+pub fn resolve_allowed_tools(cli_tools: &[String]) -> Vec<String> {
+    // CLI takes highest precedence
+    if !cli_tools.is_empty() {
+        if cli_tools.len() == 1 && cli_tools[0].eq_ignore_ascii_case("none") {
+            return Vec::new();
+        }
+        return cli_tools.to_vec();
+    }
+
+    // Check env var
+    if let Ok(env_val) = std::env::var("RALPH_ALLOWED_TOOLS") {
+        let trimmed = env_val.trim();
+        if trimmed.eq_ignore_ascii_case("none") {
+            return Vec::new();
+        }
+        if !trimmed.is_empty() {
+            return trimmed.split(',').map(|s| s.trim().to_string()).collect();
+        }
+    }
+
+    // Fall back to defaults
+    DEFAULT_ALLOWED_TOOLS
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect()
+}
+
 /// Output from a claude -p invocation.
 pub struct ClaudeOutput {
     /// Raw JSON output from claude --output-format json
@@ -245,5 +289,85 @@ mod tests {
                 "Bash"
             ]
         );
+    }
+
+    #[test]
+    fn resolve_defaults_when_empty() {
+        // Clear env to ensure defaults apply
+        std::env::remove_var("RALPH_ALLOWED_TOOLS");
+        let result = resolve_allowed_tools(&[]);
+        assert_eq!(result.len(), DEFAULT_ALLOWED_TOOLS.len());
+        assert!(result.contains(&"Read".to_string()));
+        assert!(result.contains(&"Glob".to_string()));
+        assert!(result.contains(&"Bash(room *)".to_string()));
+    }
+
+    #[test]
+    fn resolve_cli_overrides_defaults() {
+        std::env::remove_var("RALPH_ALLOWED_TOOLS");
+        let cli = vec!["Write".to_string(), "Edit".to_string()];
+        let result = resolve_allowed_tools(&cli);
+        assert_eq!(result, vec!["Write", "Edit"]);
+    }
+
+    #[test]
+    fn resolve_cli_none_disables_restrictions() {
+        std::env::remove_var("RALPH_ALLOWED_TOOLS");
+        let cli = vec!["none".to_string()];
+        let result = resolve_allowed_tools(&cli);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn resolve_cli_none_case_insensitive() {
+        std::env::remove_var("RALPH_ALLOWED_TOOLS");
+        let cli = vec!["NONE".to_string()];
+        let result = resolve_allowed_tools(&cli);
+        assert!(result.is_empty());
+
+        let cli = vec!["None".to_string()];
+        let result = resolve_allowed_tools(&cli);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn resolve_env_overrides_defaults() {
+        std::env::set_var("RALPH_ALLOWED_TOOLS", "Bash,Read,WebSearch");
+        let result = resolve_allowed_tools(&[]);
+        assert_eq!(result, vec!["Bash", "Read", "WebSearch"]);
+        std::env::remove_var("RALPH_ALLOWED_TOOLS");
+    }
+
+    #[test]
+    fn resolve_env_none_disables_restrictions() {
+        std::env::set_var("RALPH_ALLOWED_TOOLS", "none");
+        let result = resolve_allowed_tools(&[]);
+        assert!(result.is_empty());
+        std::env::remove_var("RALPH_ALLOWED_TOOLS");
+    }
+
+    #[test]
+    fn resolve_cli_takes_precedence_over_env() {
+        std::env::set_var("RALPH_ALLOWED_TOOLS", "Bash,Read");
+        let cli = vec!["Write".to_string()];
+        let result = resolve_allowed_tools(&cli);
+        assert_eq!(result, vec!["Write"]);
+        std::env::remove_var("RALPH_ALLOWED_TOOLS");
+    }
+
+    #[test]
+    fn resolve_env_trims_whitespace() {
+        std::env::set_var("RALPH_ALLOWED_TOOLS", " Bash , Read , Grep ");
+        let result = resolve_allowed_tools(&[]);
+        assert_eq!(result, vec!["Bash", "Read", "Grep"]);
+        std::env::remove_var("RALPH_ALLOWED_TOOLS");
+    }
+
+    #[test]
+    fn resolve_env_empty_string_uses_defaults() {
+        std::env::set_var("RALPH_ALLOWED_TOOLS", "");
+        let result = resolve_allowed_tools(&[]);
+        assert_eq!(result.len(), DEFAULT_ALLOWED_TOOLS.len());
+        std::env::remove_var("RALPH_ALLOWED_TOOLS");
     }
 }

--- a/crates/room-ralph/src/loop_runner.rs
+++ b/crates/room-ralph/src/loop_runner.rs
@@ -63,8 +63,9 @@ pub async fn run_loop(cli: &Cli, token: &str, running: &Arc<AtomicBool>) -> Resu
             cli.model,
             iteration
         );
+        let effective_tools = claude::resolve_allowed_tools(&cli.allow_tools);
         let claude_output =
-            match claude::spawn_claude(&cli.model, &prompt_file, &cli.add_dirs, &cli.allow_tools) {
+            match claude::spawn_claude(&cli.model, &prompt_file, &cli.add_dirs, &effective_tools) {
                 Ok(o) => o,
                 Err(e) => {
                     tracing::error!("failed to spawn claude: {}", e);


### PR DESCRIPTION
## Summary

- Add `DEFAULT_ALLOWED_TOOLS` const with safe read-only defaults: Read, Glob, Grep, WebSearch, Bash(room *), Bash(git status), Bash(git log), Bash(git diff)
- Add `resolve_allowed_tools()` with precedence: CLI `--allow-tools` > `RALPH_ALLOWED_TOOLS` env > built-in defaults
- Special value `none` (case-insensitive) disables tool restrictions entirely
- 9 new unit tests covering all resolution paths

## Usage

```bash
# Uses safe defaults (read-only tools + room CLI + read-only git)
room-ralph myroom agent1

# Override via env var (for orchestrators like hive)
RALPH_ALLOWED_TOOLS="Read,Write,Bash" room-ralph myroom agent1

# Override via CLI flag (highest precedence)
room-ralph myroom agent1 --allow-tools Read,Write,Bash

# Disable all restrictions
room-ralph myroom agent1 --allow-tools none
```

## Test plan

- [x] `cargo test -p room-ralph` — 98/98 pass (90 unit + 8 integration)
- [x] `cargo clippy -- -D warnings` — clean
- [x] Pre-push checks pass
