### PR TITLE
refactor(tests): extract reusable broker lifecycle helpers

### DIFF
--- a/crates/room-cli/tests/common/mod.rs
+++ b/crates/room-cli/tests/common/mod.rs
@@ -1,0 +1,53 @@
+/// Shared test helpers for broker lifecycle management.
+///
+/// Provides reusable utilities for test fixtures that spawn brokers:
+/// - Port allocation
+/// - Socket/TCP readiness polling
+/// - Stale file cleanup
+use std::path::Path;
+use std::time::Duration;
+
+/// Find a free ephemeral port by binding to port 0 and releasing.
+pub fn free_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.local_addr().unwrap().port()
+}
+
+/// Poll until a Unix socket file appears on disk, or panic after `timeout`.
+pub async fn wait_for_socket(path: &Path, timeout: Duration) {
+    let deadline = tokio::time::Instant::now() + timeout;
+    while !path.exists() {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "socket did not appear at {} within {:?}",
+            path.display(),
+            timeout
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+/// Poll until a TCP connection to `port` succeeds, or panic after `timeout`.
+pub async fn wait_for_tcp(port: u16, timeout: Duration) {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .is_ok()
+        {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "TCP port {port} not ready within {timeout:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+/// Remove stale files from a previous test run. Ignores missing files.
+pub fn cleanup_stale_files(paths: &[&str]) {
+    for path in paths {
+        let _ = std::fs::remove_file(path);
+    }
+}

--- a/crates/room-cli/tests/integration.rs
+++ b/crates/room-cli/tests/integration.rs
@@ -2,6 +2,8 @@
 ///
 /// Each test spins up a real broker (bound to a temp socket), connects raw
 /// Unix-socket clients, and verifies behaviour at the wire level.
+mod common;
+
 use std::{path::PathBuf, time::Duration};
 
 use futures_util::{SinkExt, StreamExt};
@@ -36,24 +38,9 @@ impl TestBroker {
     /// Start a broker with both UDS and WebSocket/REST transport.
     /// Returns (TestBroker, ws_port).
     async fn start_with_ws(room_id: &str) -> (Self, u16) {
-        // Bind to port 0 to get a free ephemeral port, then release it.
-        let tmp = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-        let port = tmp.local_addr().unwrap().port();
-        drop(tmp);
-
+        let port = common::free_port();
         let broker = Self::start_inner(room_id, Some(port)).await;
-
-        // Wait for the HTTP server to be ready.
-        for _ in 0..100 {
-            if tokio::net::TcpStream::connect(("127.0.0.1", port))
-                .await
-                .is_ok()
-            {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-
+        common::wait_for_tcp(port, Duration::from_secs(1)).await;
         (broker, port)
     }
 
@@ -67,14 +54,7 @@ impl TestBroker {
             broker.run().await.ok();
         });
 
-        // Wait until the socket file appears (broker has bound)
-        for _ in 0..100 {
-            if socket_path.exists() {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-        assert!(socket_path.exists(), "broker did not start in time");
+        common::wait_for_socket(&socket_path, Duration::from_secs(1)).await;
 
         Self {
             socket_path,
@@ -2684,13 +2664,7 @@ impl TestDaemon {
             daemon.run().await.ok();
         });
 
-        for _ in 0..100 {
-            if socket_path.exists() {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-        assert!(socket_path.exists(), "daemon did not start in time");
+        common::wait_for_socket(&socket_path, Duration::from_secs(1)).await;
 
         Self {
             socket_path,
@@ -2699,37 +2673,9 @@ impl TestDaemon {
     }
 
     async fn start(rooms: &[&str]) -> Self {
-        let dir = tempfile::tempdir().unwrap();
-        let socket_path = dir.path().join("roomd.sock");
-
-        let config = DaemonConfig {
-            socket_path: socket_path.clone(),
-            data_dir: dir.path().to_owned(),
-            ws_port: None,
-        };
-
-        let daemon = DaemonState::new(config);
-        for room_id in rooms {
-            daemon.create_room(room_id).await.unwrap();
-        }
-
-        tokio::spawn(async move {
-            daemon.run().await.ok();
-        });
-
-        // Wait until the socket file appears.
-        for _ in 0..100 {
-            if socket_path.exists() {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-        assert!(socket_path.exists(), "daemon did not start in time");
-
-        Self {
-            socket_path,
-            _dir: dir,
-        }
+        let rooms_with_config: Vec<(&str, Option<RoomConfig>)> =
+            rooms.iter().map(|id| (*id, None)).collect();
+        Self::start_with_configs(rooms_with_config).await
     }
 }
 

--- a/crates/room-cli/tests/ws_smoke.rs
+++ b/crates/room-cli/tests/ws_smoke.rs
@@ -7,6 +7,8 @@
 /// Tests are serialized via `SMOKE_LOCK` because spawning 5 broker processes
 /// simultaneously causes disk I/O contention on encrypted volumes, preventing
 /// any of them from starting within a reasonable timeout.
+mod common;
+
 use std::{
     process::Stdio,
     sync::{LazyLock, Mutex},
@@ -20,12 +22,6 @@ use tokio_tungstenite::{connect_async, tungstenite::Message as TungsteniteMsg};
 /// Serialize smoke test execution to prevent disk I/O contention when multiple
 /// broker processes start simultaneously on encrypted volumes.
 static SMOKE_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
-
-/// Find a free ephemeral port by binding to port 0 and releasing.
-fn free_port() -> u16 {
-    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-    listener.local_addr().unwrap().port()
-}
 
 /// Find the compiled `room` binary. Works with `cargo test`.
 fn room_binary() -> std::path::PathBuf {
@@ -42,20 +38,16 @@ fn room_binary() -> std::path::PathBuf {
 }
 
 /// Spawn a `room` broker process with a unique room ID and WS port.
-/// Returns (child, ws_port, room_id).
+/// Returns (child, ws_port).
 /// The caller must kill the child when done.
 async fn spawn_broker(room_id: &str) -> (tokio::process::Child, u16) {
-    let port = free_port();
+    let port = common::free_port();
     let bin = room_binary();
 
-    // Create a temp directory for the chat file.
     let chat_file = format!("/tmp/ws_smoke_{room_id}.chat");
-    // Clean up any stale files from previous runs.
-    let _ = std::fs::remove_file(&chat_file);
     let token_file = format!("/tmp/ws_smoke_{room_id}.tokens");
-    let _ = std::fs::remove_file(&token_file);
     let socket_path = format!("/tmp/room-{room_id}.sock");
-    let _ = std::fs::remove_file(&socket_path);
+    common::cleanup_stale_files(&[&chat_file, &token_file, &socket_path]);
 
     let mut child = tokio::process::Command::new(&bin)
         .args([
@@ -74,7 +66,7 @@ async fn spawn_broker(room_id: &str) -> (tokio::process::Child, u16) {
         .spawn()
         .unwrap_or_else(|e| panic!("failed to spawn room binary at {}: {e}", bin.display()));
 
-    // Wait for the WS server to be ready.
+    // Wait for TCP readiness with early crash detection.
     let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
     loop {
         if tokio::net::TcpStream::connect(("127.0.0.1", port))
@@ -83,7 +75,6 @@ async fn spawn_broker(room_id: &str) -> (tokio::process::Child, u16) {
         {
             break;
         }
-        // Check if the broker crashed before the port was ready.
         if let Ok(Some(status)) = child.try_wait() {
             panic!("broker exited with {status} before WS server was ready on port {port}");
         }


### PR DESCRIPTION
## Summary
- Extracts duplicated broker lifecycle helpers into `tests/common/mod.rs`: `free_port()`, `wait_for_socket()`, `wait_for_tcp()`, `cleanup_stale_files()`
- Refactors `TestBroker`, `TestDaemon`, and `spawn_broker` to use shared helpers instead of inline polling loops
- Consolidates `TestDaemon::start()` to delegate to `start_with_configs()`, eliminating ~30 lines of duplicated setup logic
- Net reduction: -78 lines removed, +68 added (10 fewer lines total)

## Test plan
- [x] All 694 Rust tests pass (no behavioral changes — pure refactoring)
- [x] WS smoke tests pass with shared `free_port()` and `cleanup_stale_files()`
- [x] Integration tests pass with shared `wait_for_socket()` and `wait_for_tcp()`
- [x] Pre-push checks clean (check, fmt, clippy, test)

Closes #181
