### PR TITLE
fix(tui): remove kicked users from member panel (#235)

### DIFF
--- a/crates/room-cli/src/tui/input.rs
+++ b/crates/room-cli/src/tui/input.rs
@@ -543,6 +543,19 @@ pub(super) fn parse_status_broadcast(content: &str) -> Option<(String, String)> 
     None
 }
 
+/// Parse a `/kick` system broadcast into the kicked username.
+///
+/// The broker broadcasts `"alice kicked bob (token invalidated)"`.
+/// Returns `Some("bob")` — the target user who was kicked.
+pub(super) fn parse_kick_broadcast(content: &str) -> Option<&str> {
+    let rest = content.strip_suffix(" (token invalidated)")?;
+    let (_issuer, target) = rest.split_once(" kicked ")?;
+    if target.is_empty() {
+        return None;
+    }
+    Some(target)
+}
+
 /// Move the cursor to the start of the previous word.
 ///
 /// "Word" is a maximal run of non-whitespace characters. Starting from
@@ -694,6 +707,37 @@ mod tests {
             result,
             Some(("my-agent".to_owned(), "reviewing PR".to_owned()))
         );
+    }
+
+    // ── parse_kick_broadcast tests ──────────────────────────────────────────
+
+    #[test]
+    fn parse_kick_standard() {
+        let result = parse_kick_broadcast("alice kicked bob (token invalidated)");
+        assert_eq!(result, Some("bob"));
+    }
+
+    #[test]
+    fn parse_kick_hyphenated_names() {
+        let result = parse_kick_broadcast("room-host kicked my-agent (token invalidated)");
+        assert_eq!(result, Some("my-agent"));
+    }
+
+    #[test]
+    fn parse_kick_unrelated_message() {
+        assert!(parse_kick_broadcast("alice set status: busy").is_none());
+        assert!(parse_kick_broadcast("hello world").is_none());
+        assert!(parse_kick_broadcast("alice cleared their status").is_none());
+    }
+
+    #[test]
+    fn parse_kick_missing_suffix() {
+        assert!(parse_kick_broadcast("alice kicked bob").is_none());
+    }
+
+    #[test]
+    fn parse_kick_missing_target() {
+        assert!(parse_kick_broadcast("alice kicked  (token invalidated)").is_none());
     }
 
     // ── build_payload tests ───────────────────────────────────────────────────

--- a/crates/room-cli/src/tui/mod.rs
+++ b/crates/room-cli/src/tui/mod.rs
@@ -24,7 +24,7 @@ mod widgets;
 
 use crate::message::Message;
 use input::{
-    build_payload, cursor_display_pos, handle_key, parse_status_broadcast,
+    build_payload, cursor_display_pos, handle_key, parse_kick_broadcast, parse_status_broadcast,
     seed_online_users_from_who, wrap_input_display, Action, InputState,
 };
 use render::{assign_color, find_view_start, format_message, user_color, welcome_splash, ColorMap};
@@ -143,6 +143,10 @@ pub async fn run(
                             );
                             if let Some((name, status)) = parse_status_broadcast(content) {
                                 user_statuses.insert(name, status);
+                            }
+                            if let Some(kicked) = parse_kick_broadcast(content) {
+                                online_users.retain(|u| u != kicked);
+                                user_statuses.remove(kicked);
                             }
                             for u in &online_users {
                                 assign_color(u, &mut color_map);
@@ -524,6 +528,10 @@ pub async fn run(
                             );
                             if let Some((name, status)) = parse_status_broadcast(content) {
                                 user_statuses.insert(name, status);
+                            }
+                            if let Some(kicked) = parse_kick_broadcast(content) {
+                                online_users.retain(|u| u != kicked);
+                                user_statuses.remove(kicked);
                             }
                             for u in &online_users {
                                 assign_color(u, &mut color_map);


### PR DESCRIPTION
## Summary

- Add `parse_kick_broadcast()` helper in `tui/input.rs` to extract the kicked username from the broker's system message (`"{issuer} kicked {target} (token invalidated)"`)
- Wire it into both message drain loops in `tui/mod.rs` — when a kick broadcast arrives, the kicked user is removed from `online_users` (member panel + @autocomplete) and `user_statuses`
- 5 new unit tests for the parser (standard, hyphenated names, unrelated messages, missing suffix, missing target)

## Files modified

- `crates/room-cli/src/tui/input.rs` — new `parse_kick_broadcast()` function + 5 tests
- `crates/room-cli/src/tui/mod.rs` — import + call in both drain loops

## Test plan

- [x] `parse_kick_broadcast` returns kicked username for standard format
- [x] `parse_kick_broadcast` handles hyphenated usernames
- [x] `parse_kick_broadcast` returns None for unrelated system messages
- [x] `parse_kick_broadcast` returns None when suffix is missing
- [x] `parse_kick_broadcast` returns None when target is empty
- [x] Full test suite: 461 tests pass (456 → 461)

Closes #235