### PR TITLE
fix(broker): echo system message to oneshot callers for set_status

### DIFF
--- a/crates/room-cli/src/broker/commands.rs
+++ b/crates/room-cli/src/broker/commands.rs
@@ -13,6 +13,13 @@ pub(crate) const ADMIN_CMD_NAMES: &[&str] = &["kick", "reauth", "clear-tokens", 
 pub(crate) enum CommandResult {
     /// The command was fully handled with a broadcast or no-op; nothing to send back privately.
     Handled,
+    /// The command was handled with a broadcast; oneshot callers should receive this JSON echo.
+    ///
+    /// Interactive clients already receive the message via the broadcast channel, so
+    /// `handle_client` treats this identically to `Handled`. One-shot senders are not
+    /// subscribed to the broadcast, so `handle_oneshot_send` writes the JSON back to them
+    /// directly, avoiding the EOF parse error the client would otherwise see.
+    HandledWithReply(String),
     /// The command was handled privately; send this JSON line back only to the issuer.
     Reply(String),
     /// The command was handled and the broker is shutting down.
@@ -55,9 +62,11 @@ pub(crate) async fn route_command(
             let sys = make_system(&state.room_id, "broker", display);
             broadcast_and_persist(&sys, &state.clients, &state.chat_path, &state.seq_counter)
                 .await?;
-            // Broadcast already delivers to all connected clients including the sender;
-            // no additional private reply needed.
-            return Ok(CommandResult::Handled);
+            // Broadcast already delivers to all interactive clients. One-shot callers are not
+            // subscribed to the broadcast channel, so we carry the JSON in HandledWithReply so
+            // handle_oneshot_send can write it back — preventing the EOF parse error.
+            let json = serde_json::to_string(&sys)?;
+            return Ok(CommandResult::HandledWithReply(json));
         }
 
         if cmd == "who" {
@@ -361,12 +370,22 @@ mod tests {
     // ── route_command: set_status ──────────────────────────────────────────
 
     #[tokio::test]
-    async fn route_command_set_status_returns_handled_and_updates_map() {
+    async fn route_command_set_status_returns_handled_with_reply_and_updates_map() {
         let tmp = NamedTempFile::new().unwrap();
         let state = make_state(tmp.path().to_path_buf());
         let msg = make_command("test-room", "alice", "set_status", vec!["busy".to_owned()]);
         let result = route_command(msg, "alice", &state).await.unwrap();
-        assert!(matches!(result, CommandResult::Handled));
+        let CommandResult::HandledWithReply(json) = result else {
+            panic!("expected HandledWithReply, got Handled or other");
+        };
+        assert!(
+            json.contains("set status"),
+            "reply JSON should contain status announcement"
+        );
+        assert!(
+            json.contains("busy"),
+            "reply JSON should contain the status text"
+        );
         assert_eq!(
             state
                 .status_map
@@ -389,7 +408,7 @@ mod tests {
             .insert("alice".to_owned(), "busy".to_owned());
         let msg = make_command("test-room", "alice", "set_status", vec![]);
         let result = route_command(msg, "alice", &state).await.unwrap();
-        assert!(matches!(result, CommandResult::Handled));
+        assert!(matches!(result, CommandResult::HandledWithReply(_)));
         assert_eq!(
             state
                 .status_map

--- a/crates/room-cli/src/broker/mod.rs
+++ b/crates/room-cli/src/broker/mod.rs
@@ -299,7 +299,7 @@ async fn handle_client(
                     }
                     match parse_client_line(trimmed, &room_id_in, &username_in) {
                         Ok(msg) => match route_command(msg, &username_in, &state_in).await {
-                            Ok(CommandResult::Handled) => {}
+                            Ok(CommandResult::Handled | CommandResult::HandledWithReply(_)) => {}
                             Ok(CommandResult::Reply(json)) => {
                                 let _ = write_half_in
                                     .lock()
@@ -380,7 +380,7 @@ async fn handle_oneshot_send(
     let msg = parse_client_line(trimmed, &state.room_id, &username)?;
     match route_command(msg, &username, state).await? {
         CommandResult::Handled | CommandResult::Shutdown => {}
-        CommandResult::Reply(json) => {
+        CommandResult::HandledWithReply(json) | CommandResult::Reply(json) => {
             write_half.write_all(format!("{json}\n").as_bytes()).await?;
         }
         CommandResult::Passthrough(msg) => {

--- a/crates/room-cli/src/broker/ws.rs
+++ b/crates/room-cli/src/broker/ws.rs
@@ -236,7 +236,7 @@ async fn run_ws_session(
                     }
                     match parse_client_line(trimmed, &room_id_in, &username_in) {
                         Ok(msg) => match route_command(msg, &username_in, &state_in).await {
-                            Ok(CommandResult::Handled) => {}
+                            Ok(CommandResult::Handled | CommandResult::HandledWithReply(_)) => {}
                             Ok(CommandResult::Reply(json)) => {
                                 let _ = ws_tx_in
                                     .lock()
@@ -349,7 +349,7 @@ async fn ws_oneshot_send(
     let msg = parse_client_line(trimmed, &state.room_id, &username)?;
     match route_command(msg, &username, state).await? {
         CommandResult::Handled | CommandResult::Shutdown => {}
-        CommandResult::Reply(json) => {
+        CommandResult::HandledWithReply(json) | CommandResult::Reply(json) => {
             let _ = ws_tx.send(WsMessage::Text(json.into())).await;
         }
         CommandResult::Passthrough(msg) => {
@@ -478,7 +478,7 @@ async fn api_send(
         Ok(CommandResult::Handled) => {
             (StatusCode::OK, Json(serde_json::json!({"type":"ok"}))).into_response()
         }
-        Ok(CommandResult::Reply(json)) => {
+        Ok(CommandResult::HandledWithReply(json) | CommandResult::Reply(json)) => {
             let v: serde_json::Value =
                 serde_json::from_str(&json).unwrap_or(serde_json::json!({"reply": json}));
             (StatusCode::OK, Json(v)).into_response()

--- a/crates/room-cli/tests/integration.rs
+++ b/crates/room-cli/tests/integration.rs
@@ -770,6 +770,46 @@ async fn set_status_broadcasts_system_message_to_all() {
     );
 }
 
+/// `send_message_with_token` with a `/set_status` command returns the system echo
+/// instead of producing an EOF error. Regression test for #234.
+#[tokio::test]
+async fn oneshot_set_status_returns_system_echo_not_eof() {
+    let broker = TestBroker::start("t_set_status_oneshot").await;
+
+    let mut watcher = TestClient::connect(&broker.socket_path, "watcher").await;
+    watcher
+        .recv_until(|m| matches!(m, Message::Join { user, .. } if user == "watcher"))
+        .await;
+
+    let (_, token) = room_cli::oneshot::join_session(&broker.socket_path, "agent")
+        .await
+        .expect("join_session failed");
+
+    let wire = serde_json::json!({
+        "type": "command",
+        "cmd": "set_status",
+        "params": ["drafting auth handler"]
+    })
+    .to_string();
+
+    // Before the fix this would fail with "EOF while parsing a value".
+    let msg = room_cli::oneshot::send_message_with_token(&broker.socket_path, &token, &wire)
+        .await
+        .expect("send_message_with_token should not return EOF for set_status");
+
+    assert!(
+        matches!(&msg, Message::System { content, .. } if content.contains("drafting auth handler")),
+        "expected System echo with status text, got: {msg:?}"
+    );
+
+    // The broadcast should also have reached the watcher.
+    watcher
+        .recv_until(|m| {
+            matches!(m, Message::System { content, .. } if content.contains("drafting auth handler"))
+        })
+        .await;
+}
+
 /// who responds only to the requesting client with the current online list.
 /// The response is a System message and is not broadcast to other clients.
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Adds `CommandResult::HandledWithReply(String)` to the `CommandResult` enum in `broker/commands.rs`. This variant signals that a command was fully handled with a broadcast, but carries a JSON payload for callers that are not subscribed to the broadcast channel (oneshot senders).
- Changes `route_command` for `set_status` to return `HandledWithReply` instead of `Handled`. The system message is broadcast to all interactive clients as before; the JSON is also returned so oneshot transports can write it back.
- Updates all `CommandResult` match sites in `broker/mod.rs` and `broker/ws.rs`: interactive handlers treat `HandledWithReply` identically to `Handled` (no duplicate delivery); oneshot handlers write the JSON back.
- Adds regression test `oneshot_set_status_returns_system_echo_not_eof` in `tests/integration.rs`.

## Root cause

`handle_oneshot_send` matched `CommandResult::Handled` and wrote nothing back to the socket. The oneshot transport (`send_message_with_token`) then called `read_line` on an empty stream, producing `EOF while parsing a value`. Interactive clients were unaffected because they receive broadcasts via their subscription channel; oneshot senders are never subscribed.

## Test plan

- [x] `cargo check` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — 477 tests pass (was 476; +1 regression test `oneshot_set_status_returns_system_echo_not_eof`)
- [x] Existing `set_status_broadcasts_system_message_to_all` test continues to pass — broadcast behaviour unchanged
- [x] New test verifies `send_message_with_token` with `/set_status` returns a `Message::System` echo instead of an EOF error

Closes #234
