### PR TITLE
feat: TUI floating member status panel

### DIFF
--- a/crates/room-cli/src/tui/input.rs
+++ b/crates/room-cli/src/tui/input.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use unicode_width::UnicodeWidthChar;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
@@ -500,20 +502,45 @@ pub(super) fn build_payload(input: &str) -> String {
     }
 }
 
-/// Seed `online_users` from the broker's `/who` response content.
+/// Seed `online_users` and `user_statuses` from the broker's `/who` response content.
 ///
 /// The broker sends `"online — alice, bob: away, charlie"` (or `"no users online"`).
-/// Each entry is either a bare username or `username: status`; we extract the username part.
+/// Each entry is either a bare username or `username: status`.
 /// Merges into the existing list without removing users added by Join events.
-pub(super) fn seed_online_users_from_who(content: &str, online_users: &mut Vec<String>) {
+pub(super) fn seed_online_users_from_who(
+    content: &str,
+    online_users: &mut Vec<String>,
+    user_statuses: &mut HashMap<String, String>,
+) {
     if let Some(rest) = content.strip_prefix("online \u{2014} ") {
         for entry in rest.split(", ") {
-            let username = entry.split(':').next().unwrap_or(entry).trim().to_owned();
-            if !username.is_empty() && !online_users.contains(&username) {
-                online_users.push(username);
+            let (username, status) = match entry.split_once(": ") {
+                Some((u, s)) => (u.trim().to_owned(), s.trim().to_owned()),
+                None => (entry.trim().to_owned(), String::new()),
+            };
+            if !username.is_empty() {
+                if !online_users.contains(&username) {
+                    online_users.push(username.clone());
+                }
+                user_statuses.insert(username, status);
             }
         }
     }
+}
+
+/// Parse a `/set_status` system broadcast into `(username, status)`.
+///
+/// The broker broadcasts either:
+/// - `"alice set status: busy"` → `Some(("alice", "busy"))`
+/// - `"alice cleared their status"` → `Some(("alice", ""))`
+pub(super) fn parse_status_broadcast(content: &str) -> Option<(String, String)> {
+    if let Some(rest) = content.strip_suffix(" cleared their status") {
+        return Some((rest.to_owned(), String::new()));
+    }
+    if let Some((name, status)) = content.split_once(" set status: ") {
+        return Some((name.to_owned(), status.to_owned()));
+    }
+    None
 }
 
 /// Move the cursor to the start of the previous word.
@@ -589,36 +616,84 @@ mod tests {
     #[test]
     fn seed_who_populates_users() {
         let mut users = Vec::new();
-        seed_online_users_from_who("online \u{2014} alice, bob, charlie", &mut users);
+        let mut statuses = HashMap::new();
+        seed_online_users_from_who(
+            "online \u{2014} alice, bob, charlie",
+            &mut users,
+            &mut statuses,
+        );
         assert_eq!(users, ["alice", "bob", "charlie"]);
+        assert_eq!(statuses.get("alice").unwrap(), "");
     }
 
     #[test]
-    fn seed_who_strips_status_suffix() {
+    fn seed_who_extracts_statuses() {
         let mut users = Vec::new();
-        seed_online_users_from_who("online \u{2014} alice: away, bob: coding", &mut users);
-        assert_eq!(users, ["alice", "bob"]);
+        let mut statuses = HashMap::new();
+        seed_online_users_from_who(
+            "online \u{2014} alice: away, bob: coding, charlie",
+            &mut users,
+            &mut statuses,
+        );
+        assert_eq!(users, ["alice", "bob", "charlie"]);
+        assert_eq!(statuses.get("alice").unwrap(), "away");
+        assert_eq!(statuses.get("bob").unwrap(), "coding");
+        assert_eq!(statuses.get("charlie").unwrap(), "");
     }
 
     #[test]
     fn seed_who_no_users_online_is_noop() {
         let mut users = Vec::new();
-        seed_online_users_from_who("no users online", &mut users);
+        let mut statuses = HashMap::new();
+        seed_online_users_from_who("no users online", &mut users, &mut statuses);
         assert!(users.is_empty());
+        assert!(statuses.is_empty());
     }
 
     #[test]
     fn seed_who_does_not_duplicate_existing_users() {
         let mut users = vec!["alice".to_owned()];
-        seed_online_users_from_who("online \u{2014} alice, bob", &mut users);
+        let mut statuses = HashMap::new();
+        seed_online_users_from_who("online \u{2014} alice, bob", &mut users, &mut statuses);
         assert_eq!(users, ["alice", "bob"]);
     }
 
     #[test]
     fn seed_who_unrelated_system_message_is_noop() {
         let mut users = Vec::new();
-        seed_online_users_from_who("alice set status: away", &mut users);
+        let mut statuses = HashMap::new();
+        seed_online_users_from_who("alice set status: away", &mut users, &mut statuses);
         assert!(users.is_empty());
+        assert!(statuses.is_empty());
+    }
+
+    // ── parse_status_broadcast tests ─────────────────────────────────────────
+
+    #[test]
+    fn parse_status_set() {
+        let result = parse_status_broadcast("alice set status: busy");
+        assert_eq!(result, Some(("alice".to_owned(), "busy".to_owned())));
+    }
+
+    #[test]
+    fn parse_status_cleared() {
+        let result = parse_status_broadcast("alice cleared their status");
+        assert_eq!(result, Some(("alice".to_owned(), String::new())));
+    }
+
+    #[test]
+    fn parse_status_unrelated_message() {
+        assert!(parse_status_broadcast("alice joined").is_none());
+        assert!(parse_status_broadcast("hello world").is_none());
+    }
+
+    #[test]
+    fn parse_status_with_spaces_in_name() {
+        let result = parse_status_broadcast("my-agent set status: reviewing PR");
+        assert_eq!(
+            result,
+            Some(("my-agent".to_owned(), "reviewing PR".to_owned()))
+        );
     }
 
     // ── build_payload tests ───────────────────────────────────────────────────

--- a/crates/room-cli/src/tui/mod.rs
+++ b/crates/room-cli/src/tui/mod.rs
@@ -24,8 +24,8 @@ mod widgets;
 
 use crate::message::Message;
 use input::{
-    build_payload, cursor_display_pos, handle_key, seed_online_users_from_who, wrap_input_display,
-    Action, InputState,
+    build_payload, cursor_display_pos, handle_key, parse_status_broadcast,
+    seed_online_users_from_who, wrap_input_display, Action, InputState,
 };
 use render::{assign_color, find_view_start, format_message, user_color, welcome_splash, ColorMap};
 
@@ -95,6 +95,8 @@ pub async fn run(
 
     let mut messages: Vec<Message> = Vec::new();
     let mut online_users: Vec<String> = Vec::new();
+    let mut user_statuses: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
     let mut color_map = ColorMap::new();
     let mut state = InputState::new();
     let mut result: anyhow::Result<()> = Ok(());
@@ -120,6 +122,7 @@ pub async fn run(
                         }
                         Message::Leave { user, .. } => {
                             online_users.retain(|u| u != user);
+                            user_statuses.remove(user);
                         }
                         // Seed from message senders so @mention works for users who connected
                         // via poll/send (no persistent connection, not in the status_map).
@@ -133,7 +136,14 @@ pub async fn run(
                         }
                         // Parse the /who response to seed the authoritative user list.
                         Message::System { user, content, .. } if user == "broker" => {
-                            seed_online_users_from_who(content, &mut online_users);
+                            seed_online_users_from_who(
+                                content,
+                                &mut online_users,
+                                &mut user_statuses,
+                            );
+                            if let Some((name, status)) = parse_status_broadcast(content) {
+                                user_statuses.insert(name, status);
+                            }
                             for u in &online_users {
                                 assign_color(u, &mut color_map);
                             }
@@ -280,6 +290,70 @@ pub async fn run(
             let cursor_x = chunks[1].x + 1 + cursor_col as u16;
             let cursor_y = chunks[1].y + 1 + visible_cursor_row as u16;
             f.set_cursor_position((cursor_x, cursor_y));
+
+            // Render floating member status panel (top-right of message area).
+            // Hidden when terminal is too narrow (< 80 cols) or no users online.
+            const PANEL_MIN_TERM_WIDTH: u16 = 80;
+            if f.area().width >= PANEL_MIN_TERM_WIDTH && !online_users.is_empty() {
+                let panel_items: Vec<ListItem> = online_users
+                    .iter()
+                    .map(|u| {
+                        let status = user_statuses.get(u).map(|s| s.as_str()).unwrap_or("");
+                        let mut spans = vec![Span::styled(
+                            format!(" {u}"),
+                            Style::default()
+                                .fg(user_color(u, &color_map))
+                                .add_modifier(Modifier::BOLD),
+                        )];
+                        if !status.is_empty() {
+                            spans.push(Span::styled(
+                                format!("  {status}"),
+                                Style::default().fg(Color::DarkGray),
+                            ));
+                        }
+                        spans.push(Span::raw(" "));
+                        ListItem::new(Line::from(spans))
+                    })
+                    .collect();
+
+                let panel_content_width = online_users
+                    .iter()
+                    .map(|u| {
+                        let status = user_statuses.get(u).map(|s| s.as_str()).unwrap_or("");
+                        let status_len = if status.is_empty() {
+                            0
+                        } else {
+                            status.len() + 2 // "  " + status
+                        };
+                        u.len() + 1 + status_len + 1 // " " + name + status_part + " "
+                    })
+                    .max()
+                    .unwrap_or(10);
+                let panel_width = (panel_content_width as u16 + 2)
+                    .min(chunks[0].width / 3)
+                    .max(12);
+                let panel_height =
+                    (online_users.len() as u16 + 2).min(chunks[0].height.saturating_sub(1));
+
+                let panel_x = chunks[0].x + chunks[0].width - panel_width - 1;
+                let panel_y = chunks[0].y + 1;
+
+                let panel_rect = Rect {
+                    x: panel_x,
+                    y: panel_y,
+                    width: panel_width,
+                    height: panel_height,
+                };
+
+                f.render_widget(Clear, panel_rect);
+                let panel = List::new(panel_items).block(
+                    Block::default()
+                        .title(" members ")
+                        .borders(Borders::ALL)
+                        .border_style(Style::default().fg(Color::DarkGray)),
+                );
+                f.render_widget(panel, panel_rect);
+            }
 
             // Render the command palette popup above the input box when active.
             if state.palette.active && !state.palette.filtered.is_empty() {
@@ -433,6 +507,7 @@ pub async fn run(
                         }
                         Message::Leave { user, .. } => {
                             online_users.retain(|u| u != user);
+                            user_statuses.remove(user);
                         }
                         Message::Message { user, .. } if !online_users.contains(user) => {
                             assign_color(user, &mut color_map);
@@ -442,7 +517,14 @@ pub async fn run(
                             assign_color(user, &mut color_map);
                         }
                         Message::System { user, content, .. } if user == "broker" => {
-                            seed_online_users_from_who(content, &mut online_users);
+                            seed_online_users_from_who(
+                                content,
+                                &mut online_users,
+                                &mut user_statuses,
+                            );
+                            if let Some((name, status)) = parse_status_broadcast(content) {
+                                user_statuses.insert(name, status);
+                            }
                             for u in &online_users {
                                 assign_color(u, &mut color_map);
                             }


### PR DESCRIPTION
## Summary

- Add floating member status panel in the top-right corner of the TUI message area
- Panel shows connected users (color-coded) with their `/set_status` text in gray
- Auto-hides when terminal width is below 80 columns or no users are online
- Panel width adapts to content (capped at 1/3 of message area width)
- `seed_online_users_from_who` now also populates a `user_statuses` HashMap from the `/who` response
- New `parse_status_broadcast()` extracts status changes from system messages (`"alice set status: busy"` / `"alice cleared their status"`)
- User statuses are cleared on Leave events

Closes #225

## Test plan

- [x] 4 new unit tests: `seed_who_extracts_statuses`, `parse_status_set`, `parse_status_cleared`, `parse_status_with_spaces_in_name`
- [x] Existing `seed_who_*` tests updated for new 3-argument signature
- [x] All 449 tests pass (`cargo test`)
- [x] `cargo check`, `cargo fmt`, `cargo clippy -- -D warnings` clean
