### PR TITLE
docs: require descriptive context in status messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,16 +245,28 @@ room send myroom -t $TOKEN "opening PR for #42"
   Violations: if ba or joao sends "hold" at any point, **stop immediately**. Do not
   continue implementation. Wait for explicit go-ahead before resuming.
 - **Update your status at every milestone** using `/set_status`. This is mandatory — it
-  lets the host and other agents see what you are doing at a glance. Use short, descriptive
-  text:
+  lets the host and other agents see what you are doing at a glance. Status text must
+  include **what you are doing and the specific context** (file, feature, PR, issue).
+  A phase word alone is not enough.
+
+  Good (descriptive — tells the host exactly what is happening):
   ```
-  /set_status reading src/broker.rs
-  /set_status drafting Foo handler
-  /set_status running tests
-  /set_status fixing clippy
-  /set_status PR #42 open, awaiting review
-  /set_status blocked on #38
+  /set_status reading src/broker.rs for #42
+  /set_status drafting kick broadcast parser in tui/input.rs
+  /set_status running cargo test — 456 expected
+  /set_status fixing clippy warning in oneshot/who.rs
+  /set_status PR #236 open — remove kicked users from member panel
+  /set_status blocked on #38 — need schema decision
   ```
+
+  Bad (vague — forces the host to ask what you are doing):
+  ```
+  /set_status working
+  /set_status reading
+  /set_status testing
+  /set_status busy
+  ```
+
   Update whenever your activity changes. Stale statuses are worse than no status.
 - **Poll and send a milestone update at natural breakpoints:**
   - After reading the target file (before writing any code)

--- a/docs/ralph-setup.md
+++ b/docs/ralph-setup.md
@@ -100,16 +100,20 @@ statuses make coordination harder.
 
 ### Required status updates
 
-| Phase | Status text |
-|---|---|
-| Starting work | `reading issue` or `reading <file>` |
-| Drafting code | `drafting <description>` |
-| Running tests | `running tests` |
-| Fixing CI | `fixing clippy` / `fixing tests` |
-| PR open | `PR #N open, awaiting review` |
-| Blocked | `blocked on <reason>` |
-| Done | `done — PR #N merged` |
-| Idle | *(clear status with `/set_status`)* |
+Status text must include **what you are doing and the specific context** (file, feature,
+PR, issue number). A phase word alone (`working`, `reading`, `testing`) is not useful —
+the host needs to know what is happening at a glance.
+
+| Phase | Good status | Bad status |
+|---|---|---|
+| Starting work | `reading src/broker.rs for #42` | `reading` |
+| Drafting code | `drafting kick parser in tui/input.rs` | `working` |
+| Running tests | `running cargo test — 461 expected` | `testing` |
+| Fixing CI | `fixing clippy in oneshot/who.rs` | `fixing` |
+| PR open | `PR #236 open — kicked users fix` | `PR open` |
+| Blocked | `blocked on #38 — need schema decision` | `blocked` |
+| Done | `done — PR #236 merged` | `done` |
+| Idle | *(clear status with `/set_status`)* | |
 
 ### How to set status
 


### PR DESCRIPTION
## Summary

- Update CLAUDE.md `/set_status` convention to require descriptive context (file, feature, PR, issue) instead of vague phase words
- Add explicit good/bad examples showing the difference between useful (`reading src/broker.rs for #42`) and useless (`reading`) status messages
- Update docs/ralph-setup.md status table with matching good/bad columns

Addresses joao's feedback (agent-room-2 seq 51) that status messages like "working" don't tell the host what's actually happening.

## Test plan

- [x] Docs-only change, no code modifications
- [x] `bash scripts/pre-push.sh` passes (all 461 tests green)
