### PR TITLE
feat: route slash commands in oneshot send

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1949,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "room-cli"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "room-protocol"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "chrono",
  "serde",
@@ -1982,7 +1982,7 @@ dependencies = [
 
 [[package]]
 name = "room-ralph"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/room-cli/src/oneshot/mod.rs
+++ b/crates/room-cli/src/oneshot/mod.rs
@@ -17,6 +17,9 @@ use transport::send_message_with_token as transport_send;
 /// Authenticates via `token` (from `room join`). The broker resolves the sender's
 /// username from the token — no username arg required. When `to` is `Some(recipient)`,
 /// the message is sent as a DM routed only to sender, recipient, and host.
+///
+/// Slash commands (e.g. `/who`, `/dm user msg`) are automatically converted to the
+/// appropriate JSON envelope, matching TUI behaviour.
 pub async fn cmd_send(
     room_id: &str,
     token: &str,
@@ -28,7 +31,7 @@ pub async fn cmd_send(
         Some(recipient) => {
             serde_json::json!({"type": "dm", "to": recipient, "content": content}).to_string()
         }
-        None => serde_json::json!({"type": "message", "content": content}).to_string(),
+        None => build_wire_payload(content),
     };
     let msg = transport_send(&socket_path, token, &wire)
         .await
@@ -41,4 +44,122 @@ pub async fn cmd_send(
         })?;
     println!("{}", serde_json::to_string(&msg)?);
     Ok(())
+}
+
+/// Convert user input into a JSON wire envelope, routing slash commands to the
+/// appropriate message type. Mirrors `tui::input::build_payload` for parity.
+fn build_wire_payload(input: &str) -> String {
+    // `/dm <user> <message>`
+    if let Some(rest) = input.strip_prefix("/dm ") {
+        let mut parts = rest.splitn(2, ' ');
+        let to = parts.next().unwrap_or("");
+        let content = parts.next().unwrap_or("");
+        return serde_json::json!({"type": "dm", "to": to, "content": content}).to_string();
+    }
+    // Any other slash command: `/who`, `/kick user`, etc.
+    if let Some(rest) = input.strip_prefix('/') {
+        let mut parts = rest.splitn(2, ' ');
+        let cmd = parts.next().unwrap_or("");
+        let params: Vec<&str> = parts.next().unwrap_or("").split_whitespace().collect();
+        return serde_json::json!({"type": "command", "cmd": cmd, "params": params}).to_string();
+    }
+    // Plain message
+    serde_json::json!({"type": "message", "content": input}).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_message() {
+        let wire = build_wire_payload("hello world");
+        let v: serde_json::Value = serde_json::from_str(&wire).unwrap();
+        assert_eq!(v["type"], "message");
+        assert_eq!(v["content"], "hello world");
+    }
+
+    #[test]
+    fn who_command() {
+        let wire = build_wire_payload("/who");
+        let v: serde_json::Value = serde_json::from_str(&wire).unwrap();
+        assert_eq!(v["type"], "command");
+        assert_eq!(v["cmd"], "who");
+        let params = v["params"].as_array().unwrap();
+        assert!(params.is_empty());
+    }
+
+    #[test]
+    fn command_with_params() {
+        let wire = build_wire_payload("/kick alice");
+        let v: serde_json::Value = serde_json::from_str(&wire).unwrap();
+        assert_eq!(v["type"], "command");
+        assert_eq!(v["cmd"], "kick");
+        let params: Vec<&str> = v["params"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|p| p.as_str().unwrap())
+            .collect();
+        assert_eq!(params, vec!["alice"]);
+    }
+
+    #[test]
+    fn command_with_multiple_params() {
+        let wire = build_wire_payload("/set_status away brb");
+        let v: serde_json::Value = serde_json::from_str(&wire).unwrap();
+        assert_eq!(v["type"], "command");
+        assert_eq!(v["cmd"], "set_status");
+        let params: Vec<&str> = v["params"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|p| p.as_str().unwrap())
+            .collect();
+        assert_eq!(params, vec!["away", "brb"]);
+    }
+
+    #[test]
+    fn dm_via_slash() {
+        let wire = build_wire_payload("/dm bob hey there");
+        let v: serde_json::Value = serde_json::from_str(&wire).unwrap();
+        assert_eq!(v["type"], "dm");
+        assert_eq!(v["to"], "bob");
+        assert_eq!(v["content"], "hey there");
+    }
+
+    #[test]
+    fn dm_slash_no_message() {
+        let wire = build_wire_payload("/dm bob");
+        let v: serde_json::Value = serde_json::from_str(&wire).unwrap();
+        assert_eq!(v["type"], "dm");
+        assert_eq!(v["to"], "bob");
+        assert_eq!(v["content"], "");
+    }
+
+    #[test]
+    fn slash_only() {
+        let wire = build_wire_payload("/");
+        let v: serde_json::Value = serde_json::from_str(&wire).unwrap();
+        assert_eq!(v["type"], "command");
+        assert_eq!(v["cmd"], "");
+    }
+
+    #[test]
+    fn message_starting_with_slash_like_path() {
+        // Only exact slash-prefix triggers command routing — `/tmp/foo` is a command named `tmp/foo`
+        // This matches TUI behaviour: any `/` prefix is a command
+        let wire = build_wire_payload("/tmp/foo");
+        let v: serde_json::Value = serde_json::from_str(&wire).unwrap();
+        assert_eq!(v["type"], "command");
+        assert_eq!(v["cmd"], "tmp/foo");
+    }
+
+    #[test]
+    fn empty_string() {
+        let wire = build_wire_payload("");
+        let v: serde_json::Value = serde_json::from_str(&wire).unwrap();
+        assert_eq!(v["type"], "message");
+        assert_eq!(v["content"], "");
+    }
 }


### PR DESCRIPTION
## Summary

- Fix `cmd_send` in `crates/room-cli/src/oneshot/mod.rs` to detect slash-prefixed input and route to the appropriate JSON envelope instead of always wrapping as a plain message
- `/who`, `/kick user`, `/set_status away`, etc. now produce `{"type":"command","cmd":"...","params":[...]}` envelopes
- `/dm user message` now produces `{"type":"dm","to":"user","content":"message"}` envelopes
- Plain text (no `/` prefix) continues to produce `{"type":"message","content":"..."}` as before
- New `build_wire_payload()` function mirrors TUI's `build_payload` logic for parity

## Test plan

- [x] 9 unit tests for `build_wire_payload`: plain message, `/who`, command with params, multi-params, `/dm` with and without message body, edge cases (`/`, `/tmp/foo`, empty string)
- [x] Existing integration test `oneshot_who_returns_user_list` confirms broker accepts command envelopes from oneshot
- [x] All 430 tests pass (`cargo test`)
- [x] `cargo check`, `cargo fmt`, `cargo clippy -- -D warnings` clean
