### PR TITLE
feat(cli): add room who subcommand

### DIFF
--- a/crates/room-cli/src/main.rs
+++ b/crates/room-cli/src/main.rs
@@ -68,6 +68,19 @@ enum Cmd {
         #[arg(long, default_value_t = 5)]
         interval: u64,
     },
+    /// Query who is online and their status.
+    ///
+    /// Sends `/who` to the broker and prints the member list with statuses.
+    /// With `--json`, prints the raw JSON response instead of human-readable text.
+    Who {
+        room_id: String,
+        /// Session token from `room join` (required)
+        #[arg(short = 't', long)]
+        token: String,
+        /// Print raw JSON instead of human-readable text
+        #[arg(long)]
+        json: bool,
+    },
     /// List active rooms with running brokers.
     ///
     /// Scans `/tmp` for `room-*.sock` files and probes each to verify the broker
@@ -150,6 +163,13 @@ async fn main() -> anyhow::Result<()> {
             interval,
         }) => {
             oneshot::cmd_watch(&room_id, &token, interval).await?;
+        }
+        Some(Cmd::Who {
+            room_id,
+            token,
+            json,
+        }) => {
+            oneshot::cmd_who(&room_id, &token, json).await?;
         }
         Some(Cmd::List) => {
             oneshot::cmd_list().await?;

--- a/crates/room-cli/src/oneshot/mod.rs
+++ b/crates/room-cli/src/oneshot/mod.rs
@@ -2,11 +2,13 @@ pub mod list;
 pub mod poll;
 pub mod token;
 pub mod transport;
+pub mod who;
 
 pub use list::cmd_list;
 pub use poll::{cmd_poll, cmd_pull, cmd_watch, poll_messages, pull_messages};
 pub use token::{cmd_join, token_file_path, username_from_token};
 pub use transport::{join_session, send_message, send_message_with_token};
+pub use who::cmd_who;
 
 use std::path::PathBuf;
 

--- a/crates/room-cli/src/oneshot/who.rs
+++ b/crates/room-cli/src/oneshot/who.rs
@@ -1,0 +1,57 @@
+use std::path::PathBuf;
+
+use super::transport::send_message_with_token as transport_send;
+use crate::message::Message;
+
+/// One-shot who subcommand: send `/who` to the broker, print the response, exit.
+///
+/// By default prints just the human-readable content line. With `json = true`,
+/// prints the full JSON response for machine consumption.
+pub async fn cmd_who(room_id: &str, token: &str, json: bool) -> anyhow::Result<()> {
+    let socket_path = PathBuf::from(format!("/tmp/room-{room_id}.sock"));
+    let wire = serde_json::json!({"type": "command", "cmd": "who", "params": []}).to_string();
+    let msg = transport_send(&socket_path, token, &wire)
+        .await
+        .map_err(|e| {
+            if e.to_string().contains("invalid token") {
+                anyhow::anyhow!("invalid token — run: room join {room_id} <username>")
+            } else {
+                e
+            }
+        })?;
+
+    if json {
+        println!("{}", serde_json::to_string(&msg)?);
+    } else {
+        match &msg {
+            Message::System { content, .. } => println!("{content}"),
+            _ => println!("{}", serde_json::to_string(&msg)?),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::message::Message;
+
+    #[test]
+    fn system_message_content_extraction() {
+        let json = r#"{"type":"system","id":"abc","room":"r","user":"broker","ts":"2026-01-01T00:00:00Z","seq":1,"content":"online — alice, bob: reviewing PR"}"#;
+        let msg: Message = serde_json::from_str(json).unwrap();
+        if let Message::System { content, .. } = &msg {
+            assert_eq!(content, "online — alice, bob: reviewing PR");
+        } else {
+            panic!("expected System message");
+        }
+    }
+
+    #[test]
+    fn who_wire_payload_is_valid_command() {
+        let wire = serde_json::json!({"type": "command", "cmd": "who", "params": []}).to_string();
+        let v: serde_json::Value = serde_json::from_str(&wire).unwrap();
+        assert_eq!(v["type"], "command");
+        assert_eq!(v["cmd"], "who");
+        assert!(v["params"].as_array().unwrap().is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

- Add 8 integration tests for `room-ralph` in `crates/room-ralph/tests/integration.rs`
- Tests cover: dry-run mode, max-iter limits, context exhaustion progress writes, token expiry detection, claude failure handling, NDJSON poll parsing, and live broker join
- Uses mock shell scripts for `room` and `claude` binaries (created in tempdir, prepended to PATH)
- Mutex serializes PATH-dependent tests for thread safety
- Workspace test count: 400 -> 407

## Test plan

- [x] `cargo test -p room-ralph --test integration -- --test-threads=1` (7 pass, 1 ignored)
- [x] `cargo test` full workspace (407 tests pass)
- [x] `cargo check && cargo fmt --check && cargo clippy -- -D warnings`

Closes section C of the test plan (sprint 4 gap analysis).
