### PR TITLE
docs(claude): shell constraints apply to interactive sessions only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,10 @@ room send myroom -t $TOKEN "fix pushed"
 
 ## Shell environment constraints
 
+> **Note:** These restrictions apply to **interactive Claude Code sessions only**.
+> Agents spawned via room-ralph (`claude -p`) run non-interactively and do not
+> trigger permission prompts, so heredocs, `$()`, and env expansion are fine there.
+
 Claude Code's Bash tool triggers permission prompts on certain shell patterns. Avoid these
 to keep the workflow smooth:
 


### PR DESCRIPTION
## Summary

- Add note to CLAUDE.md shell environment constraints section clarifying these apply to interactive Claude Code sessions only
- Ralph-spawned agents (`claude -p`) run non-interactively and don't trigger permission prompts

Per joao's note at room seq 121 and BA's confirmation at seq 123.

## Test plan

- [x] Docs-only change