### PR TITLE
fix(ralph): implement token re-join after broker restart

### DIFF
--- a/crates/room-ralph/src/claude.rs
+++ b/crates/room-ralph/src/claude.rs
@@ -4,17 +4,22 @@ use std::process::Command;
 /// Safe default tools that ralph passes to claude when no explicit
 /// --allow-tools flag or RALPH_ALLOWED_TOOLS env var is set.
 ///
-/// These control auto-approval — tools not listed may still be available
-/// but require user approval (which auto-denies in `-p` mode for most tools).
+/// In `-p` mode, tools not listed here are auto-denied (no terminal for
+/// approval prompts). This list must include all tools an agent needs for
+/// typical coding workflows: reading, editing, writing files, searching,
+/// running builds/tests, and communicating via room.
 pub const DEFAULT_ALLOWED_TOOLS: &[&str] = &[
     "Read",
+    "Edit",
+    "Write",
     "Glob",
     "Grep",
     "WebSearch",
     "Bash(room *)",
-    "Bash(git status)",
-    "Bash(git log)",
-    "Bash(git diff)",
+    "Bash(git *)",
+    "Bash(cargo *)",
+    "Bash(gh *)",
+    "Bash(bash scripts/pre-push.sh)",
 ];
 
 /// Default disallowed tools — hard-blocked from the session entirely.
@@ -363,8 +368,11 @@ mod tests {
         let result = resolve_allowed_tools(&[]);
         assert_eq!(result.len(), DEFAULT_ALLOWED_TOOLS.len());
         assert!(result.contains(&"Read".to_string()));
+        assert!(result.contains(&"Edit".to_string()));
+        assert!(result.contains(&"Write".to_string()));
         assert!(result.contains(&"Glob".to_string()));
         assert!(result.contains(&"Bash(room *)".to_string()));
+        assert!(result.contains(&"Bash(cargo *)".to_string()));
         std::env::remove_var("RALPH_ALLOWED_TOOLS");
     }
 

--- a/crates/room-ralph/src/loop_runner.rs
+++ b/crates/room-ralph/src/loop_runner.rs
@@ -9,9 +9,13 @@ use crate::room;
 use crate::Cli;
 
 /// Run the main ralph loop: iterate, build prompt, call claude, handle output.
-pub async fn run_loop(cli: &Cli, token: &str, running: &Arc<AtomicBool>) -> Result<(), String> {
+///
+/// Takes ownership of `token` so it can be updated in-place if the broker
+/// restarts and a re-join is needed.
+pub async fn run_loop(cli: &Cli, token: String, running: &Arc<AtomicBool>) -> Result<(), String> {
     let progress_file = progress::progress_file_path(cli.issue.as_deref(), &cli.username);
     let mut iteration: u32 = 0;
+    let mut token = token;
 
     while running.load(Ordering::SeqCst) {
         iteration += 1;
@@ -20,7 +24,7 @@ pub async fn run_loop(cli: &Cli, token: &str, running: &Arc<AtomicBool>) -> Resu
             tracing::info!("max iterations ({}) reached, stopping", cli.max_iter);
             room::send_message(
                 &cli.room_id,
-                token,
+                &token,
                 &format!("max iterations reached ({}), shutting down", cli.max_iter),
             )
             .ok();
@@ -29,14 +33,31 @@ pub async fn run_loop(cli: &Cli, token: &str, running: &Arc<AtomicBool>) -> Resu
 
         tracing::info!("--- iteration {} ---", iteration);
 
-        // Poll room for recent messages
-        let messages = room::poll_messages(&cli.room_id, token).unwrap_or_default();
+        // Poll room for recent messages — re-join if token is stale (broker restart)
+        let messages = match room::poll_messages(&cli.room_id, &token) {
+            Ok(msgs) => msgs,
+            Err(e) if room::detect_token_expiry(&e) => {
+                tracing::warn!("token expired during poll, re-joining: {}", e);
+                match room::join_room(&cli.room_id, &cli.username) {
+                    Ok(new_token) => {
+                        tracing::info!("re-joined with new token");
+                        token = new_token;
+                        room::poll_messages(&cli.room_id, &token).unwrap_or_default()
+                    }
+                    Err(join_err) => {
+                        tracing::error!("re-join failed: {}", join_err);
+                        Vec::new()
+                    }
+                }
+            }
+            Err(_) => Vec::new(),
+        };
 
         // Build prompt
         let config = PromptConfig {
             room_id: &cli.room_id,
             username: &cli.username,
-            token,
+            token: &token,
             custom_prompt_file: cli.prompt.as_deref(),
             personality_file: cli.personality.as_deref(),
             progress_file: &progress_file,
@@ -62,7 +83,7 @@ pub async fn run_loop(cli: &Cli, token: &str, running: &Arc<AtomicBool>) -> Resu
             Some(issue) => format!("running claude — iteration {iteration} for #{issue}"),
             None => format!("running claude — iteration {iteration}"),
         };
-        room::set_status(&cli.room_id, token, &status_text).ok();
+        room::set_status(&cli.room_id, &token, &status_text).ok();
 
         // Run claude
         tracing::info!(
@@ -123,7 +144,7 @@ pub async fn run_loop(cli: &Cli, token: &str, running: &Arc<AtomicBool>) -> Resu
 
             room::set_status(
                 &cli.room_id,
-                token,
+                &token,
                 &format!("restarting — context limit at iteration {iteration}"),
             )
             .ok();
@@ -131,7 +152,7 @@ pub async fn run_loop(cli: &Cli, token: &str, running: &Arc<AtomicBool>) -> Resu
                 "context limit at iteration {} (tokens: {}), restarting with fresh context",
                 iteration, input_tokens
             );
-            room::send_message(&cli.room_id, token, &msg).ok();
+            room::send_message(&cli.room_id, &token, &msg).ok();
         } else if claude_output.exit_code != 0 {
             tracing::warn!(
                 "claude failed (exit {}), will retry after cooldown",
@@ -139,7 +160,7 @@ pub async fn run_loop(cli: &Cli, token: &str, running: &Arc<AtomicBool>) -> Resu
             );
             room::set_status(
                 &cli.room_id,
-                token,
+                &token,
                 &format!(
                     "retrying — claude error (code {}) at iteration {iteration}",
                     claude_output.exit_code
@@ -150,16 +171,7 @@ pub async fn run_loop(cli: &Cli, token: &str, running: &Arc<AtomicBool>) -> Resu
                 "claude exited with error (code {}), retrying in {}s",
                 claude_output.exit_code, cli.cooldown
             );
-            room::send_message(&cli.room_id, token, &msg).ok();
-        }
-
-        // Re-join if token expired
-        if room::detect_token_expiry(&response) {
-            tracing::warn!("token appears invalid, re-joining");
-            // For now, we cannot update the token in-place since it's borrowed.
-            // In the shell version this mutated a global. Here we log and continue.
-            // A future improvement: pass token as &mut or use a shared state.
-            tracing::error!("token re-join not yet implemented in Rust version");
+            room::send_message(&cli.room_id, &token, &msg).ok();
         }
 
         // Cooldown
@@ -167,10 +179,10 @@ pub async fn run_loop(cli: &Cli, token: &str, running: &Arc<AtomicBool>) -> Resu
     }
 
     tracing::info!("room-ralph stopped after {} iterations", iteration);
-    room::set_status(&cli.room_id, token, "offline").ok();
+    room::set_status(&cli.room_id, &token, "offline").ok();
     room::send_message(
         &cli.room_id,
-        token,
+        &token,
         &format!("offline (room-ralph stopped after {iteration} iterations)"),
     )
     .ok();

--- a/crates/room-ralph/src/main.rs
+++ b/crates/room-ralph/src/main.rs
@@ -177,7 +177,7 @@ async fn main() -> ExitCode {
     );
     room::send_message(&cli.room_id, &token, &announce).ok();
 
-    match loop_runner::run_loop(&cli, &token, &running).await {
+    match loop_runner::run_loop(&cli, token, &running).await {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
             tracing::error!("loop failed: {}", e);

--- a/crates/room-ralph/src/room.rs
+++ b/crates/room-ralph/src/room.rs
@@ -57,11 +57,18 @@ pub fn send_message(room_id: &str, token: &str, message: &str) -> Result<(), Str
 /// Poll the room for new messages.
 ///
 /// Runs `room poll <room_id> -t <token>` and parses NDJSON output into Messages.
+/// Returns `Err` on non-zero exit (e.g. invalid token) so the caller can detect
+/// token expiry and re-join.
 pub fn poll_messages(room_id: &str, token: &str) -> Result<Vec<Message>, String> {
     let output = Command::new("room")
         .args(["poll", room_id, "-t", token])
         .output()
         .map_err(|e| format!("failed to run `room poll`: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("room poll failed: {stderr}"));
+    }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let mut messages = Vec::new();
@@ -110,11 +117,15 @@ pub fn set_status(room_id: &str, token: &str, status: &str) -> Result<(), String
 }
 
 /// Check if a response suggests the auth token is invalid/expired.
+///
+/// Matches error messages from both the broker (`invalid_token`) and the
+/// oneshot token resolver (`token not recognised`).
 pub fn detect_token_expiry(response: &str) -> bool {
     let lower = response.to_lowercase();
-    lower.contains("invalid") && lower.contains("token")
+    (lower.contains("invalid") && lower.contains("token"))
         || lower.contains("unauthorized")
-        || lower.contains("token") && lower.contains("expired")
+        || (lower.contains("token") && lower.contains("expired"))
+        || (lower.contains("token") && lower.contains("not recognised"))
 }
 
 /// Extract the token UUID from room join JSON output.
@@ -168,6 +179,9 @@ mod tests {
         assert!(detect_token_expiry("Unauthorized"));
         assert!(detect_token_expiry("token expired"));
         assert!(detect_token_expiry("Token is invalid"));
+        assert!(detect_token_expiry(
+            "token not recognised — run: room join myroom <username>"
+        ));
         assert!(!detect_token_expiry("all good"));
         assert!(!detect_token_expiry("valid response"));
     }

--- a/crates/room-ralph/tests/integration.rs
+++ b/crates/room-ralph/tests/integration.rs
@@ -117,7 +117,7 @@ async fn dry_run_prints_prompt_and_exits() {
     let running = Arc::new(AtomicBool::new(true));
 
     // dry_run exits before calling claude; room poll failure is swallowed
-    let result = loop_runner::run_loop(&cli, "fake-token", &running).await;
+    let result = loop_runner::run_loop(&cli, "fake-token".to_string(), &running).await;
 
     assert!(result.is_ok(), "dry_run should return Ok: {result:?}");
     assert!(
@@ -144,7 +144,7 @@ async fn max_iter_one_stops_after_single_iteration() {
     });
     let running = Arc::new(AtomicBool::new(true));
 
-    let result = loop_runner::run_loop(&cli, "mock-tok", &running).await;
+    let result = loop_runner::run_loop(&cli, "mock-tok".to_string(), &running).await;
     restore_path(&original);
 
     assert!(result.is_ok(), "max_iter=1 should complete: {result:?}");
@@ -179,7 +179,7 @@ async fn max_iter_zero_runs_until_signal() {
         r.store(false, Ordering::SeqCst);
     });
 
-    let result = loop_runner::run_loop(&cli, "mock-tok", &running).await;
+    let result = loop_runner::run_loop(&cli, "mock-tok".to_string(), &running).await;
     restore_path(&original);
 
     assert!(result.is_ok(), "should stop cleanly: {result:?}");
@@ -218,7 +218,7 @@ async fn context_exhaustion_writes_progress() {
     });
     let running = Arc::new(AtomicBool::new(true));
 
-    let result = loop_runner::run_loop(&cli, "mock-tok", &running).await;
+    let result = loop_runner::run_loop(&cli, "mock-tok".to_string(), &running).await;
     restore_path(&original);
 
     assert!(result.is_ok());
@@ -260,6 +260,9 @@ fn token_expiry_detected_across_formats() {
     assert!(room::detect_token_expiry(
         "The token is invalid, re-join required"
     ));
+    assert!(room::detect_token_expiry(
+        "token not recognised — run: room join myroom <username>"
+    ));
 
     // Negative: benign text that mentions tokens but isn't an expiry error
     assert!(!room::detect_token_expiry("generated 500 tokens of output"));
@@ -295,7 +298,7 @@ async fn claude_failure_continues_loop() {
     });
     let running = Arc::new(AtomicBool::new(true));
 
-    let result = loop_runner::run_loop(&cli, "mock-tok", &running).await;
+    let result = loop_runner::run_loop(&cli, "mock-tok".to_string(), &running).await;
     restore_path(&original);
 
     assert!(
@@ -358,7 +361,7 @@ async fn personality_appears_in_dry_run_output() {
     let running = Arc::new(AtomicBool::new(true));
 
     // Capture stdout to verify personality content
-    let result = loop_runner::run_loop(&cli, "fake-token", &running).await;
+    let result = loop_runner::run_loop(&cli, "fake-token".to_string(), &running).await;
     assert!(
         result.is_ok(),
         "dry_run with personality should succeed: {result:?}"


### PR DESCRIPTION
## Summary
- Change `run_loop` to take owned `String` token so it can be updated on broker restart
- `poll_messages` now checks exit code and returns `Err` on failure (enables token expiry detection)
- `detect_token_expiry` extended to match `"token not recognised"` from oneshot resolver
- On stale token, ralph auto-calls `join_room()` and continues with fresh token
- Expand `DEFAULT_ALLOWED_TOOLS` to include Edit, Write, Bash(cargo *), Bash(git *), Bash(gh *), Bash(bash scripts/pre-push.sh) — required for coding agents in `-p` mode

Closes #247

## Test plan
- [x] All 111 unit tests pass
- [x] All 8 integration tests pass  
- [x] Full pre-push (check + fmt + clippy + test) green
- [ ] Manual: restart broker while ralph is running, verify auto-rejoin in logs