### PR TITLE
docs(ralph): add environment variables section and update changelog

### DIFF
--- a/crates/room-ralph/CHANGELOG.md
+++ b/crates/room-ralph/CHANGELOG.md
@@ -7,6 +7,16 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Environment variable configuration: `RALPH_ROOM`, `RALPH_USERNAME`, `RALPH_MODEL`,
+  `RALPH_ISSUE` as alternatives to CLI positional args and flags. (#222)
+- `RALPH_ALLOWED_TOOLS` environment variable for setting the tool allow list without
+  the CLI flag. Supports `none` to disable restrictions. (#222)
+- Safe default tool set (`Read`, `Glob`, `Grep`, `WebSearch`, `Bash(room *)`,
+  `Bash(git status)`, `Bash(git log)`, `Bash(git diff)`) applied when neither
+  `--allow-tools` nor `RALPH_ALLOWED_TOOLS` is set. (#221)
+
 ## [0.2.0] - 2026-03-06
 
 ### Added

--- a/crates/room-ralph/README.md
+++ b/crates/room-ralph/README.md
@@ -82,6 +82,33 @@ room-ralph myroom agent1 --model sonnet --add-dir ../shared-lib --add-dir ../doc
 | `--dry-run` | off | Print the prompt that would be sent, then exit |
 | `-v` / `-V` / `--version` | — | Print version |
 
+## Environment variables
+
+All positional arguments and key options can be set via environment variables.
+CLI flags take precedence over environment variables.
+
+| Variable | Equivalent flag | Description |
+|---|---|---|
+| `RALPH_ROOM` | `<room-id>` | Room to join |
+| `RALPH_USERNAME` | `<username>` | Username to register with |
+| `RALPH_MODEL` | `--model` | Claude model to use (default: `opus`) |
+| `RALPH_ISSUE` | `--issue` | GitHub issue number |
+| `RALPH_ALLOWED_TOOLS` | `--allow-tools` | Comma-separated tool allow list (see below) |
+| `CONTEXT_LIMIT` | — | Total context window size (default: `200000`) |
+| `CONTEXT_THRESHOLD` | — | Percentage at which to restart (default: `80`) |
+
+### Tool precedence
+
+Allowed tools are resolved in this order:
+
+1. `--allow-tools` CLI flag (highest)
+2. `RALPH_ALLOWED_TOOLS` environment variable
+3. Safe defaults: `Read`, `Glob`, `Grep`, `WebSearch`, `Bash(room *)`,
+   `Bash(git status)`, `Bash(git log)`, `Bash(git diff)`
+
+Set `RALPH_ALLOWED_TOOLS=none` (or `--allow-tools none`) to disable tool
+restrictions entirely and let claude use all available tools.
+
 ## Context exhaustion
 
 room-ralph monitors token usage after each claude invocation. When input tokens
@@ -91,10 +118,8 @@ exceed 80% of the context limit (default 200k), it:
 2. Announces the restart in the room
 3. Spawns a fresh claude instance with the progress file included in the prompt
 
-The threshold and limit can be tuned via environment variables:
-
-- `CONTEXT_LIMIT` — total context window size (default: `200000`)
-- `CONTEXT_THRESHOLD` — percentage at which to restart (default: `80`)
+The threshold and limit can be tuned via `CONTEXT_LIMIT` and `CONTEXT_THRESHOLD`
+environment variables (see [Environment variables](#environment-variables) above).
 
 ## Progress files
 


### PR DESCRIPTION
## Summary

- Add "Environment variables" section to `crates/room-ralph/README.md` documenting `RALPH_ROOM`, `RALPH_USERNAME`, `RALPH_MODEL`, `RALPH_ISSUE`, `RALPH_ALLOWED_TOOLS`, `CONTEXT_LIMIT`, `CONTEXT_THRESHOLD`
- Add "Tool precedence" subsection explaining CLI > env > defaults resolution order and listing the safe default tool set
- De-duplicate `CONTEXT_LIMIT`/`CONTEXT_THRESHOLD` docs from the "Context exhaustion" section (now cross-references the env vars table)
- Fill `[Unreleased]` section in `crates/room-ralph/CHANGELOG.md` with env var config (#222) and default tool set (#221)

## Test plan

- [x] Docs-only change, no code modifications
- [x] `bash scripts/pre-push.sh` passes (all 456 tests green)
