### PR TITLE
feat(query): add QueryFilter struct for room query engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1962,6 +1962,7 @@ dependencies = [
  "crossterm",
  "futures-util",
  "ratatui",
+ "regex",
  "reqwest",
  "room-protocol",
  "serde",

--- a/crates/room-cli/Cargo.toml
+++ b/crates/room-cli/Cargo.toml
@@ -28,6 +28,7 @@ chrono = { version = "0.4", features = ["serde"] }
 ratatui = "0.30"
 crossterm = "0.29"
 anyhow = "1"
+regex = "1"
 unicode-width = "0.2"
 axum = { version = "0.8.8", features = ["ws"] }
 tower-http = { version = "0.6.8", features = ["cors"] }

--- a/crates/room-cli/src/lib.rs
+++ b/crates/room-cli/src/lib.rs
@@ -4,5 +4,6 @@ pub mod history;
 pub mod message;
 pub mod oneshot;
 pub mod plugin;
+pub mod query;
 pub mod registry;
 pub mod tui;

--- a/crates/room-cli/src/query.rs
+++ b/crates/room-cli/src/query.rs
@@ -1,0 +1,588 @@
+//! Query filter for the `room query` subcommand.
+//!
+//! [`QueryFilter`] determines whether a given message should be included in
+//! query output. All fields are optional — a missing field means "no constraint
+//! on that dimension". A message passes [`QueryFilter::matches`] only when
+//! every present constraint is satisfied (logical AND).
+
+use chrono::{DateTime, Utc};
+use regex::Regex;
+use room_protocol::Message;
+
+/// Filter criteria for the `room query` subcommand (née `room poll`).
+///
+/// Constructed by the CLI flag parser and evaluated per-message. The `limit`
+/// and `ascending` fields control result set size and ordering; they are
+/// applied externally by the caller after filtering, not inside `matches`.
+#[derive(Debug, Clone, Default)]
+pub struct QueryFilter {
+    /// Only include messages from these rooms. Empty = all rooms.
+    pub rooms: Vec<String>,
+    /// Only include messages sent by these users. Empty = all users.
+    pub users: Vec<String>,
+    /// Only include messages whose content contains this substring
+    /// (case-sensitive).
+    pub content_search: Option<String>,
+    /// Only include messages whose content matches this regex pattern.
+    ///
+    /// Stored as `String` to keep the struct `Clone`-able; compiled inside
+    /// [`matches`][Self::matches] on each call. An invalid pattern causes the
+    /// message to be excluded (treated as "no match").
+    pub content_regex: Option<String>,
+    /// Only include messages whose sequence number is strictly greater than
+    /// this value. Tuple is `(room_id, seq)`. The constraint is skipped for
+    /// messages whose `room_id` differs from the filter room.
+    pub after_seq: Option<(String, u64)>,
+    /// Only include messages whose sequence number is strictly less than this
+    /// value. Tuple is `(room_id, seq)`. Skipped for messages from other rooms.
+    pub before_seq: Option<(String, u64)>,
+    /// Only include messages with a timestamp strictly after this instant.
+    pub after_ts: Option<DateTime<Utc>>,
+    /// Only include messages with a timestamp strictly before this instant.
+    pub before_ts: Option<DateTime<Utc>>,
+    /// Only include messages that @mention this username.
+    pub mention_user: Option<String>,
+    /// Exclude `DirectMessage` variants (public-channel filter).
+    pub public_only: bool,
+    /// Maximum number of messages to return. Applied externally by the caller.
+    pub limit: Option<usize>,
+    /// If `true`, return messages oldest-first. If `false`, newest-first.
+    /// Applied externally by the caller.
+    pub ascending: bool,
+}
+
+impl QueryFilter {
+    /// Returns `true` if `msg` satisfies all constraints in this filter.
+    ///
+    /// `room_id` is the room in which `msg` arrived; it is used when comparing
+    /// against `after_seq`/`before_seq` (which carry their own room component).
+    pub fn matches(&self, msg: &Message, room_id: &str) -> bool {
+        // ── room filter ───────────────────────────────────────────────────────
+        if !self.rooms.is_empty() && !self.rooms.iter().any(|r| r == room_id) {
+            return false;
+        }
+
+        // ── user filter ───────────────────────────────────────────────────────
+        if !self.users.is_empty() && !self.users.iter().any(|u| u == msg.user()) {
+            return false;
+        }
+
+        // ── public_only: skip DirectMessage variants ──────────────────────────
+        if self.public_only {
+            if let Message::DirectMessage { .. } = msg {
+                return false;
+            }
+        }
+
+        // ── content_search: substring match ───────────────────────────────────
+        if let Some(ref needle) = self.content_search {
+            match msg.content() {
+                Some(content) if content.contains(needle.as_str()) => {}
+                _ => return false,
+            }
+        }
+
+        // ── content_regex: regex match ─────────────────────────────────────────
+        if let Some(ref pattern) = self.content_regex {
+            match Regex::new(pattern) {
+                Ok(re) => match msg.content() {
+                    Some(content) if re.is_match(content) => {}
+                    _ => return false,
+                },
+                Err(_) => return false,
+            }
+        }
+
+        // ── mention filter ────────────────────────────────────────────────────
+        if let Some(ref user) = self.mention_user {
+            if !msg.mentions().contains(user) {
+                return false;
+            }
+        }
+
+        // ── seq range filter ──────────────────────────────────────────────────
+        // Constraints only apply when the message's room matches the filter room.
+        if let Some((ref filter_room, filter_seq)) = self.after_seq {
+            if room_id == filter_room {
+                match msg.seq() {
+                    Some(seq) if seq > filter_seq => {}
+                    _ => return false,
+                }
+            }
+        }
+
+        if let Some((ref filter_room, filter_seq)) = self.before_seq {
+            if room_id == filter_room {
+                match msg.seq() {
+                    Some(seq) if seq < filter_seq => {}
+                    _ => return false,
+                }
+            }
+        }
+
+        // ── timestamp range filter ────────────────────────────────────────────
+        if let Some(after) = self.after_ts {
+            if msg.ts() <= &after {
+                return false;
+            }
+        }
+
+        if let Some(before) = self.before_ts {
+            if msg.ts() >= &before {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use room_protocol::{make_dm, make_join, make_message};
+
+    fn ts(year: i32, month: u32, day: u32, h: u32, m: u32, s: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(year, month, day, h, m, s).unwrap()
+    }
+
+    fn msg_with_seq(room: &str, user: &str, content: &str, seq: u64) -> Message {
+        let mut m = make_message(room, user, content);
+        m.set_seq(seq);
+        m
+    }
+
+    fn msg_with_ts(room: &str, user: &str, content: &str, t: DateTime<Utc>) -> Message {
+        match make_message(room, user, content) {
+            Message::Message {
+                id,
+                room,
+                user,
+                content,
+                seq,
+                ..
+            } => Message::Message {
+                id,
+                room,
+                user,
+                ts: t,
+                content,
+                seq,
+            },
+            other => other,
+        }
+    }
+
+    // ── default filter passes everything ─────────────────────────────────────
+
+    #[test]
+    fn default_filter_passes_message() {
+        let f = QueryFilter::default();
+        let msg = make_message("r", "alice", "hello");
+        assert!(f.matches(&msg, "r"));
+    }
+
+    #[test]
+    fn default_filter_passes_join() {
+        let f = QueryFilter::default();
+        let msg = make_join("r", "alice");
+        assert!(f.matches(&msg, "r"));
+    }
+
+    #[test]
+    fn default_filter_passes_dm() {
+        let f = QueryFilter::default();
+        let msg = make_dm("r", "alice", "bob", "secret");
+        assert!(f.matches(&msg, "r"));
+    }
+
+    // ── rooms filter ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn rooms_filter_passes_matching_room() {
+        let f = QueryFilter {
+            rooms: vec!["dev".into()],
+            ..Default::default()
+        };
+        let msg = make_message("dev", "alice", "hi");
+        assert!(f.matches(&msg, "dev"));
+    }
+
+    #[test]
+    fn rooms_filter_rejects_other_room() {
+        let f = QueryFilter {
+            rooms: vec!["dev".into()],
+            ..Default::default()
+        };
+        let msg = make_message("prod", "alice", "hi");
+        assert!(!f.matches(&msg, "prod"));
+    }
+
+    #[test]
+    fn rooms_filter_multiple_rooms_passes_any() {
+        let f = QueryFilter {
+            rooms: vec!["dev".into(), "staging".into()],
+            ..Default::default()
+        };
+        assert!(f.matches(&make_message("dev", "u", "x"), "dev"));
+        assert!(f.matches(&make_message("staging", "u", "x"), "staging"));
+        assert!(!f.matches(&make_message("prod", "u", "x"), "prod"));
+    }
+
+    #[test]
+    fn rooms_filter_empty_passes_all() {
+        let f = QueryFilter::default();
+        assert!(f.matches(&make_message("anywhere", "u", "x"), "anywhere"));
+    }
+
+    // ── users filter ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn users_filter_passes_matching_user() {
+        let f = QueryFilter {
+            users: vec!["alice".into()],
+            ..Default::default()
+        };
+        assert!(f.matches(&make_message("r", "alice", "hi"), "r"));
+    }
+
+    #[test]
+    fn users_filter_rejects_other_user() {
+        let f = QueryFilter {
+            users: vec!["alice".into()],
+            ..Default::default()
+        };
+        assert!(!f.matches(&make_message("r", "bob", "hi"), "r"));
+    }
+
+    #[test]
+    fn users_filter_multiple_users() {
+        let f = QueryFilter {
+            users: vec!["alice".into(), "carol".into()],
+            ..Default::default()
+        };
+        assert!(f.matches(&make_message("r", "alice", "x"), "r"));
+        assert!(f.matches(&make_message("r", "carol", "x"), "r"));
+        assert!(!f.matches(&make_message("r", "bob", "x"), "r"));
+    }
+
+    // ── public_only filter ────────────────────────────────────────────────────
+
+    #[test]
+    fn public_only_excludes_dm() {
+        let f = QueryFilter {
+            public_only: true,
+            ..Default::default()
+        };
+        let msg = make_dm("r", "alice", "bob", "secret");
+        assert!(!f.matches(&msg, "r"));
+    }
+
+    #[test]
+    fn public_only_passes_regular_message() {
+        let f = QueryFilter {
+            public_only: true,
+            ..Default::default()
+        };
+        assert!(f.matches(&make_message("r", "alice", "hi"), "r"));
+    }
+
+    #[test]
+    fn public_only_false_passes_dm() {
+        let f = QueryFilter {
+            public_only: false,
+            ..Default::default()
+        };
+        let msg = make_dm("r", "alice", "bob", "secret");
+        assert!(f.matches(&msg, "r"));
+    }
+
+    // ── content_search filter ─────────────────────────────────────────────────
+
+    #[test]
+    fn content_search_passes_when_contained() {
+        let f = QueryFilter {
+            content_search: Some("hello".into()),
+            ..Default::default()
+        };
+        assert!(f.matches(&make_message("r", "u", "say hello there"), "r"));
+    }
+
+    #[test]
+    fn content_search_rejects_when_absent() {
+        let f = QueryFilter {
+            content_search: Some("hello".into()),
+            ..Default::default()
+        };
+        assert!(!f.matches(&make_message("r", "u", "goodbye"), "r"));
+    }
+
+    #[test]
+    fn content_search_rejects_join_no_content() {
+        let f = QueryFilter {
+            content_search: Some("hello".into()),
+            ..Default::default()
+        };
+        assert!(!f.matches(&make_join("r", "alice"), "r"));
+    }
+
+    #[test]
+    fn content_search_is_case_sensitive() {
+        let f = QueryFilter {
+            content_search: Some("Hello".into()),
+            ..Default::default()
+        };
+        assert!(!f.matches(&make_message("r", "u", "hello"), "r"));
+        assert!(f.matches(&make_message("r", "u", "say Hello world"), "r"));
+    }
+
+    // ── content_regex filter ──────────────────────────────────────────────────
+
+    #[test]
+    fn content_regex_passes_matching_pattern() {
+        let f = QueryFilter {
+            content_regex: Some(r"\d+".into()),
+            ..Default::default()
+        };
+        assert!(f.matches(&make_message("r", "u", "issue #42 fixed"), "r"));
+    }
+
+    #[test]
+    fn content_regex_rejects_non_matching() {
+        let f = QueryFilter {
+            content_regex: Some(r"^\d+$".into()),
+            ..Default::default()
+        };
+        assert!(!f.matches(&make_message("r", "u", "no numbers here"), "r"));
+    }
+
+    #[test]
+    fn content_regex_invalid_pattern_excludes_message() {
+        let f = QueryFilter {
+            content_regex: Some("[invalid".into()),
+            ..Default::default()
+        };
+        assert!(!f.matches(&make_message("r", "u", "anything"), "r"));
+    }
+
+    #[test]
+    fn content_regex_rejects_no_content() {
+        let f = QueryFilter {
+            content_regex: Some(".*".into()),
+            ..Default::default()
+        };
+        // Join has no content — should be excluded.
+        assert!(!f.matches(&make_join("r", "alice"), "r"));
+    }
+
+    // ── mention_user filter ────────────────────────────────────────────────────
+
+    #[test]
+    fn mention_user_passes_when_mentioned() {
+        let f = QueryFilter {
+            mention_user: Some("bob".into()),
+            ..Default::default()
+        };
+        assert!(f.matches(&make_message("r", "alice", "hey @bob"), "r"));
+    }
+
+    #[test]
+    fn mention_user_rejects_when_not_mentioned() {
+        let f = QueryFilter {
+            mention_user: Some("bob".into()),
+            ..Default::default()
+        };
+        assert!(!f.matches(&make_message("r", "alice", "hey @carol"), "r"));
+    }
+
+    #[test]
+    fn mention_user_rejects_no_content() {
+        let f = QueryFilter {
+            mention_user: Some("bob".into()),
+            ..Default::default()
+        };
+        assert!(!f.matches(&make_join("r", "alice"), "r"));
+    }
+
+    // ── after_seq filter ──────────────────────────────────────────────────────
+
+    #[test]
+    fn after_seq_passes_strictly_greater() {
+        let f = QueryFilter {
+            after_seq: Some(("r".into(), 10)),
+            ..Default::default()
+        };
+        assert!(f.matches(&msg_with_seq("r", "u", "x", 11), "r"));
+    }
+
+    #[test]
+    fn after_seq_rejects_equal() {
+        let f = QueryFilter {
+            after_seq: Some(("r".into(), 10)),
+            ..Default::default()
+        };
+        assert!(!f.matches(&msg_with_seq("r", "u", "x", 10), "r"));
+    }
+
+    #[test]
+    fn after_seq_rejects_lesser() {
+        let f = QueryFilter {
+            after_seq: Some(("r".into(), 10)),
+            ..Default::default()
+        };
+        assert!(!f.matches(&msg_with_seq("r", "u", "x", 5), "r"));
+    }
+
+    #[test]
+    fn after_seq_skips_constraint_for_different_room() {
+        // Filter room is "dev", message is in "prod" — constraint does not apply.
+        let f = QueryFilter {
+            after_seq: Some(("dev".into(), 10)),
+            ..Default::default()
+        };
+        assert!(f.matches(&msg_with_seq("prod", "u", "x", 1), "prod"));
+    }
+
+    #[test]
+    fn after_seq_rejects_msg_with_no_seq() {
+        let f = QueryFilter {
+            after_seq: Some(("r".into(), 0)),
+            ..Default::default()
+        };
+        // Message with no seq (None) fails the constraint.
+        let msg = make_message("r", "u", "x");
+        assert!(!f.matches(&msg, "r"));
+    }
+
+    // ── before_seq filter ─────────────────────────────────────────────────────
+
+    #[test]
+    fn before_seq_passes_strictly_lesser() {
+        let f = QueryFilter {
+            before_seq: Some(("r".into(), 10)),
+            ..Default::default()
+        };
+        assert!(f.matches(&msg_with_seq("r", "u", "x", 9), "r"));
+    }
+
+    #[test]
+    fn before_seq_rejects_equal() {
+        let f = QueryFilter {
+            before_seq: Some(("r".into(), 10)),
+            ..Default::default()
+        };
+        assert!(!f.matches(&msg_with_seq("r", "u", "x", 10), "r"));
+    }
+
+    #[test]
+    fn before_seq_skips_for_different_room() {
+        let f = QueryFilter {
+            before_seq: Some(("dev".into(), 5)),
+            ..Default::default()
+        };
+        assert!(f.matches(&msg_with_seq("prod", "u", "x", 100), "prod"));
+    }
+
+    // ── after_ts / before_ts filters ─────────────────────────────────────────
+
+    #[test]
+    fn after_ts_passes_strictly_after() {
+        let cutoff = ts(2026, 3, 1, 12, 0, 0);
+        let f = QueryFilter {
+            after_ts: Some(cutoff),
+            ..Default::default()
+        };
+        let msg = msg_with_ts("r", "u", "x", ts(2026, 3, 1, 13, 0, 0));
+        assert!(f.matches(&msg, "r"));
+    }
+
+    #[test]
+    fn after_ts_rejects_equal() {
+        let cutoff = ts(2026, 3, 1, 12, 0, 0);
+        let f = QueryFilter {
+            after_ts: Some(cutoff),
+            ..Default::default()
+        };
+        let msg = msg_with_ts("r", "u", "x", cutoff);
+        assert!(!f.matches(&msg, "r"));
+    }
+
+    #[test]
+    fn after_ts_rejects_before() {
+        let cutoff = ts(2026, 3, 1, 12, 0, 0);
+        let f = QueryFilter {
+            after_ts: Some(cutoff),
+            ..Default::default()
+        };
+        let msg = msg_with_ts("r", "u", "x", ts(2026, 3, 1, 11, 0, 0));
+        assert!(!f.matches(&msg, "r"));
+    }
+
+    #[test]
+    fn before_ts_passes_strictly_before() {
+        let cutoff = ts(2026, 3, 1, 12, 0, 0);
+        let f = QueryFilter {
+            before_ts: Some(cutoff),
+            ..Default::default()
+        };
+        let msg = msg_with_ts("r", "u", "x", ts(2026, 3, 1, 11, 0, 0));
+        assert!(f.matches(&msg, "r"));
+    }
+
+    #[test]
+    fn before_ts_rejects_equal() {
+        let cutoff = ts(2026, 3, 1, 12, 0, 0);
+        let f = QueryFilter {
+            before_ts: Some(cutoff),
+            ..Default::default()
+        };
+        let msg = msg_with_ts("r", "u", "x", cutoff);
+        assert!(!f.matches(&msg, "r"));
+    }
+
+    // ── combined filters ──────────────────────────────────────────────────────
+
+    #[test]
+    fn combined_room_and_user_filter() {
+        let f = QueryFilter {
+            rooms: vec!["dev".into()],
+            users: vec!["alice".into()],
+            ..Default::default()
+        };
+        assert!(f.matches(&make_message("dev", "alice", "x"), "dev"));
+        // Wrong room.
+        assert!(!f.matches(&make_message("prod", "alice", "x"), "prod"));
+        // Wrong user.
+        assert!(!f.matches(&make_message("dev", "bob", "x"), "dev"));
+    }
+
+    #[test]
+    fn combined_content_and_mention() {
+        let f = QueryFilter {
+            content_search: Some("ticket".into()),
+            mention_user: Some("bob".into()),
+            ..Default::default()
+        };
+        // Both match.
+        assert!(f.matches(&make_message("r", "u", "ticket #1 assigned @bob"), "r"));
+        // Only content matches.
+        assert!(!f.matches(&make_message("r", "u", "ticket #1"), "r"));
+        // Only mention matches.
+        assert!(!f.matches(&make_message("r", "u", "hey @bob"), "r"));
+    }
+
+    #[test]
+    fn combined_seq_range() {
+        let f = QueryFilter {
+            after_seq: Some(("r".into(), 5)),
+            before_seq: Some(("r".into(), 10)),
+            ..Default::default()
+        };
+        assert!(f.matches(&msg_with_seq("r", "u", "x", 7), "r"));
+        assert!(!f.matches(&msg_with_seq("r", "u", "x", 5), "r"));
+        assert!(!f.matches(&msg_with_seq("r", "u", "x", 10), "r"));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `crates/room-cli/src/query.rs` with `QueryFilter` struct and `matches()` method
- `QueryFilter` is the Phase 1 foundation for the `room query` engine; downstream tickets (#303–#306, #314–#315, #316) build on this struct
- Add `regex = "1"` to room-cli dependencies for `content_regex` matching
- Export `query` module from `crates/room-cli/src/lib.rs`

### QueryFilter fields

| Field | Type | Description |
|---|---|---|
| `rooms` | `Vec<String>` | Include-list by room ID (empty = all) |
| `users` | `Vec<String>` | Include-list by sender (empty = all) |
| `content_search` | `Option<String>` | Case-sensitive substring match |
| `content_regex` | `Option<String>` | Regex match (compiled in `matches()`) |
| `after_seq` | `Option<(String, u64)>` | Seq > N for given room |
| `before_seq` | `Option<(String, u64)>` | Seq < N for given room |
| `after_ts` | `Option<DateTime<Utc>>` | Timestamp strictly after cutoff |
| `before_ts` | `Option<DateTime<Utc>>` | Timestamp strictly before cutoff |
| `mention_user` | `Option<String>` | @mention filter |
| `public_only` | `bool` | Exclude `DirectMessage` variants |
| `limit` | `Option<usize>` | Max results (applied externally) |
| `ascending` | `bool` | Sort order (applied externally) |

`matches(&self, msg, room_id) -> bool` returns true only when all present constraints are satisfied. Invalid regex patterns return `false` (no panic). Seq constraints are scoped to their room — messages from other rooms pass through unaffected.

## Test plan

- [x] Default filter passes all message types (Message, Join, DirectMessage)
- [x] `rooms` — passes matching, rejects other, multiple rooms, empty passes all
- [x] `users` — passes matching, rejects other, multiple users
- [x] `public_only` — excludes DM, passes regular message, false allows DM
- [x] `content_search` — substring match, case-sensitive, rejects no-content variants
- [x] `content_regex` — regex match, invalid pattern excludes, no-content excludes
- [x] `mention_user` — passes when mentioned, rejects when not, rejects no-content
- [x] `after_seq` — strictly greater, rejects equal, rejects lesser, skips for different room, rejects None seq
- [x] `before_seq` — strictly lesser, rejects equal, skips for different room
- [x] `after_ts` / `before_ts` — strictly after/before, rejects equal
- [x] Combined: room+user, content+mention, seq range

40 new tests. Total Rust tests: 752 (was 702).

Closes #302
