### PR TITLE
feat(cli): multiplexed poll across multiple rooms (#255)

### DIFF
--- a/crates/room-cli/src/main.rs
+++ b/crates/room-cli/src/main.rs
@@ -40,14 +40,20 @@ enum Cmd {
     /// Poll for new messages, printing NDJSON to stdout.
     ///
     /// Updates a per-user cursor file so subsequent calls return only unseen messages.
+    /// Use `--rooms r1,r2` (comma-separated or repeated) to poll multiple rooms at once;
+    /// messages are merged by timestamp and each carries its `room` field.
     Poll {
-        room_id: String,
+        /// Single room ID (omit when using --rooms)
+        room_id: Option<String>,
         /// Session token from `room join` (required)
         #[arg(short = 't', long)]
         token: String,
-        /// Return only messages after this message ID (overrides stored cursor)
+        /// Return only messages after this message ID (overrides stored cursor; single-room only)
         #[arg(long)]
         since: Option<String>,
+        /// Poll multiple rooms (comma-separated or repeated). Merges messages by timestamp.
+        #[arg(long, value_delimiter = ',')]
+        rooms: Vec<String>,
     },
     /// Fetch the last N messages from history without updating the poll cursor.
     ///
@@ -174,8 +180,20 @@ async fn main() -> anyhow::Result<()> {
             room_id,
             token,
             since,
+            rooms,
         }) => {
-            oneshot::cmd_poll(&room_id, &token, since).await?;
+            if !rooms.is_empty() {
+                if since.is_some() {
+                    anyhow::bail!("--since is not supported with --rooms (use per-room cursors)");
+                }
+                oneshot::cmd_poll_multi(&rooms, &token).await?;
+            } else {
+                let room_id = room_id.unwrap_or_else(|| {
+                    eprintln!("error: room_id is required when --rooms is not given");
+                    std::process::exit(1);
+                });
+                oneshot::cmd_poll(&room_id, &token, since).await?;
+            }
         }
         Some(Cmd::Pull {
             room_id,

--- a/crates/room-cli/src/oneshot/mod.rs
+++ b/crates/room-cli/src/oneshot/mod.rs
@@ -5,7 +5,10 @@ pub mod transport;
 pub mod who;
 
 pub use list::cmd_list;
-pub use poll::{cmd_poll, cmd_pull, cmd_watch, poll_messages, pull_messages};
+pub use poll::{
+    cmd_poll, cmd_poll_multi, cmd_pull, cmd_watch, poll_messages, poll_messages_multi,
+    pull_messages,
+};
 pub use token::{cmd_join, token_file_path, username_from_token};
 pub use transport::{join_session, send_message, send_message_with_token};
 pub use who::cmd_who;

--- a/crates/room-cli/src/oneshot/poll.rs
+++ b/crates/room-cli/src/oneshot/poll.rs
@@ -145,6 +145,65 @@ pub async fn cmd_poll(room_id: &str, token: &str, since: Option<String>) -> anyh
     Ok(())
 }
 
+/// Poll multiple rooms, returning messages merged by timestamp.
+///
+/// Each room uses its own cursor file (`/tmp/room-{room_id}-{username}.cursor`).
+/// Messages are sorted by timestamp across all rooms. Each message already carries
+/// a `room` field, so the caller can distinguish sources.
+pub async fn poll_messages_multi(
+    rooms: &[(&str, &Path)],
+    username: &str,
+) -> anyhow::Result<Vec<Message>> {
+    let mut all_messages: Vec<Message> = Vec::new();
+
+    for &(room_id, chat_path) in rooms {
+        let cursor_path = PathBuf::from(format!("/tmp/room-{room_id}-{username}.cursor"));
+        let msgs = poll_messages(chat_path, &cursor_path, Some(username), None).await?;
+        all_messages.extend(msgs);
+    }
+
+    all_messages.sort_by(|a, b| a.ts().cmp(b.ts()));
+    Ok(all_messages)
+}
+
+/// One-shot multi-room poll subcommand: poll multiple rooms, merge by timestamp, print NDJSON.
+///
+/// Resolves the username from the token by trying each room in order. Each room's cursor
+/// is updated independently.
+pub async fn cmd_poll_multi(room_ids: &[String], token: &str) -> anyhow::Result<()> {
+    // Resolve username by trying the token against each room
+    let username = resolve_username_from_rooms(room_ids, token)?;
+
+    // Resolve chat paths for all rooms
+    let mut rooms: Vec<(&str, PathBuf)> = Vec::new();
+    for room_id in room_ids {
+        let meta_path = PathBuf::from(format!("/tmp/room-{room_id}.meta"));
+        let chat_path = chat_path_from_meta(room_id, &meta_path);
+        rooms.push((room_id.as_str(), chat_path));
+    }
+
+    let room_refs: Vec<(&str, &Path)> = rooms.iter().map(|(id, p)| (*id, p.as_path())).collect();
+    let messages = poll_messages_multi(&room_refs, &username).await?;
+    for msg in &messages {
+        println!("{}", serde_json::to_string(msg)?);
+    }
+    Ok(())
+}
+
+/// Try to resolve a username from a token by scanning token files for each room.
+///
+/// Returns the username from the first room where the token is found.
+fn resolve_username_from_rooms(room_ids: &[String], token: &str) -> anyhow::Result<String> {
+    for room_id in room_ids {
+        if let Ok(username) = username_from_token(room_id, token) {
+            return Ok(username);
+        }
+    }
+    anyhow::bail!(
+        "token not recognised in any of the specified rooms — run: room join <room_id> <username>"
+    )
+}
+
 pub(super) fn chat_path_from_meta(room_id: &str, meta_path: &Path) -> PathBuf {
     if meta_path.exists() {
         if let Ok(data) = std::fs::read_to_string(meta_path) {
@@ -299,6 +358,169 @@ mod tests {
             foreign.is_empty(),
             "DMs sent by the watcher should not wake watch"
         );
+    }
+
+    // ── poll_messages_multi tests ──────────────────────────────────────────
+
+    /// Multi-room poll merges messages from two rooms sorted by timestamp.
+    #[tokio::test]
+    async fn poll_multi_merges_by_timestamp() {
+        let chat_a = NamedTempFile::new().unwrap();
+        let chat_b = NamedTempFile::new().unwrap();
+
+        let rid_a = format!("test-merge-a-{}", std::process::id());
+        let rid_b = format!("test-merge-b-{}", std::process::id());
+
+        // Append messages with interleaved timestamps
+        let msg_a1 = make_message(&rid_a, "alice", "a1");
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+        let msg_b1 = make_message(&rid_b, "bob", "b1");
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+        let msg_a2 = make_message(&rid_a, "alice", "a2");
+
+        crate::history::append(chat_a.path(), &msg_a1)
+            .await
+            .unwrap();
+        crate::history::append(chat_b.path(), &msg_b1)
+            .await
+            .unwrap();
+        crate::history::append(chat_a.path(), &msg_a2)
+            .await
+            .unwrap();
+
+        let rooms: Vec<(&str, &Path)> = vec![
+            (rid_a.as_str(), chat_a.path()),
+            (rid_b.as_str(), chat_b.path()),
+        ];
+
+        let result = poll_messages_multi(&rooms, "viewer").await.unwrap();
+        assert_eq!(result.len(), 3);
+        // Verify timestamp ordering
+        assert!(result[0].ts() <= result[1].ts());
+        assert!(result[1].ts() <= result[2].ts());
+        // First message should be from room-a (earliest)
+        assert_eq!(result[0].room(), &rid_a);
+
+        // Clean up cursor files
+        let _ = std::fs::remove_file(format!("/tmp/room-{rid_a}-viewer.cursor"));
+        let _ = std::fs::remove_file(format!("/tmp/room-{rid_b}-viewer.cursor"));
+    }
+
+    /// Multi-room poll uses per-room cursors (second call returns nothing).
+    #[tokio::test]
+    async fn poll_multi_advances_per_room_cursors() {
+        let chat_a = NamedTempFile::new().unwrap();
+        let chat_b = NamedTempFile::new().unwrap();
+
+        // Use unique room IDs to avoid cursor file collisions with parallel tests
+        let rid_a = format!("test-cursor-a-{}", std::process::id());
+        let rid_b = format!("test-cursor-b-{}", std::process::id());
+
+        let msg_a = make_message(&rid_a, "alice", "hello a");
+        let msg_b = make_message(&rid_b, "bob", "hello b");
+        crate::history::append(chat_a.path(), &msg_a).await.unwrap();
+        crate::history::append(chat_b.path(), &msg_b).await.unwrap();
+
+        let rooms: Vec<(&str, &Path)> = vec![
+            (rid_a.as_str(), chat_a.path()),
+            (rid_b.as_str(), chat_b.path()),
+        ];
+
+        // First poll gets everything
+        let result = poll_messages_multi(&rooms, "viewer").await.unwrap();
+        assert_eq!(result.len(), 2);
+
+        // Second poll gets nothing (cursors advanced)
+        let result2 = poll_messages_multi(&rooms, "viewer").await.unwrap();
+        assert!(
+            result2.is_empty(),
+            "second multi-poll should return nothing"
+        );
+
+        // Clean up cursor files
+        let _ = std::fs::remove_file(format!("/tmp/room-{rid_a}-viewer.cursor"));
+        let _ = std::fs::remove_file(format!("/tmp/room-{rid_b}-viewer.cursor"));
+    }
+
+    /// Multi-room poll with one empty room still returns messages from the other.
+    #[tokio::test]
+    async fn poll_multi_one_empty_room() {
+        let chat_a = NamedTempFile::new().unwrap();
+        let chat_b = NamedTempFile::new().unwrap();
+
+        let rid_a = format!("test-empty-a-{}", std::process::id());
+        let rid_b = format!("test-empty-b-{}", std::process::id());
+
+        let msg = make_message(&rid_a, "alice", "only here");
+        crate::history::append(chat_a.path(), &msg).await.unwrap();
+        // chat_b is empty
+
+        let rooms: Vec<(&str, &Path)> = vec![
+            (rid_a.as_str(), chat_a.path()),
+            (rid_b.as_str(), chat_b.path()),
+        ];
+
+        let result = poll_messages_multi(&rooms, "viewer").await.unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].room(), &rid_a);
+
+        let _ = std::fs::remove_file(format!("/tmp/room-{rid_a}-viewer.cursor"));
+        let _ = std::fs::remove_file(format!("/tmp/room-{rid_b}-viewer.cursor"));
+    }
+
+    /// Multi-room poll with no rooms returns nothing.
+    #[tokio::test]
+    async fn poll_multi_no_rooms() {
+        let rooms: Vec<(&str, &Path)> = vec![];
+        let result = poll_messages_multi(&rooms, "viewer").await.unwrap();
+        assert!(result.is_empty());
+    }
+
+    /// Multi-room poll filters DMs by viewer across rooms.
+    #[tokio::test]
+    async fn poll_multi_filters_dms_across_rooms() {
+        use crate::message::make_dm;
+        let chat_a = NamedTempFile::new().unwrap();
+        let chat_b = NamedTempFile::new().unwrap();
+
+        let rid_a = format!("test-dm-a-{}", std::process::id());
+        let rid_b = format!("test-dm-b-{}", std::process::id());
+
+        // DM to bob in room-a, DM to carol in room-b
+        let dm_to_bob = make_dm(&rid_a, "alice", "bob", "secret for bob");
+        let dm_to_carol = make_dm(&rid_b, "alice", "carol", "secret for carol");
+        crate::history::append(chat_a.path(), &dm_to_bob)
+            .await
+            .unwrap();
+        crate::history::append(chat_b.path(), &dm_to_carol)
+            .await
+            .unwrap();
+
+        let rooms: Vec<(&str, &Path)> = vec![
+            (rid_a.as_str(), chat_a.path()),
+            (rid_b.as_str(), chat_b.path()),
+        ];
+
+        // bob sees only room-a DM
+        let result = poll_messages_multi(&rooms, "bob").await.unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].room(), &rid_a);
+
+        let _ = std::fs::remove_file(format!("/tmp/room-{rid_a}-bob.cursor"));
+        let _ = std::fs::remove_file(format!("/tmp/room-{rid_b}-bob.cursor"));
+    }
+
+    /// resolve_username_from_rooms finds username from the first matching room.
+    #[test]
+    fn resolve_username_finds_token_in_second_room() {
+        // This test can't easily be hermetic since resolve_username_from_rooms
+        // calls username_from_token which scans /tmp. We test the error case instead.
+        let result = resolve_username_from_rooms(&["nonexistent-room-xyz".to_owned()], "bad-token");
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("token not recognised"));
     }
 
     /// pull_messages returns the last n entries without moving the cursor.


### PR DESCRIPTION
## Summary

- Add `--rooms` flag to `room poll` for polling multiple rooms at once
- Messages from all rooms are merged by timestamp; each carries its `room` field for source identification
- `poll_messages_multi()` polls N rooms with independent per-room cursors, merges by timestamp
- `resolve_username_from_rooms()` finds username by trying the token against each room's token files
- Backward compatible: single positional `room_id` still works as before
- `--since` is not supported with `--rooms` (use per-room cursors instead)

## Usage

```bash
# Single room (unchanged)
room poll myroom -t TOKEN

# Multiple rooms (new)
room poll --rooms room1,room2,room3 -t TOKEN

# Repeated flag also works
room poll --rooms room1 --rooms room2 -t TOKEN
```

## Files changed

| File | Changes |
|---|---|
| `main.rs` | `--rooms` flag on Poll, dispatch to `cmd_poll_multi` |
| `oneshot/poll.rs` | `poll_messages_multi`, `cmd_poll_multi`, `resolve_username_from_rooms`, 6 tests |
| `oneshot/mod.rs` | Export `cmd_poll_multi`, `poll_messages_multi` |

## Test plan

- [x] 6 new unit tests: merge ordering, cursor advancement, empty room, no rooms, DM filtering across rooms, error case
- [x] `cargo check` passes
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] All 620 Rust tests pass

Closes #255
