### PR TITLE
feat(cli): typed command params with schema validation (#257)

### DIFF
--- a/crates/room-cli/src/broker/commands.rs
+++ b/crates/room-cli/src/broker/commands.rs
@@ -1,6 +1,9 @@
 use crate::{
     message::{make_system, Message},
-    plugin::{ChatWriter, CommandContext, HistoryReader, PluginResult, RoomMetadata},
+    plugin::{
+        ChatWriter, CommandContext, CommandInfo, HistoryReader, ParamType, PluginResult,
+        RoomMetadata,
+    },
 };
 
 use super::{fanout::broadcast_and_persist, state::RoomState};
@@ -129,6 +132,64 @@ pub(crate) async fn route_command(
     Ok(CommandResult::Passthrough(msg))
 }
 
+/// Validate `params` against a command's [`CommandInfo`] schema.
+///
+/// Returns `Ok(())` if all constraints pass, or `Err(message)` with a
+/// human-readable error suitable for sending back as a reply.
+///
+/// Validation rules:
+/// - Required params must be present (not blank).
+/// - `ParamType::Choice` values must be in the allowed set.
+/// - `ParamType::Number` values must parse as `i64` and respect min/max bounds.
+/// - `ParamType::Text` and `ParamType::Username` are accepted as-is (no
+///   server-side validation — username existence is not checked here).
+fn validate_params(params: &[String], schema: &CommandInfo) -> Result<(), String> {
+    for (i, ps) in schema.params.iter().enumerate() {
+        let value = params.get(i).map(String::as_str).unwrap_or("");
+        if ps.required && value.is_empty() {
+            return Err(format!(
+                "/{}: missing required parameter <{}>",
+                schema.name, ps.name
+            ));
+        }
+        if value.is_empty() {
+            continue;
+        }
+        match &ps.param_type {
+            ParamType::Choice(allowed) => {
+                if !allowed.iter().any(|a| a == value) {
+                    return Err(format!(
+                        "/{}: <{}> must be one of: {}",
+                        schema.name,
+                        ps.name,
+                        allowed.join(", ")
+                    ));
+                }
+            }
+            ParamType::Number { min, max } => {
+                let Ok(n) = value.parse::<i64>() else {
+                    return Err(format!(
+                        "/{}: <{}> must be a number, got '{}'",
+                        schema.name, ps.name, value
+                    ));
+                };
+                if let Some(lo) = min {
+                    if n < *lo {
+                        return Err(format!("/{}: <{}> must be >= {lo}", schema.name, ps.name));
+                    }
+                }
+                if let Some(hi) = max {
+                    if n > *hi {
+                        return Err(format!("/{}: <{}> must be <= {hi}", schema.name, ps.name));
+                    }
+                }
+            }
+            ParamType::Text | ParamType::Username => {}
+        }
+    }
+    Ok(())
+}
+
 /// Build a [`CommandContext`] and call a plugin's `handle` method, translating
 /// the [`PluginResult`] into a [`CommandResult`] the broker understands.
 async fn dispatch_plugin(
@@ -147,6 +208,20 @@ async fn dispatch_plugin(
         } => (cmd, params, id, ts),
         _ => return Ok(CommandResult::Passthrough(msg.clone())),
     };
+
+    // Schema validation — check params against the plugin's declared schema
+    // before invoking the handler.
+    if let Some(cmd_info) = plugin.commands().iter().find(|c| c.name == *cmd) {
+        if let Err(err_msg) = validate_params(params, cmd_info) {
+            let sys = make_system(
+                &state.room_id,
+                &format!("plugin:{}", plugin.name()),
+                err_msg,
+            );
+            let json = serde_json::to_string(&sys)?;
+            return Ok(CommandResult::Reply(json));
+        }
+    }
 
     let history = HistoryReader::new(&state.chat_path, username);
     let writer = ChatWriter::new(
@@ -584,5 +659,213 @@ mod tests {
             !contents.contains("some existing history"),
             "prior history must be gone after clear"
         );
+    }
+
+    // ── validate_params tests ─────────────────────────────────────────────
+
+    mod validation_tests {
+        use super::super::validate_params;
+        use crate::plugin::{CommandInfo, ParamSchema, ParamType};
+
+        fn cmd_with_params(params: Vec<ParamSchema>) -> CommandInfo {
+            CommandInfo {
+                name: "test".to_owned(),
+                description: "test".to_owned(),
+                usage: "/test".to_owned(),
+                params,
+            }
+        }
+
+        #[test]
+        fn validate_empty_schema_always_passes() {
+            let cmd = cmd_with_params(vec![]);
+            assert!(validate_params(&[], &cmd).is_ok());
+            assert!(validate_params(&["extra".to_owned()], &cmd).is_ok());
+        }
+
+        #[test]
+        fn validate_required_param_missing() {
+            let cmd = cmd_with_params(vec![ParamSchema {
+                name: "user".to_owned(),
+                param_type: ParamType::Text,
+                required: true,
+                description: "target user".to_owned(),
+            }]);
+            let err = validate_params(&[], &cmd).unwrap_err();
+            assert!(err.contains("missing required"));
+            assert!(err.contains("<user>"));
+        }
+
+        #[test]
+        fn validate_required_param_present() {
+            let cmd = cmd_with_params(vec![ParamSchema {
+                name: "user".to_owned(),
+                param_type: ParamType::Text,
+                required: true,
+                description: "target user".to_owned(),
+            }]);
+            assert!(validate_params(&["alice".to_owned()], &cmd).is_ok());
+        }
+
+        #[test]
+        fn validate_optional_param_missing_is_ok() {
+            let cmd = cmd_with_params(vec![ParamSchema {
+                name: "count".to_owned(),
+                param_type: ParamType::Number {
+                    min: None,
+                    max: None,
+                },
+                required: false,
+                description: "count".to_owned(),
+            }]);
+            assert!(validate_params(&[], &cmd).is_ok());
+        }
+
+        #[test]
+        fn validate_choice_valid_value() {
+            let cmd = cmd_with_params(vec![ParamSchema {
+                name: "color".to_owned(),
+                param_type: ParamType::Choice(vec!["red".to_owned(), "blue".to_owned()]),
+                required: true,
+                description: "pick a color".to_owned(),
+            }]);
+            assert!(validate_params(&["red".to_owned()], &cmd).is_ok());
+            assert!(validate_params(&["blue".to_owned()], &cmd).is_ok());
+        }
+
+        #[test]
+        fn validate_choice_invalid_value() {
+            let cmd = cmd_with_params(vec![ParamSchema {
+                name: "color".to_owned(),
+                param_type: ParamType::Choice(vec!["red".to_owned(), "blue".to_owned()]),
+                required: true,
+                description: "pick a color".to_owned(),
+            }]);
+            let err = validate_params(&["green".to_owned()], &cmd).unwrap_err();
+            assert!(err.contains("must be one of"));
+            assert!(err.contains("red"));
+            assert!(err.contains("blue"));
+        }
+
+        #[test]
+        fn validate_number_valid() {
+            let cmd = cmd_with_params(vec![ParamSchema {
+                name: "count".to_owned(),
+                param_type: ParamType::Number {
+                    min: Some(1),
+                    max: Some(100),
+                },
+                required: true,
+                description: "count".to_owned(),
+            }]);
+            assert!(validate_params(&["50".to_owned()], &cmd).is_ok());
+            assert!(validate_params(&["1".to_owned()], &cmd).is_ok());
+            assert!(validate_params(&["100".to_owned()], &cmd).is_ok());
+        }
+
+        #[test]
+        fn validate_number_not_a_number() {
+            let cmd = cmd_with_params(vec![ParamSchema {
+                name: "count".to_owned(),
+                param_type: ParamType::Number {
+                    min: None,
+                    max: None,
+                },
+                required: true,
+                description: "count".to_owned(),
+            }]);
+            let err = validate_params(&["abc".to_owned()], &cmd).unwrap_err();
+            assert!(err.contains("must be a number"));
+        }
+
+        #[test]
+        fn validate_number_below_min() {
+            let cmd = cmd_with_params(vec![ParamSchema {
+                name: "count".to_owned(),
+                param_type: ParamType::Number {
+                    min: Some(10),
+                    max: None,
+                },
+                required: true,
+                description: "count".to_owned(),
+            }]);
+            let err = validate_params(&["5".to_owned()], &cmd).unwrap_err();
+            assert!(err.contains("must be >= 10"));
+        }
+
+        #[test]
+        fn validate_number_above_max() {
+            let cmd = cmd_with_params(vec![ParamSchema {
+                name: "count".to_owned(),
+                param_type: ParamType::Number {
+                    min: None,
+                    max: Some(50),
+                },
+                required: true,
+                description: "count".to_owned(),
+            }]);
+            let err = validate_params(&["100".to_owned()], &cmd).unwrap_err();
+            assert!(err.contains("must be <= 50"));
+        }
+
+        #[test]
+        fn validate_text_always_passes() {
+            let cmd = cmd_with_params(vec![ParamSchema {
+                name: "msg".to_owned(),
+                param_type: ParamType::Text,
+                required: true,
+                description: "message".to_owned(),
+            }]);
+            assert!(validate_params(&["anything at all".to_owned()], &cmd).is_ok());
+        }
+
+        #[test]
+        fn validate_username_always_passes() {
+            let cmd = cmd_with_params(vec![ParamSchema {
+                name: "user".to_owned(),
+                param_type: ParamType::Username,
+                required: true,
+                description: "user".to_owned(),
+            }]);
+            assert!(validate_params(&["alice".to_owned()], &cmd).is_ok());
+        }
+
+        #[test]
+        fn validate_multiple_params() {
+            let cmd = cmd_with_params(vec![
+                ParamSchema {
+                    name: "user".to_owned(),
+                    param_type: ParamType::Username,
+                    required: true,
+                    description: "target".to_owned(),
+                },
+                ParamSchema {
+                    name: "count".to_owned(),
+                    param_type: ParamType::Number {
+                        min: Some(1),
+                        max: Some(100),
+                    },
+                    required: false,
+                    description: "count".to_owned(),
+                },
+            ]);
+            // Both present and valid
+            assert!(validate_params(&["alice".to_owned(), "50".to_owned()], &cmd).is_ok());
+            // First present, second omitted (optional)
+            assert!(validate_params(&["alice".to_owned()], &cmd).is_ok());
+            // First missing (required)
+            assert!(validate_params(&[], &cmd).is_err());
+        }
+
+        #[test]
+        fn validate_choice_optional_missing_is_ok() {
+            let cmd = cmd_with_params(vec![ParamSchema {
+                name: "level".to_owned(),
+                param_type: ParamType::Choice(vec!["low".to_owned(), "high".to_owned()]),
+                required: false,
+                description: "level".to_owned(),
+            }]);
+            assert!(validate_params(&[], &cmd).is_ok());
+        }
     }
 }

--- a/crates/room-cli/src/plugin/help.rs
+++ b/crates/room-cli/src/plugin/help.rs
@@ -1,4 +1,4 @@
-use super::{BoxFuture, CommandContext, CommandInfo, Plugin, PluginResult};
+use super::{BoxFuture, CommandContext, CommandInfo, ParamType, Plugin, PluginResult};
 
 /// Built-in `/help` plugin. Lists all available commands or shows details
 /// for a specific command. Dogfoods the plugin API — uses
@@ -16,7 +16,12 @@ impl Plugin for HelpPlugin {
             name: "help".to_owned(),
             description: "List available commands or get help for a specific command".to_owned(),
             usage: "/help [command]".to_owned(),
-            completions: vec![],
+            params: vec![super::ParamSchema {
+                name: "command".to_owned(),
+                param_type: ParamType::Text,
+                required: false,
+                description: "Command name to get help for".to_owned(),
+            }],
         }]
     }
 
@@ -25,29 +30,25 @@ impl Plugin for HelpPlugin {
             if let Some(target) = ctx.params.first() {
                 // Show help for a specific command
                 let target = target.strip_prefix('/').unwrap_or(target);
+
+                // Check plugin/available commands first
                 if let Some(cmd) = ctx.available_commands.iter().find(|c| c.name == target) {
-                    let text = format!("{}\n  {}", cmd.usage, cmd.description);
-                    return Ok(PluginResult::Reply(text));
+                    return Ok(PluginResult::Reply(format_command_help(cmd)));
                 }
                 // Also check built-in commands
-                let builtin = builtin_help(target);
-                if let Some(text) = builtin {
-                    return Ok(PluginResult::Reply(text));
+                let builtins = super::builtin_command_infos();
+                if let Some(cmd) = builtins.iter().find(|c| c.name == target) {
+                    return Ok(PluginResult::Reply(format_command_help(cmd)));
                 }
                 return Ok(PluginResult::Reply(format!("unknown command: /{target}")));
             }
 
             // List all commands: built-ins first, then plugins
-            let mut lines = vec![
-                "available commands:".to_owned(),
-                "  /who — show online users".to_owned(),
-                "  /set_status <status> — set your status".to_owned(),
-                "  /kick <user> — kick a user (host only)".to_owned(),
-                "  /reauth <user> — clear a user's token (host only)".to_owned(),
-                "  /clear-tokens — clear all tokens (host only)".to_owned(),
-                "  /clear — clear chat history (host only)".to_owned(),
-                "  /exit — shut down the room (host only)".to_owned(),
-            ];
+            let builtins = super::builtin_command_infos();
+            let mut lines = vec!["available commands:".to_owned()];
+            for cmd in &builtins {
+                lines.push(format!("  {} — {}", cmd.usage, cmd.description));
+            }
             for cmd in &ctx.available_commands {
                 lines.push(format!("  {} — {}", cmd.usage, cmd.description));
             }
@@ -57,31 +58,41 @@ impl Plugin for HelpPlugin {
     }
 }
 
-fn builtin_help(cmd: &str) -> Option<String> {
-    match cmd {
-        "who" => Some("/who\n  Show online users and their status".to_owned()),
-        "set_status" => {
-            Some("/set_status <status>\n  Set your status (visible in /who)".to_owned())
+/// Format detailed help for a single command, including typed parameter info.
+fn format_command_help(cmd: &CommandInfo) -> String {
+    let mut lines = vec![cmd.usage.clone(), format!("  {}", cmd.description)];
+    if !cmd.params.is_empty() {
+        lines.push("  parameters:".to_owned());
+        for p in &cmd.params {
+            let req = if p.required { "required" } else { "optional" };
+            let type_hint = match &p.param_type {
+                ParamType::Text => "text".to_owned(),
+                ParamType::Username => "username".to_owned(),
+                ParamType::Number { min, max } => match (min, max) {
+                    (Some(lo), Some(hi)) => format!("number ({lo}..{hi})"),
+                    (Some(lo), None) => format!("number ({lo}..)"),
+                    (None, Some(hi)) => format!("number (..{hi})"),
+                    (None, None) => "number".to_owned(),
+                },
+                ParamType::Choice(values) => {
+                    format!("one of: {}", values.join(", "))
+                }
+            };
+            lines.push(format!(
+                "    <{}> — {} [{}] {}",
+                p.name, p.description, req, type_hint
+            ));
         }
-        "kick" => Some(
-            "/kick <username>\n  Kick a user and invalidate their token (host only)".to_owned(),
-        ),
-        "reauth" => Some(
-            "/reauth <username>\n  Clear a user's token so they can rejoin (host only)".to_owned(),
-        ),
-        "clear-tokens" => {
-            Some("/clear-tokens\n  Clear all tokens; all users must rejoin (host only)".to_owned())
-        }
-        "clear" => Some("/clear\n  Truncate chat history (host only)".to_owned()),
-        "exit" => Some("/exit\n  Shut down the room (host only)".to_owned()),
-        _ => None,
     }
+    lines.join("\n")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::plugin::{ChatWriter, Completion, HistoryReader, RoomMetadata, UserInfo};
+    use crate::plugin::{
+        ChatWriter, HistoryReader, ParamSchema, ParamType, RoomMetadata, UserInfo,
+    };
     use chrono::Utc;
     use std::sync::{atomic::AtomicU64, Arc};
     use tempfile::NamedTempFile;
@@ -122,13 +133,13 @@ mod tests {
                 name: "stats".to_owned(),
                 description: "Show stats".to_owned(),
                 usage: "/stats [N]".to_owned(),
-                completions: vec![],
+                params: vec![],
             },
             CommandInfo {
                 name: "help".to_owned(),
                 description: "Show help".to_owned(),
                 usage: "/help [cmd]".to_owned(),
-                completions: vec![],
+                params: vec![],
             },
         ];
         let ctx = make_test_context(vec![], commands);
@@ -148,7 +159,7 @@ mod tests {
             name: "stats".to_owned(),
             description: "Show stats".to_owned(),
             usage: "/stats [N]".to_owned(),
-            completions: vec![],
+            params: vec![],
         }];
         let ctx = make_test_context(vec!["stats".to_owned()], commands);
         let result = HelpPlugin.handle(ctx).await.unwrap();
@@ -167,7 +178,7 @@ mod tests {
             panic!("expected Reply");
         };
         assert!(text.contains("/who"));
-        assert!(text.contains("Show online users"));
+        assert!(text.contains("List users in the room"));
     }
 
     #[tokio::test]
@@ -186,9 +197,14 @@ mod tests {
             name: "stats".to_owned(),
             description: "Show stats".to_owned(),
             usage: "/stats [N]".to_owned(),
-            completions: vec![Completion {
-                position: 0,
-                values: vec!["10".to_owned()],
+            params: vec![ParamSchema {
+                name: "count".to_owned(),
+                param_type: ParamType::Number {
+                    min: Some(1),
+                    max: None,
+                },
+                required: false,
+                description: "Number of messages".to_owned(),
             }],
         }];
         let ctx = make_test_context(vec!["/stats".to_owned()], commands);
@@ -200,5 +216,46 @@ mod tests {
             text.contains("/stats [N]"),
             "should find stats even with leading /"
         );
+    }
+
+    #[tokio::test]
+    async fn help_specific_command_shows_param_info() {
+        let commands = vec![CommandInfo {
+            name: "stats".to_owned(),
+            description: "Show stats".to_owned(),
+            usage: "/stats [N]".to_owned(),
+            params: vec![ParamSchema {
+                name: "count".to_owned(),
+                param_type: ParamType::Choice(vec![
+                    "10".to_owned(),
+                    "25".to_owned(),
+                    "50".to_owned(),
+                ]),
+                required: false,
+                description: "Number of messages".to_owned(),
+            }],
+        }];
+        let ctx = make_test_context(vec!["stats".to_owned()], commands);
+        let result = HelpPlugin.handle(ctx).await.unwrap();
+        let PluginResult::Reply(text) = result else {
+            panic!("expected Reply");
+        };
+        assert!(text.contains("parameters:"), "should show param section");
+        assert!(text.contains("<count>"), "should show param name");
+        assert!(text.contains("optional"), "should show required flag");
+        assert!(text.contains("one of:"), "should show choices");
+    }
+
+    #[tokio::test]
+    async fn help_builtin_command_shows_param_info() {
+        // /kick is a built-in with a Username param
+        let ctx = make_test_context(vec!["kick".to_owned()], vec![]);
+        let result = HelpPlugin.handle(ctx).await.unwrap();
+        let PluginResult::Reply(text) = result else {
+            panic!("expected Reply");
+        };
+        assert!(text.contains("parameters:"));
+        assert!(text.contains("username"));
+        assert!(text.contains("required"));
     }
 }

--- a/crates/room-cli/src/plugin/mod.rs
+++ b/crates/room-cli/src/plugin/mod.rs
@@ -60,17 +60,37 @@ pub struct CommandInfo {
     pub description: String,
     /// Usage string (e.g. `"/stats [last N]"`).
     pub usage: String,
-    /// Static argument completions for autocomplete.
-    pub completions: Vec<Completion>,
+    /// Typed parameter schemas for validation and autocomplete.
+    pub params: Vec<ParamSchema>,
 }
 
-/// A static autocomplete hint for a command argument.
+// ── Typed parameter schema ─────────────────────────────────────────────────
+
+/// Schema for a single command parameter — drives validation, `/help` output,
+/// and TUI argument autocomplete.
 #[derive(Debug, Clone)]
-pub struct Completion {
-    /// Argument position (0-indexed).
-    pub position: usize,
-    /// Possible values. Empty means freeform.
-    pub values: Vec<String>,
+pub struct ParamSchema {
+    /// Display name (e.g. `"username"`, `"count"`).
+    pub name: String,
+    /// What kind of value this parameter accepts.
+    pub param_type: ParamType,
+    /// Whether the parameter must be provided.
+    pub required: bool,
+    /// One-line description shown in `/help <command>`.
+    pub description: String,
+}
+
+/// The kind of value a parameter accepts.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ParamType {
+    /// Free-form text (no validation beyond presence).
+    Text,
+    /// One of a fixed set of allowed values.
+    Choice(Vec<String>),
+    /// An online username — TUI shows the mention picker.
+    Username,
+    /// An integer, optionally bounded.
+    Number { min: Option<i64>, max: Option<i64> },
 }
 
 // ── CommandContext ───────────────────────────────────────────────────────────
@@ -346,17 +366,19 @@ impl PluginRegistry {
         self.plugins.iter().flat_map(|p| p.commands()).collect()
     }
 
-    /// Static completions for a specific command at a given argument position.
+    /// Completions for a specific command at a given argument position,
+    /// derived from the parameter schema.
+    ///
+    /// Returns `Choice` values for `ParamType::Choice` parameters, or an
+    /// empty vec for freeform/username/number parameters.
     pub fn completions_for(&self, command: &str, arg_pos: usize) -> Vec<String> {
         self.all_commands()
             .iter()
             .find(|c| c.name == command)
-            .map(|c| {
-                c.completions
-                    .iter()
-                    .filter(|comp| comp.position == arg_pos)
-                    .flat_map(|comp| comp.values.clone())
-                    .collect()
+            .and_then(|c| c.params.get(arg_pos))
+            .map(|p| match &p.param_type {
+                ParamType::Choice(values) => values.clone(),
+                _ => vec![],
             })
             .unwrap_or_default()
     }
@@ -366,6 +388,133 @@ impl Default for PluginRegistry {
     fn default() -> Self {
         Self::new()
     }
+}
+
+// ── Built-in command schemas ───────────────────────────────────────────────
+
+/// Returns [`CommandInfo`] schemas for all built-in commands (those handled
+/// directly by the broker, not by plugins). Used by the TUI palette and
+/// `/help` to show a complete command list with typed parameter metadata.
+pub fn builtin_command_infos() -> Vec<CommandInfo> {
+    vec![
+        CommandInfo {
+            name: "dm".to_owned(),
+            description: "Send a private message".to_owned(),
+            usage: "/dm <user> <message>".to_owned(),
+            params: vec![
+                ParamSchema {
+                    name: "user".to_owned(),
+                    param_type: ParamType::Username,
+                    required: true,
+                    description: "Recipient username".to_owned(),
+                },
+                ParamSchema {
+                    name: "message".to_owned(),
+                    param_type: ParamType::Text,
+                    required: true,
+                    description: "Message content".to_owned(),
+                },
+            ],
+        },
+        CommandInfo {
+            name: "claim".to_owned(),
+            description: "Claim a task".to_owned(),
+            usage: "/claim <task>".to_owned(),
+            params: vec![ParamSchema {
+                name: "task".to_owned(),
+                param_type: ParamType::Text,
+                required: true,
+                description: "Task description".to_owned(),
+            }],
+        },
+        CommandInfo {
+            name: "reply".to_owned(),
+            description: "Reply to a message".to_owned(),
+            usage: "/reply <id> <message>".to_owned(),
+            params: vec![
+                ParamSchema {
+                    name: "id".to_owned(),
+                    param_type: ParamType::Text,
+                    required: true,
+                    description: "Message ID to reply to".to_owned(),
+                },
+                ParamSchema {
+                    name: "message".to_owned(),
+                    param_type: ParamType::Text,
+                    required: true,
+                    description: "Reply content".to_owned(),
+                },
+            ],
+        },
+        CommandInfo {
+            name: "set_status".to_owned(),
+            description: "Set your presence status".to_owned(),
+            usage: "/set_status <status>".to_owned(),
+            params: vec![ParamSchema {
+                name: "status".to_owned(),
+                param_type: ParamType::Text,
+                required: false,
+                description: "Status text (omit to clear)".to_owned(),
+            }],
+        },
+        CommandInfo {
+            name: "who".to_owned(),
+            description: "List users in the room".to_owned(),
+            usage: "/who".to_owned(),
+            params: vec![],
+        },
+        CommandInfo {
+            name: "kick".to_owned(),
+            description: "Kick a user from the room".to_owned(),
+            usage: "/kick <user>".to_owned(),
+            params: vec![ParamSchema {
+                name: "user".to_owned(),
+                param_type: ParamType::Username,
+                required: true,
+                description: "User to kick (host only)".to_owned(),
+            }],
+        },
+        CommandInfo {
+            name: "reauth".to_owned(),
+            description: "Invalidate a user's token".to_owned(),
+            usage: "/reauth <user>".to_owned(),
+            params: vec![ParamSchema {
+                name: "user".to_owned(),
+                param_type: ParamType::Username,
+                required: true,
+                description: "User to reauth (host only)".to_owned(),
+            }],
+        },
+        CommandInfo {
+            name: "clear-tokens".to_owned(),
+            description: "Revoke all session tokens".to_owned(),
+            usage: "/clear-tokens".to_owned(),
+            params: vec![],
+        },
+        CommandInfo {
+            name: "exit".to_owned(),
+            description: "Shut down the broker".to_owned(),
+            usage: "/exit".to_owned(),
+            params: vec![],
+        },
+        CommandInfo {
+            name: "clear".to_owned(),
+            description: "Clear the room history".to_owned(),
+            usage: "/clear".to_owned(),
+            params: vec![],
+        },
+    ]
+}
+
+/// Returns command schemas for all known commands: built-ins + default plugins.
+///
+/// Used by the TUI to build its command palette at startup without needing
+/// access to the broker's `PluginRegistry`.
+pub fn all_known_commands() -> Vec<CommandInfo> {
+    let mut cmds = builtin_command_infos();
+    cmds.extend(help::HelpPlugin.commands());
+    cmds.extend(stats::StatsPlugin.commands());
+    cmds
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────────
@@ -389,7 +538,7 @@ mod tests {
                 name: self.cmd.to_owned(),
                 description: "dummy".to_owned(),
                 usage: format!("/{}", self.cmd),
-                completions: vec![],
+                params: vec![],
             }]
         }
 
@@ -460,7 +609,7 @@ mod tests {
     }
 
     #[test]
-    fn registry_completions_for_returns_values() {
+    fn registry_completions_for_returns_choice_values() {
         let mut reg = PluginRegistry::new();
         reg.register(Box::new({
             struct CompPlugin;
@@ -473,9 +622,11 @@ mod tests {
                         name: "test".to_owned(),
                         description: "test".to_owned(),
                         usage: "/test".to_owned(),
-                        completions: vec![Completion {
-                            position: 0,
-                            values: vec!["10".to_owned(), "20".to_owned()],
+                        params: vec![ParamSchema {
+                            name: "count".to_owned(),
+                            param_type: ParamType::Choice(vec!["10".to_owned(), "20".to_owned()]),
+                            required: false,
+                            description: "Number of items".to_owned(),
                         }],
                     }]
                 }
@@ -496,6 +647,42 @@ mod tests {
     }
 
     #[test]
+    fn registry_completions_for_non_choice_returns_empty() {
+        let mut reg = PluginRegistry::new();
+        reg.register(Box::new({
+            struct TextPlugin;
+            impl Plugin for TextPlugin {
+                fn name(&self) -> &str {
+                    "text"
+                }
+                fn commands(&self) -> Vec<CommandInfo> {
+                    vec![CommandInfo {
+                        name: "echo".to_owned(),
+                        description: "echo".to_owned(),
+                        usage: "/echo".to_owned(),
+                        params: vec![ParamSchema {
+                            name: "msg".to_owned(),
+                            param_type: ParamType::Text,
+                            required: true,
+                            description: "Message".to_owned(),
+                        }],
+                    }]
+                }
+                fn handle(
+                    &self,
+                    _ctx: CommandContext,
+                ) -> BoxFuture<'_, anyhow::Result<PluginResult>> {
+                    Box::pin(async { Ok(PluginResult::Handled) })
+                }
+            }
+            TextPlugin
+        }))
+        .unwrap();
+        // Text params produce no completions
+        assert!(reg.completions_for("echo", 0).is_empty());
+    }
+
+    #[test]
     fn registry_rejects_all_reserved_commands() {
         for &reserved in RESERVED_COMMANDS {
             let mut reg = PluginRegistry::new();
@@ -508,6 +695,132 @@ mod tests {
                 "should reject reserved command '{reserved}'"
             );
         }
+    }
+
+    // ── ParamSchema / ParamType tests ───────────────────────────────────────
+
+    #[test]
+    fn param_type_choice_equality() {
+        let a = ParamType::Choice(vec!["x".to_owned(), "y".to_owned()]);
+        let b = ParamType::Choice(vec!["x".to_owned(), "y".to_owned()]);
+        assert_eq!(a, b);
+        let c = ParamType::Choice(vec!["x".to_owned()]);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn param_type_number_equality() {
+        let a = ParamType::Number {
+            min: Some(1),
+            max: Some(100),
+        };
+        let b = ParamType::Number {
+            min: Some(1),
+            max: Some(100),
+        };
+        assert_eq!(a, b);
+        let c = ParamType::Number {
+            min: None,
+            max: None,
+        };
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn param_type_variants_are_distinct() {
+        assert_ne!(ParamType::Text, ParamType::Username);
+        assert_ne!(
+            ParamType::Text,
+            ParamType::Number {
+                min: None,
+                max: None
+            }
+        );
+        assert_ne!(ParamType::Text, ParamType::Choice(vec!["a".to_owned()]));
+    }
+
+    // ── builtin_command_infos tests ───────────────────────────────────────
+
+    #[test]
+    fn builtin_command_infos_covers_all_expected_commands() {
+        let cmds = builtin_command_infos();
+        let names: Vec<&str> = cmds.iter().map(|c| c.name.as_str()).collect();
+        for expected in &[
+            "dm",
+            "claim",
+            "reply",
+            "set_status",
+            "who",
+            "kick",
+            "reauth",
+            "clear-tokens",
+            "exit",
+            "clear",
+        ] {
+            assert!(
+                names.contains(expected),
+                "missing built-in command: {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn builtin_command_infos_dm_has_username_param() {
+        let cmds = builtin_command_infos();
+        let dm = cmds.iter().find(|c| c.name == "dm").unwrap();
+        assert_eq!(dm.params.len(), 2);
+        assert_eq!(dm.params[0].param_type, ParamType::Username);
+        assert!(dm.params[0].required);
+        assert_eq!(dm.params[1].param_type, ParamType::Text);
+    }
+
+    #[test]
+    fn builtin_command_infos_kick_has_username_param() {
+        let cmds = builtin_command_infos();
+        let kick = cmds.iter().find(|c| c.name == "kick").unwrap();
+        assert_eq!(kick.params.len(), 1);
+        assert_eq!(kick.params[0].param_type, ParamType::Username);
+        assert!(kick.params[0].required);
+    }
+
+    #[test]
+    fn builtin_command_infos_set_status_is_optional() {
+        let cmds = builtin_command_infos();
+        let ss = cmds.iter().find(|c| c.name == "set_status").unwrap();
+        assert_eq!(ss.params.len(), 1);
+        assert!(!ss.params[0].required);
+    }
+
+    #[test]
+    fn builtin_command_infos_who_has_no_params() {
+        let cmds = builtin_command_infos();
+        let who = cmds.iter().find(|c| c.name == "who").unwrap();
+        assert!(who.params.is_empty());
+    }
+
+    // ── all_known_commands tests ──────────────────────────────────────────
+
+    #[test]
+    fn all_known_commands_includes_builtins_and_plugins() {
+        let cmds = all_known_commands();
+        let names: Vec<&str> = cmds.iter().map(|c| c.name.as_str()).collect();
+        // Built-ins
+        assert!(names.contains(&"dm"));
+        assert!(names.contains(&"who"));
+        assert!(names.contains(&"kick"));
+        // Plugins
+        assert!(names.contains(&"help"));
+        assert!(names.contains(&"stats"));
+    }
+
+    #[test]
+    fn all_known_commands_no_duplicates() {
+        let cmds = all_known_commands();
+        let mut names: Vec<&str> = cmds.iter().map(|c| c.name.as_str()).collect();
+        let before = names.len();
+        names.sort();
+        names.dedup();
+        assert_eq!(before, names.len(), "duplicate command names found");
     }
 
     #[tokio::test]

--- a/crates/room-cli/src/plugin/stats.rs
+++ b/crates/room-cli/src/plugin/stats.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::message::Message;
 
-use super::{BoxFuture, CommandContext, CommandInfo, Completion, Plugin, PluginResult};
+use super::{BoxFuture, CommandContext, CommandInfo, ParamSchema, ParamType, Plugin, PluginResult};
 
 /// Example `/stats` plugin. Shows a statistical summary of recent chat
 /// activity: message count, participant count, time range, most active user.
@@ -21,14 +21,16 @@ impl Plugin for StatsPlugin {
             name: "stats".to_owned(),
             description: "Show statistical summary of recent chat activity".to_owned(),
             usage: "/stats [last N messages, default 50]".to_owned(),
-            completions: vec![Completion {
-                position: 0,
-                values: vec![
+            params: vec![ParamSchema {
+                name: "count".to_owned(),
+                param_type: ParamType::Choice(vec![
                     "10".to_owned(),
                     "25".to_owned(),
                     "50".to_owned(),
                     "100".to_owned(),
-                ],
+                ]),
+                required: false,
+                description: "Number of recent messages to analyze".to_owned(),
             }],
         }]
     }

--- a/crates/room-cli/src/tui/input.rs
+++ b/crates/room-cli/src/tui/input.rs
@@ -4,7 +4,7 @@ use unicode_width::UnicodeWidthChar;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-use super::widgets::{CommandPalette, MentionPicker, PALETTE_COMMANDS};
+use super::widgets::{CommandPalette, MentionPicker};
 
 /// All mutable TUI input state. Pure data — no async context or I/O.
 pub(super) struct InputState {
@@ -23,7 +23,7 @@ impl InputState {
             cursor_pos: 0,
             input_row_scroll: 0,
             scroll_offset: 0,
-            palette: CommandPalette::new(PALETTE_COMMANDS),
+            palette: CommandPalette::from_commands(crate::plugin::all_known_commands()),
             mention: MentionPicker::new(),
         }
     }
@@ -77,12 +77,7 @@ pub(super) fn handle_key(
             state.mention.deactivate();
         }
         KeyCode::Tab if state.palette.active => {
-            if let Some(usage) = state.palette.selected_usage() {
-                state.input = usage.to_owned();
-                state.cursor_pos = state.input.len();
-                state.input_row_scroll = 0;
-            }
-            state.palette.deactivate();
+            complete_palette_selection(state, online_users);
         }
         KeyCode::Enter => {
             if state.mention.active {
@@ -97,12 +92,7 @@ pub(super) fn handle_key(
                 }
                 state.mention.deactivate();
             } else if state.palette.active {
-                if let Some(usage) = state.palette.selected_usage() {
-                    state.input = usage.to_owned();
-                    state.cursor_pos = state.input.len();
-                    state.input_row_scroll = 0;
-                }
-                state.palette.deactivate();
+                complete_palette_selection(state, online_users);
             } else if key.modifiers.contains(KeyModifiers::SHIFT) {
                 // Shift+Enter: insert a newline at the cursor.
                 state.input.insert(state.cursor_pos, '\n');
@@ -437,6 +427,51 @@ fn sync_mention_after_delete(state: &mut InputState, online_users: &[String]) {
         }
     } else {
         state.mention.deactivate();
+    }
+}
+
+/// Complete the currently selected palette command.
+///
+/// If the selected command's first parameter is `Username`, sets the input to
+/// `/<command> ` and activates the mention picker so the user can tab-complete
+/// a username without typing `@`. Otherwise fills in the full usage string as
+/// before.
+fn complete_palette_selection(state: &mut InputState, online_users: &[String]) {
+    let selected_idx = state.palette.filtered.get(state.palette.selected).copied();
+    if let Some(idx) = selected_idx {
+        let cmd_name = state.palette.commands[idx].cmd.clone();
+        let is_username = state.palette.is_username_param(&cmd_name, 0);
+        let has_choices = !state.palette.completions_at(&cmd_name, 0).is_empty();
+
+        if is_username {
+            // Set input to "/<cmd> " and activate mention picker at the space.
+            let prefix = format!("/{cmd_name} ");
+            let at_byte = prefix.len();
+            state.input = prefix;
+            state.cursor_pos = at_byte;
+            state.input_row_scroll = 0;
+            state.palette.deactivate();
+            state.mention.activate(at_byte, online_users, "");
+            if state.mention.filtered.is_empty() {
+                state.mention.deactivate();
+            }
+        } else if has_choices {
+            // Set input to "/<cmd> " so the user can type/pick a choice.
+            let prefix = format!("/{cmd_name} ");
+            state.input = prefix;
+            state.cursor_pos = state.input.len();
+            state.input_row_scroll = 0;
+            state.palette.deactivate();
+        } else if let Some(usage) = state.palette.selected_usage() {
+            state.input = usage.to_owned();
+            state.cursor_pos = state.input.len();
+            state.input_row_scroll = 0;
+            state.palette.deactivate();
+        } else {
+            state.palette.deactivate();
+        }
+    } else {
+        state.palette.deactivate();
     }
 }
 
@@ -1808,5 +1843,80 @@ mod tests {
         // Backspace to "@zz" — still no user matches "zz".
         handle_key(make_key(KeyCode::Backspace), &mut state, &users, 10, 80);
         assert!(!state.mention.active);
+    }
+
+    // ── complete_palette_selection tests (#257) ───────────────────────────────
+
+    #[test]
+    fn tab_on_dm_activates_mention_picker() {
+        let mut state = InputState::new();
+        let users = vec!["alice".to_owned(), "bob".to_owned()];
+        // Type "/dm" to activate and filter palette
+        for c in "/dm".chars() {
+            handle_key(make_key(KeyCode::Char(c)), &mut state, &users, 10, 80);
+        }
+        assert!(state.palette.active);
+        // Tab to complete — should set input to "/dm " and activate mention picker
+        handle_key(make_key(KeyCode::Tab), &mut state, &users, 10, 80);
+        assert_eq!(state.input, "/dm ");
+        assert!(!state.palette.active, "palette should deactivate");
+        assert!(
+            state.mention.active,
+            "mention picker should activate for Username param"
+        );
+    }
+
+    #[test]
+    fn tab_on_kick_activates_mention_picker() {
+        let mut state = InputState::new();
+        let users = vec!["alice".to_owned()];
+        for c in "/kick".chars() {
+            handle_key(make_key(KeyCode::Char(c)), &mut state, &users, 10, 80);
+        }
+        assert!(state.palette.active);
+        handle_key(make_key(KeyCode::Tab), &mut state, &users, 10, 80);
+        assert_eq!(state.input, "/kick ");
+        assert!(state.mention.active);
+    }
+
+    #[test]
+    fn tab_on_stats_sets_short_prefix_for_choices() {
+        let mut state = InputState::new();
+        let users: Vec<String> = vec![];
+        for c in "/stats".chars() {
+            handle_key(make_key(KeyCode::Char(c)), &mut state, &users, 10, 80);
+        }
+        assert!(state.palette.active);
+        handle_key(make_key(KeyCode::Tab), &mut state, &users, 10, 80);
+        // stats has Choice param — should set "/stats " for the user to type a number
+        assert_eq!(state.input, "/stats ");
+        assert!(!state.palette.active);
+        assert!(!state.mention.active);
+    }
+
+    #[test]
+    fn tab_on_who_fills_full_usage() {
+        let mut state = InputState::new();
+        let users: Vec<String> = vec![];
+        for c in "/who".chars() {
+            handle_key(make_key(KeyCode::Char(c)), &mut state, &users, 10, 80);
+        }
+        handle_key(make_key(KeyCode::Tab), &mut state, &users, 10, 80);
+        // who has no params — fills in the full usage string
+        assert_eq!(state.input, "/who");
+        assert!(!state.palette.active);
+    }
+
+    #[test]
+    fn enter_on_dm_activates_mention_picker() {
+        let mut state = InputState::new();
+        let users = vec!["alice".to_owned()];
+        for c in "/dm".chars() {
+            handle_key(make_key(KeyCode::Char(c)), &mut state, &users, 10, 80);
+        }
+        // Enter also completes palette selection
+        handle_key(make_key(KeyCode::Enter), &mut state, &users, 10, 80);
+        assert_eq!(state.input, "/dm ");
+        assert!(state.mention.active);
     }
 }

--- a/crates/room-cli/src/tui/widgets.rs
+++ b/crates/room-cli/src/tui/widgets.rs
@@ -1,75 +1,19 @@
+use crate::plugin::{CommandInfo, ParamType};
+
 // ── Command palette ───────────────────────────────────────────────────────────
 
+/// A single entry in the command palette.
+///
+/// Constructed from [`CommandInfo`] schemas via [`CommandPalette::from_commands`],
+/// or directly for testing. Owns its strings so the palette can be built
+/// dynamically at runtime from the plugin registry.
 pub(super) struct PaletteItem {
-    pub(super) cmd: &'static str,
-    pub(super) usage: &'static str,
-    pub(super) description: &'static str,
+    pub(super) cmd: String,
+    pub(super) usage: String,
+    pub(super) description: String,
+    /// Typed parameter schemas — drives argument-level autocomplete.
+    pub(super) params: Vec<crate::plugin::ParamSchema>,
 }
-
-pub(super) const PALETTE_COMMANDS: &[PaletteItem] = &[
-    PaletteItem {
-        cmd: "dm",
-        usage: "/dm <user> <message>",
-        description: "Send a private message",
-    },
-    PaletteItem {
-        cmd: "claim",
-        usage: "/claim <task>",
-        description: "Claim a task",
-    },
-    PaletteItem {
-        cmd: "reply",
-        usage: "/reply <id> <message>",
-        description: "Reply to a message",
-    },
-    PaletteItem {
-        cmd: "set_status",
-        usage: "/set_status <status>",
-        description: "Set your presence status",
-    },
-    PaletteItem {
-        cmd: "who",
-        usage: "/who",
-        description: "List users in the room",
-    },
-    // Plugin commands
-    PaletteItem {
-        cmd: "help",
-        usage: "/help [command]",
-        description: "List available commands or get help for a specific command",
-    },
-    PaletteItem {
-        cmd: "stats",
-        usage: "/stats [last N]",
-        description: "Show statistical summary of recent chat activity",
-    },
-    // Admin commands
-    PaletteItem {
-        cmd: "kick",
-        usage: "/kick <user>",
-        description: "Kick a user from the room",
-    },
-    PaletteItem {
-        cmd: "reauth",
-        usage: "/reauth <user>",
-        description: "Invalidate a user's token",
-    },
-    PaletteItem {
-        cmd: "clear-tokens",
-        usage: "/clear-tokens",
-        description: "Revoke all session tokens",
-    },
-    PaletteItem {
-        cmd: "exit",
-        usage: "/exit",
-        description: "Shut down the broker",
-    },
-    PaletteItem {
-        cmd: "clear",
-        usage: "/clear",
-        description: "Clear the room history",
-    },
-];
 
 pub(super) struct CommandPalette {
     pub(super) active: bool,
@@ -77,15 +21,26 @@ pub(super) struct CommandPalette {
     /// Indices into `commands` that match the current query.
     pub(super) filtered: Vec<usize>,
     /// The command list this palette draws from.
-    pub(super) commands: &'static [PaletteItem],
+    pub(super) commands: Vec<PaletteItem>,
 }
 
 impl CommandPalette {
-    pub(super) fn new(commands: &'static [PaletteItem]) -> Self {
+    /// Build a palette from a list of [`CommandInfo`] schemas.
+    pub(super) fn from_commands(infos: Vec<CommandInfo>) -> Self {
+        let commands: Vec<PaletteItem> = infos
+            .into_iter()
+            .map(|c| PaletteItem {
+                cmd: c.name,
+                usage: c.usage,
+                description: c.description,
+                params: c.params,
+            })
+            .collect();
+        let filtered = (0..commands.len()).collect();
         Self {
             active: false,
             selected: 0,
-            filtered: (0..commands.len()).collect(),
+            filtered,
             commands,
         }
     }
@@ -133,10 +88,35 @@ impl CommandPalette {
     }
 
     /// The full usage string (e.g. `/dm <user>`) of the selected entry.
-    pub(super) fn selected_usage(&self) -> Option<&'static str> {
+    pub(super) fn selected_usage(&self) -> Option<&str> {
         self.filtered
             .get(self.selected)
-            .map(|&i| self.commands[i].usage)
+            .map(|&i| self.commands[i].usage.as_str())
+    }
+
+    /// Look up a command by name and return completions for the given argument
+    /// position. Returns `Choice` values or an empty vec.
+    pub(super) fn completions_at(&self, cmd_name: &str, arg_pos: usize) -> Vec<String> {
+        self.commands
+            .iter()
+            .find(|c| c.cmd == cmd_name)
+            .and_then(|c| c.params.get(arg_pos))
+            .map(|p| match &p.param_type {
+                ParamType::Choice(values) => values.clone(),
+                _ => vec![],
+            })
+            .unwrap_or_default()
+    }
+
+    /// Check if the parameter at `arg_pos` for `cmd_name` is a `Username` type
+    /// (for triggering the mention picker instead of a choice picker).
+    pub(super) fn is_username_param(&self, cmd_name: &str, arg_pos: usize) -> bool {
+        self.commands
+            .iter()
+            .find(|c| c.cmd == cmd_name)
+            .and_then(|c| c.params.get(arg_pos))
+            .map(|p| matches!(p.param_type, ParamType::Username))
+            .unwrap_or(false)
     }
 }
 
@@ -205,19 +185,24 @@ impl MentionPicker {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::plugin::all_known_commands;
+
+    fn make_palette() -> CommandPalette {
+        CommandPalette::from_commands(all_known_commands())
+    }
 
     // ── CommandPalette unit tests ─────────────────────────────────────────────
 
     #[test]
     fn palette_starts_inactive() {
-        let p = CommandPalette::new(PALETTE_COMMANDS);
+        let p = make_palette();
         assert!(!p.active);
         assert_eq!(p.filtered.len(), p.commands.len());
     }
 
     #[test]
     fn palette_activate_resets_state() {
-        let mut p = CommandPalette::new(PALETTE_COMMANDS);
+        let mut p = make_palette();
         p.selected = 2;
         p.filtered = vec![1];
         p.activate();
@@ -228,7 +213,7 @@ mod tests {
 
     #[test]
     fn palette_deactivate_clears_active() {
-        let mut p = CommandPalette::new(PALETTE_COMMANDS);
+        let mut p = make_palette();
         p.activate();
         p.deactivate();
         assert!(!p.active);
@@ -236,8 +221,7 @@ mod tests {
 
     #[test]
     fn palette_filter_by_cmd_prefix() {
-        let mut p = CommandPalette::new(PALETTE_COMMANDS);
-        // "dm" matches exactly one command by cmd prefix (no description ambiguity)
+        let mut p = make_palette();
         p.update_filter("dm");
         assert_eq!(p.filtered.len(), 1);
         assert_eq!(p.commands[p.filtered[0]].cmd, "dm");
@@ -245,7 +229,7 @@ mod tests {
 
     #[test]
     fn palette_filter_dm_exact() {
-        let mut p = CommandPalette::new(PALETTE_COMMANDS);
+        let mut p = make_palette();
         p.update_filter("dm");
         assert_eq!(p.filtered.len(), 1);
         assert_eq!(p.commands[p.filtered[0]].cmd, "dm");
@@ -253,29 +237,28 @@ mod tests {
 
     #[test]
     fn palette_filter_empty_query_shows_all() {
-        let mut p = CommandPalette::new(PALETTE_COMMANDS);
+        let mut p = make_palette();
         p.update_filter("");
         assert_eq!(p.filtered.len(), p.commands.len());
     }
 
     #[test]
     fn palette_filter_no_match_returns_empty() {
-        let mut p = CommandPalette::new(PALETTE_COMMANDS);
+        let mut p = make_palette();
         p.update_filter("zzz_no_match");
         assert!(p.filtered.is_empty());
     }
 
     #[test]
     fn palette_filter_by_description_keyword() {
-        let mut p = CommandPalette::new(PALETTE_COMMANDS);
+        let mut p = make_palette();
         p.update_filter("private");
-        // Should match "dm" whose description is "Send a private message"
         assert!(p.filtered.iter().any(|&i| p.commands[i].cmd == "dm"));
     }
 
     #[test]
     fn palette_move_up_clamps_at_zero() {
-        let mut p = CommandPalette::new(PALETTE_COMMANDS);
+        let mut p = make_palette();
         p.activate();
         p.move_up();
         assert_eq!(p.selected, 0);
@@ -283,7 +266,7 @@ mod tests {
 
     #[test]
     fn palette_move_down_clamps_at_end() {
-        let mut p = CommandPalette::new(PALETTE_COMMANDS);
+        let mut p = make_palette();
         p.activate();
         for _ in 0..100 {
             p.move_down();
@@ -293,7 +276,7 @@ mod tests {
 
     #[test]
     fn palette_move_up_down_navigate() {
-        let mut p = CommandPalette::new(PALETTE_COMMANDS);
+        let mut p = make_palette();
         p.activate();
         p.move_down();
         p.move_down();
@@ -304,48 +287,46 @@ mod tests {
 
     #[test]
     fn palette_selected_usage_returns_usage_string() {
-        let mut p = CommandPalette::new(PALETTE_COMMANDS);
+        let mut p = make_palette();
         p.activate();
-        // First entry in unfiltered list
         let usage = p.selected_usage().unwrap();
         assert!(usage.starts_with('/'));
     }
 
     #[test]
     fn palette_selected_usage_empty_when_no_filtered() {
-        let mut p = CommandPalette::new(PALETTE_COMMANDS);
+        let mut p = make_palette();
         p.filtered.clear();
         assert!(p.selected_usage().is_none());
     }
 
     #[test]
     fn palette_selected_clamps_after_filter_narrows() {
-        let mut p = CommandPalette::new(PALETTE_COMMANDS);
+        let mut p = make_palette();
         p.activate();
-        // Navigate to last entry
         for _ in 0..100 {
             p.move_down();
         }
         assert_eq!(p.selected, p.commands.len() - 1);
-        // Now narrow filter so fewer entries remain
         p.update_filter("dm");
         assert_eq!(p.filtered.len(), 1);
-        assert_eq!(p.selected, 0); // clamped
+        assert_eq!(p.selected, 0);
     }
 
-    // ── PALETTE_COMMANDS completeness tests ───────────────────────────────────
+    // ── Completeness tests ───────────────────────────────────────────────────
 
     #[test]
     fn palette_commands_contains_set_status() {
+        let p = make_palette();
         assert!(
-            PALETTE_COMMANDS.iter().any(|c| c.cmd == "set_status"),
-            "PALETTE_COMMANDS must include set_status"
+            p.commands.iter().any(|c| c.cmd == "set_status"),
+            "palette must include set_status"
         );
     }
 
     #[test]
     fn palette_filter_set_status() {
-        let mut p = CommandPalette::new(PALETTE_COMMANDS);
+        let mut p = make_palette();
         p.update_filter("set");
         assert!(
             p.filtered
@@ -355,18 +336,10 @@ mod tests {
         );
     }
 
-    // ── ADMIN_COMMANDS palette tests ──────────────────────────────────────────
-
-    #[test]
-    fn unified_palette_starts_inactive() {
-        let p = CommandPalette::new(PALETTE_COMMANDS);
-        assert!(!p.active);
-        assert_eq!(p.filtered.len(), PALETTE_COMMANDS.len());
-    }
-
     #[test]
     fn palette_contains_all_admin_commands() {
-        let cmds: Vec<&str> = PALETTE_COMMANDS.iter().map(|c| c.cmd).collect();
+        let p = make_palette();
+        let cmds: Vec<&str> = p.commands.iter().map(|c| c.cmd.as_str()).collect();
         assert!(cmds.contains(&"kick"));
         assert!(cmds.contains(&"reauth"));
         assert!(cmds.contains(&"clear-tokens"));
@@ -376,9 +349,10 @@ mod tests {
 
     #[test]
     fn admin_usages_use_slash_prefix() {
+        let p = make_palette();
         let admin_cmds = ["kick", "reauth", "clear-tokens", "exit", "clear"];
-        for item in PALETTE_COMMANDS {
-            if admin_cmds.contains(&item.cmd) {
+        for item in &p.commands {
+            if admin_cmds.contains(&item.cmd.as_str()) {
                 assert!(
                     item.usage.starts_with('/'),
                     "admin command '{}' usage must start with /",
@@ -390,7 +364,7 @@ mod tests {
 
     #[test]
     fn palette_filter_kick() {
-        let mut p = CommandPalette::new(PALETTE_COMMANDS);
+        let mut p = make_palette();
         p.update_filter("ki");
         assert_eq!(p.filtered.len(), 1);
         assert_eq!(p.commands[p.filtered[0]].cmd, "kick");
@@ -398,9 +372,8 @@ mod tests {
 
     #[test]
     fn admin_selected_usage_slash() {
-        let mut p = CommandPalette::new(PALETTE_COMMANDS);
+        let mut p = make_palette();
         p.activate();
-        // All commands use / prefix
         let usage = p.selected_usage().unwrap();
         assert!(usage.starts_with('/'));
     }
@@ -409,23 +382,18 @@ mod tests {
 
     #[test]
     fn palette_filter_ranks_prefix_before_description() {
-        // "se" matches "set_status" by cmd prefix AND "dm" by description ("Send a private message").
-        // Prefix matches must appear first in the filtered list.
-        let mut p = CommandPalette::new(PALETTE_COMMANDS);
+        let mut p = make_palette();
         p.update_filter("se");
         assert!(
             p.filtered.len() >= 2,
             "expected at least 2 matches for 'se', got {}",
             p.filtered.len()
         );
-        // First match must be the cmd-prefix match (set_status).
-        let first_cmd = p.commands[p.filtered[0]].cmd;
+        let first_cmd = &p.commands[p.filtered[0]].cmd;
         assert_eq!(
             first_cmd, "set_status",
-            "first match should be 'set_status' (prefix), not '{}'",
-            first_cmd
+            "first match should be 'set_status' (prefix), not '{first_cmd}'"
         );
-        // Description-only matches (like "dm" whose description starts with "Send") come after.
         let prefix_count = p
             .filtered
             .iter()
@@ -446,9 +414,7 @@ mod tests {
 
     #[test]
     fn palette_filter_description_match_appears_after_all_prefix_matches() {
-        // "re" matches "reply" and "reauth" by prefix. It also matches "set_status" by description
-        // ("Set your presence status"). Prefix matches must come first.
-        let mut p = CommandPalette::new(PALETTE_COMMANDS);
+        let mut p = make_palette();
         p.update_filter("re");
         let prefix_count = p
             .filtered
@@ -469,19 +435,68 @@ mod tests {
         }
     }
 
+    // ── completions_at / is_username_param tests ──────────────────────────────
+
+    #[test]
+    fn completions_at_returns_choice_values() {
+        let p = make_palette();
+        let completions = p.completions_at("stats", 0);
+        assert!(
+            completions.contains(&"10".to_owned()),
+            "stats param 0 should include '10'"
+        );
+        assert!(
+            completions.contains(&"50".to_owned()),
+            "stats param 0 should include '50'"
+        );
+    }
+
+    #[test]
+    fn completions_at_returns_empty_for_text_param() {
+        let p = make_palette();
+        // set_status param is Text — no completions
+        assert!(p.completions_at("set_status", 0).is_empty());
+    }
+
+    #[test]
+    fn completions_at_returns_empty_for_unknown_command() {
+        let p = make_palette();
+        assert!(p.completions_at("nonexistent", 0).is_empty());
+    }
+
+    #[test]
+    fn is_username_param_true_for_dm_first_arg() {
+        let p = make_palette();
+        assert!(p.is_username_param("dm", 0));
+    }
+
+    #[test]
+    fn is_username_param_true_for_kick() {
+        let p = make_palette();
+        assert!(p.is_username_param("kick", 0));
+    }
+
+    #[test]
+    fn is_username_param_false_for_text_param() {
+        let p = make_palette();
+        assert!(!p.is_username_param("set_status", 0));
+    }
+
+    #[test]
+    fn is_username_param_false_for_unknown_command() {
+        let p = make_palette();
+        assert!(!p.is_username_param("nonexistent", 0));
+    }
+
     // ── MentionPicker tests ───────────────────────────────────────────────────
 
     #[test]
     fn mention_picker_shows_user_added_from_message_sender() {
-        // Simulate: a user r2d2 sends a message; their name is seeded into online_users
-        // (the drain loop adds Message::Message senders if not already present).
         let mut online_users: Vec<String> = Vec::new();
-        // Replicate the drain-loop guard exactly as written in the source.
         let user = "r2d2".to_owned();
         if !online_users.contains(&user) {
             online_users.push(user);
         }
-        // MentionPicker should now find this user when activated with an empty query.
         let mut picker = MentionPicker::new();
         picker.activate(0, &online_users, "");
         assert!(picker.active);
@@ -491,7 +506,6 @@ mod tests {
     #[test]
     fn message_sender_not_duplicated_if_already_online() {
         let mut online_users = vec!["alice".to_owned()];
-        // Same guard as the drain loop.
         let user = "alice".to_owned();
         if !online_users.contains(&user) {
             online_users.push(user);


### PR DESCRIPTION
## Summary

- Add `ParamSchema` and `ParamType` to the plugin system, replacing the old `Completion` struct
- Each command declares typed parameters (`Text`, `Username`, `Choice`, `Number`) with required/optional flags and descriptions
- `builtin_command_infos()` provides schema declarations for all 10 built-in commands
- `validate_params()` performs server-side schema validation in `dispatch_plugin()` before the handler runs
- `/help` now renders typed parameter info (type hints, required/optional flags)
- `CommandPalette` dynamically built from schemas instead of static array
- Smart Tab completion: `Username` params auto-activate mention picker, `Choice` params set short prefix

## Files changed

| File | Changes |
|---|---|
| `plugin/mod.rs` | `ParamType`, `ParamSchema`, `builtin_command_infos()`, `all_known_commands()`, `completions_for()` rewrite |
| `plugin/help.rs` | `format_command_help()` with typed param rendering |
| `plugin/stats.rs` | Migrated from `Completion` to `ParamSchema` |
| `broker/commands.rs` | `validate_params()` + wiring into `dispatch_plugin()` |
| `tui/widgets.rs` | Dynamic `CommandPalette`, `completions_at()`, `is_username_param()` |
| `tui/input.rs` | `complete_palette_selection()` with smart Tab behavior |

## Test plan

- [x] 33 new tests added (510 total, up from 477)
- [x] `cargo check` passes
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] All 510 Rust tests pass

Closes #257
