### PR TITLE
fix(ralph): serialize env var tests with mutex

### DIFF
--- a/crates/room-ralph/src/claude.rs
+++ b/crates/room-ralph/src/claude.rs
@@ -157,6 +157,10 @@ pub fn detect_context_exhaustion(exit_code: i32, response: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    /// Mutex to serialize tests that touch RALPH_ALLOWED_TOOLS (env is process-global).
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn extract_response_from_result_field() {
@@ -293,33 +297,39 @@ mod tests {
 
     #[test]
     fn resolve_defaults_when_empty() {
-        // Clear env to ensure defaults apply
+        let _lock = ENV_LOCK.lock().unwrap();
         std::env::remove_var("RALPH_ALLOWED_TOOLS");
         let result = resolve_allowed_tools(&[]);
         assert_eq!(result.len(), DEFAULT_ALLOWED_TOOLS.len());
         assert!(result.contains(&"Read".to_string()));
         assert!(result.contains(&"Glob".to_string()));
         assert!(result.contains(&"Bash(room *)".to_string()));
+        std::env::remove_var("RALPH_ALLOWED_TOOLS");
     }
 
     #[test]
     fn resolve_cli_overrides_defaults() {
+        let _lock = ENV_LOCK.lock().unwrap();
         std::env::remove_var("RALPH_ALLOWED_TOOLS");
         let cli = vec!["Write".to_string(), "Edit".to_string()];
         let result = resolve_allowed_tools(&cli);
         assert_eq!(result, vec!["Write", "Edit"]);
+        std::env::remove_var("RALPH_ALLOWED_TOOLS");
     }
 
     #[test]
     fn resolve_cli_none_disables_restrictions() {
+        let _lock = ENV_LOCK.lock().unwrap();
         std::env::remove_var("RALPH_ALLOWED_TOOLS");
         let cli = vec!["none".to_string()];
         let result = resolve_allowed_tools(&cli);
         assert!(result.is_empty());
+        std::env::remove_var("RALPH_ALLOWED_TOOLS");
     }
 
     #[test]
     fn resolve_cli_none_case_insensitive() {
+        let _lock = ENV_LOCK.lock().unwrap();
         std::env::remove_var("RALPH_ALLOWED_TOOLS");
         let cli = vec!["NONE".to_string()];
         let result = resolve_allowed_tools(&cli);
@@ -328,10 +338,13 @@ mod tests {
         let cli = vec!["None".to_string()];
         let result = resolve_allowed_tools(&cli);
         assert!(result.is_empty());
+        std::env::remove_var("RALPH_ALLOWED_TOOLS");
     }
 
     #[test]
     fn resolve_env_overrides_defaults() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("RALPH_ALLOWED_TOOLS");
         std::env::set_var("RALPH_ALLOWED_TOOLS", "Bash,Read,WebSearch");
         let result = resolve_allowed_tools(&[]);
         assert_eq!(result, vec!["Bash", "Read", "WebSearch"]);
@@ -340,6 +353,8 @@ mod tests {
 
     #[test]
     fn resolve_env_none_disables_restrictions() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("RALPH_ALLOWED_TOOLS");
         std::env::set_var("RALPH_ALLOWED_TOOLS", "none");
         let result = resolve_allowed_tools(&[]);
         assert!(result.is_empty());
@@ -348,6 +363,8 @@ mod tests {
 
     #[test]
     fn resolve_cli_takes_precedence_over_env() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("RALPH_ALLOWED_TOOLS");
         std::env::set_var("RALPH_ALLOWED_TOOLS", "Bash,Read");
         let cli = vec!["Write".to_string()];
         let result = resolve_allowed_tools(&cli);
@@ -357,6 +374,8 @@ mod tests {
 
     #[test]
     fn resolve_env_trims_whitespace() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("RALPH_ALLOWED_TOOLS");
         std::env::set_var("RALPH_ALLOWED_TOOLS", " Bash , Read , Grep ");
         let result = resolve_allowed_tools(&[]);
         assert_eq!(result, vec!["Bash", "Read", "Grep"]);
@@ -365,6 +384,8 @@ mod tests {
 
     #[test]
     fn resolve_env_empty_string_uses_defaults() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("RALPH_ALLOWED_TOOLS");
         std::env::set_var("RALPH_ALLOWED_TOOLS", "");
         let result = resolve_allowed_tools(&[]);
         assert_eq!(result.len(), DEFAULT_ALLOWED_TOOLS.len());


### PR DESCRIPTION
## Summary
- Adds `ENV_LOCK` mutex to `claude.rs` test module to serialize all `resolve_*` tests that touch `RALPH_ALLOWED_TOOLS`
- Matches the pattern already used in `lib.rs` (added by #222)
- Fixes flaky CI failures on PR #223 (and any future PR) where parallel test execution causes env var races

## Context
CI for PR #223 failed twice with different tests each time:
1. `resolve_env_none_disables_restrictions` — got non-empty when expecting empty
2. `resolve_env_trims_whitespace` — got `[]` when expecting `[Bash, Read, Grep]`

Both are classic symptoms of unsynchronized `set_var`/`remove_var` calls across parallel test threads.

## Test plan
- [x] All 430 tests pass locally
- [x] Pre-push checks pass (check, fmt, clippy, test)