### PR TITLE
feat(auth): persist tokens across broker restarts

### DIFF
--- a/crates/room-cli/src/broker/auth.rs
+++ b/crates/room-cli/src/broker/auth.rs
@@ -1,8 +1,39 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
 use room_protocol::{RoomConfig, RoomVisibility};
 use tokio::{io::AsyncWriteExt, net::unix::OwnedWriteHalf};
 use uuid::Uuid;
 
 use super::state::TokenMap;
+
+// ── Token persistence ────────────────────────────────────────────────────────
+
+/// Derive the token file path from a chat file path.
+///
+/// Given `/tmp/myroom.chat`, returns `/tmp/myroom.tokens`.
+pub(crate) fn token_file_path(chat_path: &Path) -> PathBuf {
+    chat_path.with_extension("tokens")
+}
+
+/// Write a token map to disk as JSON.
+fn save_token_map(map: &HashMap<String, String>, path: &Path) -> Result<(), String> {
+    let json = serde_json::to_string_pretty(&map).map_err(|e| format!("serialize tokens: {e}"))?;
+    std::fs::write(path, json).map_err(|e| format!("write {}: {e}", path.display()))
+}
+
+/// Load a token map from disk. Returns an empty map if the file does not exist.
+pub(crate) fn load_token_map(chat_path: &Path) -> HashMap<String, String> {
+    let path = token_file_path(chat_path);
+    let contents = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(_) => return HashMap::new(),
+    };
+    serde_json::from_str(&contents).unwrap_or_else(|e| {
+        eprintln!("[auth] corrupt token file {}: {e}", path.display());
+        HashMap::new()
+    })
+}
 
 /// Check whether `username` is allowed to join a room with the given config.
 ///
@@ -39,15 +70,24 @@ pub(crate) fn check_join_permission(
 /// Issue a session token for `username` if the name is not already taken.
 ///
 /// Returns the new token string on success, or an error message on collision.
-/// Inserts the mapping into `token_map`; the caller is responsible for
-/// writing the token file to disk.
-pub(crate) async fn issue_token(username: &str, token_map: &TokenMap) -> Result<String, String> {
+/// If `persist_to` is `Some(chat_path)`, the updated token map is saved to
+/// disk alongside the chat file so tokens survive broker restarts.
+pub(crate) async fn issue_token(
+    username: &str,
+    token_map: &TokenMap,
+    persist_to: Option<&Path>,
+) -> Result<String, String> {
     let mut map = token_map.lock().await;
     if map.values().any(|u| u == username) {
         return Err(format!("username_taken:{username}"));
     }
     let token = Uuid::new_v4().to_string();
     map.insert(token.clone(), username.to_owned());
+    if let Some(chat_path) = persist_to {
+        if let Err(e) = save_token_map(&map, &token_file_path(chat_path)) {
+            eprintln!("[auth] token persist failed: {e}");
+        }
+    }
     Ok(token)
 }
 
@@ -64,12 +104,14 @@ pub(crate) async fn validate_token(token: &str, token_map: &TokenMap) -> Option<
 ///
 /// Checks join permission against the room config, then calls `issue_token`
 /// and writes the response JSON to the socket. Rejects unauthorized joins
-/// with an error envelope.
+/// with an error envelope. If `chat_path` is provided, the token map is
+/// persisted to disk after a successful issuance.
 pub(crate) async fn handle_oneshot_join(
     username: String,
     mut write_half: OwnedWriteHalf,
     token_map: &TokenMap,
     config: Option<&RoomConfig>,
+    chat_path: Option<&Path>,
 ) -> anyhow::Result<()> {
     // Check visibility/ACL before issuing a token.
     if let Err(reason) = check_join_permission(&username, config) {
@@ -83,7 +125,7 @@ pub(crate) async fn handle_oneshot_join(
         return Ok(());
     }
 
-    match issue_token(&username, token_map).await {
+    match issue_token(&username, token_map, chat_path).await {
         Ok(token) => {
             let resp = serde_json::json!({"type":"token","token": token,"username": username});
             write_half.write_all(format!("{resp}\n").as_bytes()).await?;
@@ -104,21 +146,21 @@ pub(crate) async fn handle_oneshot_join(
 
 #[cfg(test)]
 mod tests {
-    use super::{check_join_permission, issue_token, validate_token};
+    use super::*;
     use room_protocol::{RoomConfig, RoomVisibility};
     use std::{collections::HashMap, sync::Arc};
     use tokio::sync::Mutex;
 
-    type TokenMap = Arc<Mutex<HashMap<String, String>>>;
+    type TestTokenMap = Arc<Mutex<HashMap<String, String>>>;
 
-    fn make_token_map() -> TokenMap {
+    fn make_token_map() -> TestTokenMap {
         Arc::new(Mutex::new(HashMap::new()))
     }
 
     #[tokio::test]
     async fn issue_token_new_user_returns_non_empty_uuid() {
         let map = make_token_map();
-        let token = issue_token("alice", &map).await.unwrap();
+        let token = issue_token("alice", &map, None).await.unwrap();
         assert!(!token.is_empty());
         let guard = map.lock().await;
         assert_eq!(guard.get(&token).map(String::as_str), Some("alice"));
@@ -127,8 +169,8 @@ mod tests {
     #[tokio::test]
     async fn issue_token_same_username_twice_returns_err() {
         let map = make_token_map();
-        issue_token("alice", &map).await.unwrap();
-        let second = issue_token("alice", &map).await;
+        issue_token("alice", &map, None).await.unwrap();
+        let second = issue_token("alice", &map, None).await;
         assert!(second.is_err());
         assert!(second.unwrap_err().contains("alice"));
     }
@@ -136,8 +178,8 @@ mod tests {
     #[tokio::test]
     async fn issue_token_different_usernames_get_distinct_tokens() {
         let map = make_token_map();
-        let t1 = issue_token("alice", &map).await.unwrap();
-        let t2 = issue_token("bob", &map).await.unwrap();
+        let t1 = issue_token("alice", &map, None).await.unwrap();
+        let t2 = issue_token("bob", &map, None).await.unwrap();
         assert_ne!(t1, t2);
         let guard = map.lock().await;
         assert_eq!(guard.get(&t1).map(String::as_str), Some("alice"));
@@ -151,7 +193,7 @@ mod tests {
         map.lock()
             .await
             .insert("KICKED:alice".to_owned(), "alice".to_owned());
-        let result = issue_token("alice", &map).await;
+        let result = issue_token("alice", &map, None).await;
         assert!(
             result.is_err(),
             "kicked user must not be able to issue a new token"
@@ -161,7 +203,7 @@ mod tests {
     #[tokio::test]
     async fn validate_token_valid_returns_username() {
         let map = make_token_map();
-        let token = issue_token("alice", &map).await.unwrap();
+        let token = issue_token("alice", &map, None).await.unwrap();
         let result = validate_token(&token, &map).await;
         assert_eq!(result, Some("alice".to_owned()));
     }
@@ -175,7 +217,7 @@ mod tests {
     #[tokio::test]
     async fn validate_token_after_kick_original_uuid_is_invalidated() {
         let map = make_token_map();
-        let token = issue_token("alice", &map).await.unwrap();
+        let token = issue_token("alice", &map, None).await.unwrap();
         // Simulate kick: remove UUID token, insert KICKED sentinel
         {
             let mut guard = map.lock().await;
@@ -191,7 +233,7 @@ mod tests {
     #[tokio::test]
     async fn validate_token_after_reauth_returns_none() {
         let map = make_token_map();
-        let token = issue_token("alice", &map).await.unwrap();
+        let token = issue_token("alice", &map, None).await.unwrap();
         // Simulate reauth: remove all entries for "alice"
         map.lock().await.retain(|_, u| u != "alice");
         assert!(
@@ -274,5 +316,106 @@ mod tests {
     #[test]
     fn join_no_config_always_allowed() {
         assert!(check_join_permission("anyone", None).is_ok());
+    }
+
+    // ── Token persistence ─────────────────────────────────────────────────
+
+    #[test]
+    fn token_file_path_replaces_extension() {
+        let chat = std::path::PathBuf::from("/tmp/myroom.chat");
+        assert_eq!(
+            token_file_path(&chat),
+            std::path::PathBuf::from("/tmp/myroom.tokens")
+        );
+    }
+
+    #[test]
+    fn token_file_path_no_extension() {
+        let chat = std::path::PathBuf::from("/tmp/myroom");
+        assert_eq!(
+            token_file_path(&chat),
+            std::path::PathBuf::from("/tmp/myroom.tokens")
+        );
+    }
+
+    #[test]
+    fn load_token_map_missing_file_returns_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let chat = dir.path().join("nonexistent.chat");
+        let map = load_token_map(&chat);
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn save_and_load_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let chat = dir.path().join("test.chat");
+        let token_path = token_file_path(&chat);
+
+        let mut original = HashMap::new();
+        original.insert("tok-1".to_owned(), "alice".to_owned());
+        original.insert("tok-2".to_owned(), "bob".to_owned());
+
+        save_token_map(&original, &token_path).unwrap();
+        let loaded = load_token_map(&chat);
+        assert_eq!(loaded, original);
+    }
+
+    #[test]
+    fn load_token_map_corrupt_file_returns_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let chat = dir.path().join("corrupt.chat");
+        let token_path = token_file_path(&chat);
+        std::fs::write(token_path, "not json{{{").unwrap();
+
+        let map = load_token_map(&chat);
+        assert!(map.is_empty());
+    }
+
+    #[tokio::test]
+    async fn issue_token_persists_to_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let chat = dir.path().join("persist.chat");
+
+        let map = make_token_map();
+        let token = issue_token("alice", &map, Some(&chat)).await.unwrap();
+
+        // Verify the file was written and contains the token
+        let loaded = load_token_map(&chat);
+        assert_eq!(loaded.get(&token).map(String::as_str), Some("alice"));
+    }
+
+    #[tokio::test]
+    async fn issue_token_accumulates_on_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let chat = dir.path().join("accum.chat");
+
+        let map = make_token_map();
+        let t1 = issue_token("alice", &map, Some(&chat)).await.unwrap();
+        let t2 = issue_token("bob", &map, Some(&chat)).await.unwrap();
+
+        let loaded = load_token_map(&chat);
+        assert_eq!(loaded.len(), 2);
+        assert_eq!(loaded.get(&t1).map(String::as_str), Some("alice"));
+        assert_eq!(loaded.get(&t2).map(String::as_str), Some("bob"));
+    }
+
+    #[tokio::test]
+    async fn persisted_tokens_survive_new_token_map() {
+        let dir = tempfile::tempdir().unwrap();
+        let chat = dir.path().join("survive.chat");
+
+        // Issue tokens and persist
+        let map1 = make_token_map();
+        let token = issue_token("alice", &map1, Some(&chat)).await.unwrap();
+
+        // Simulate restart: new empty token map, load from disk
+        let loaded = load_token_map(&chat);
+        assert_eq!(loaded.get(&token).map(String::as_str), Some("alice"));
+
+        // Populate a new token map from loaded data
+        let map2 = Arc::new(Mutex::new(loaded));
+        let username = validate_token(&token, &map2).await;
+        assert_eq!(username, Some("alice".to_owned()));
     }
 }

--- a/crates/room-cli/src/broker/daemon.rs
+++ b/crates/room-cli/src/broker/daemon.rs
@@ -389,6 +389,7 @@ async fn dispatch_connection(
             write_half,
             &state.token_map,
             state.config.as_ref(),
+            Some(&state.chat_path),
         )
         .await;
     }

--- a/crates/room-cli/src/broker/mod.rs
+++ b/crates/room-cli/src/broker/mod.rs
@@ -71,11 +71,20 @@ impl Broker {
         registry.register(Box::new(plugin::help::HelpPlugin))?;
         registry.register(Box::new(plugin::stats::StatsPlugin))?;
 
+        // Load persisted tokens from a previous broker session (if any).
+        let persisted_tokens = auth::load_token_map(&self.chat_path);
+        if !persisted_tokens.is_empty() {
+            eprintln!(
+                "[broker] loaded {} persisted token(s)",
+                persisted_tokens.len()
+            );
+        }
+
         let state = Arc::new(RoomState {
             clients: Arc::new(Mutex::new(HashMap::new())),
             status_map: Arc::new(Mutex::new(HashMap::new())),
             host_user: Arc::new(Mutex::new(None)),
-            token_map: Arc::new(Mutex::new(HashMap::new())),
+            token_map: Arc::new(Mutex::new(persisted_tokens)),
             chat_path: Arc::new(self.chat_path.clone()),
             room_id: Arc::new(self.room_id.clone()),
             shutdown: Arc::new(shutdown_tx),
@@ -175,6 +184,7 @@ async fn handle_client(
             write_half,
             &token_map,
             state.config.as_ref(),
+            Some(&state.chat_path),
         )
         .await;
     }

--- a/crates/room-cli/src/broker/ws.rs
+++ b/crates/room-cli/src/broker/ws.rs
@@ -339,7 +339,7 @@ async fn ws_oneshot_join(
         let _ = ws_tx.send(WsMessage::Close(None)).await;
         return Ok(());
     }
-    match issue_token(username, &state.token_map).await {
+    match issue_token(username, &state.token_map, Some(&state.chat_path)).await {
         Ok(token) => {
             let resp = serde_json::json!({"type":"token","token": token, "username": username});
             let _ = ws_tx.send(WsMessage::Text(resp.to_string().into())).await;
@@ -435,7 +435,13 @@ async fn api_join(
         )
             .into_response();
     }
-    match issue_token(&body.username, &state.room_state.token_map).await {
+    match issue_token(
+        &body.username,
+        &state.room_state.token_map,
+        Some(&state.room_state.chat_path),
+    )
+    .await
+    {
         Ok(token) => {
             let resp = serde_json::json!({
                 "type":"token","token": token, "username": body.username
@@ -716,7 +722,7 @@ async fn daemon_api_join(
         )
             .into_response();
     }
-    match issue_token(&body.username, &room.token_map).await {
+    match issue_token(&body.username, &room.token_map, Some(&room.chat_path)).await {
         Ok(token) => {
             let resp = serde_json::json!({
                 "type":"token","token": token, "username": body.username


### PR DESCRIPTION
Save token map to .tokens file alongside .chat file on every issuance. Load on broker startup so agents survive restarts without rejoining. All paths (UDS JOIN, WS JOIN, REST /join, daemon) persist. 7 new tests, 640 total. Closes #183