### PR TITLE
docs: pre-release changelog and README updates

### DIFF
--- a/crates/room-cli/CHANGELOG.md
+++ b/crates/room-cli/CHANGELOG.md
@@ -10,6 +10,10 @@ For changes prior to the workspace restructure (v0.1.2 through v1.0.2), see the
 
 ## [Unreleased]
 
+### Fixed
+
+- TUI: kicked users are now removed from the member status panel and @-mention autocomplete when the broker broadcasts a kick message. (#236)
+
 ## [2.1.0-rc.1] - 2026-03-07
 
 ### Added

--- a/crates/room-ralph/CHANGELOG.md
+++ b/crates/room-ralph/CHANGELOG.md
@@ -7,6 +7,19 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `--disallow-tools <tools>` flag and `RALPH_DISALLOWED_TOOLS` environment variable for
+  hard-blocking tools from the claude session (passed as `--disallowedTools`). Supports
+  granular patterns like `Bash(python3:*)`. Empty by default. (#242)
+- Automatic `/set_status` updates at loop milestones: before claude spawn, on context
+  restart, on claude error, and on shutdown. Handles #234 EOF gracefully. (#243)
+
+### Fixed
+
+- Strip `CLAUDECODE` and `CLAUDE_CODE_ENTRY_POINT` environment variables from the child
+  claude process to prevent the nested-session guard from blocking startup. (#239)
+
 ## [0.3.0-rc.1] - 2026-03-07
 
 ### Added

--- a/crates/room-ralph/README.md
+++ b/crates/room-ralph/README.md
@@ -57,6 +57,9 @@ room-ralph myroom agent1 --tmux
 # Restrict which tools claude can use
 room-ralph myroom agent1 --allow-tools Read,Grep,Glob,Bash
 
+# Block specific tools (hard restriction — agent cannot use them at all)
+room-ralph myroom agent1 --disallow-tools Write,Edit
+
 # Preview the prompt without running claude
 room-ralph myroom agent1 --dry-run
 
@@ -79,6 +82,7 @@ room-ralph myroom agent1 --model sonnet --add-dir ../shared-lib --add-dir ../doc
 | `--personality <file>` | — | Personality file; contents prepended before all prompt content |
 | `--add-dir <path>` | — | Additional directories for `claude --add-dir` (repeatable) |
 | `--allow-tools <tools>` | — | Comma-separated tool allow list (passed as `--allowedTools` to claude) |
+| `--disallow-tools <tools>` | — | Comma-separated tool deny list (passed as `--disallowedTools` to claude). Supports granular patterns like `Bash(python3:*)`. |
 | `--dry-run` | off | Print the prompt that would be sent, then exit |
 | `-v` / `-V` / `--version` | — | Print version |
 
@@ -94,6 +98,7 @@ CLI flags take precedence over environment variables.
 | `RALPH_MODEL` | `--model` | Claude model to use (default: `opus`) |
 | `RALPH_ISSUE` | `--issue` | GitHub issue number |
 | `RALPH_ALLOWED_TOOLS` | `--allow-tools` | Comma-separated tool allow list (see below) |
+| `RALPH_DISALLOWED_TOOLS` | `--disallow-tools` | Comma-separated tool deny list (see below) |
 | `CONTEXT_LIMIT` | — | Total context window size (default: `200000`) |
 | `CONTEXT_THRESHOLD` | — | Percentage at which to restart (default: `80`) |
 
@@ -108,6 +113,19 @@ Allowed tools are resolved in this order:
 
 Set `RALPH_ALLOWED_TOOLS=none` (or `--allow-tools none`) to disable tool
 restrictions entirely and let claude use all available tools.
+
+### Tool deny list
+
+Disallowed tools are resolved with the same precedence:
+
+1. `--disallow-tools` CLI flag (highest)
+2. `RALPH_DISALLOWED_TOOLS` environment variable
+3. Defaults: empty (no tools blocked)
+
+Disallowed tools are hard-blocked — they are removed from the session entirely,
+regardless of what `--allow-tools` permits. Supports granular patterns like
+`Bash(python3:*)` to block specific commands while keeping the tool available for
+other uses.
 
 ## Context exhaustion
 

--- a/docs/ralph-setup.md
+++ b/docs/ralph-setup.md
@@ -25,6 +25,19 @@ Configure it via `.claude/settings.json` in the project directory:
   (`Read`) and parameterized patterns (`Bash(cargo test)`).
 - **`deny`** — tool patterns that are always blocked, even if listed in `allow`.
 
+Ralph also supports `--disallow-tools` (or `RALPH_DISALLOWED_TOOLS` env var) for
+hard-blocking specific tools from the session. Unlike `--allow-tools` which controls
+auto-approval, `--disallow-tools` removes tools entirely — the agent cannot use them
+even if prompted. Supports granular patterns like `Bash(python3:*)`.
+
+```bash
+# Block Write and Edit — agent can read but not modify files
+room-ralph myroom reviewer --disallow-tools Write,Edit
+
+# Block specific shell commands while keeping Bash available
+room-ralph myroom agent1 --disallow-tools "Bash(rm:*),Bash(curl:*)"
+```
+
 For fully autonomous operation (e.g. CI pipelines), ralph passes
 `--dangerously-skip-permissions` to the claude subprocess. Do not use this for untrusted
 workloads — it grants the agent unrestricted access to all tools including file writes,


### PR DESCRIPTION
## Summary

- Add changelog entry in `crates/room-cli/CHANGELOG.md` for #236 (kicked users removed from TUI member panel)
- Add changelog entries in `crates/room-ralph/CHANGELOG.md` for #239 (CLAUDECODE env strip), #242 (--disallow-tools flag), #243 (auto-status at loop milestones)
- Add `--disallow-tools` flag and `RALPH_DISALLOWED_TOOLS` env var to `crates/room-ralph/README.md` (Options table + Environment variables table + tool deny list section)
- Document `--disallow-tools` in `docs/ralph-setup.md` permissions section with usage examples

## Test plan

- [x] No code changes — docs only
- [x] All 476 Rust tests pass (pre-push.sh clean)
