### PR TITLE
fix(plugin): add dm/claim/reply/room-info to RESERVED_COMMANDS

### DIFF
--- a/crates/room-cli/src/plugin/mod.rs
+++ b/crates/room-cli/src/plugin/mod.rs
@@ -309,6 +309,10 @@ const RESERVED_COMMANDS: &[&str] = &[
     "kick",
     "reauth",
     "clear-tokens",
+    "dm",
+    "claim",
+    "reply",
+    "room-info",
     "exit",
     "clear",
 ];


### PR DESCRIPTION
Prevents plugins from registering command names handled by built-in routing. Adds 4 missing entries to RESERVED_COMMANDS: dm, claim, reply, room-info. Existing test `registry_rejects_all_reserved_commands` now covers all 11 entries.