### PR TITLE
feat(broker): DM privacy enforcement

### DIFF
--- a/crates/room-cli/src/broker/auth.rs
+++ b/crates/room-cli/src/broker/auth.rs
@@ -67,6 +67,32 @@ pub(crate) fn check_join_permission(
     }
 }
 
+/// Check whether `username` is allowed to send a message in a room.
+///
+/// For DM rooms, only the two participants may send. The host may join
+/// read-only (for administrative oversight) but cannot send messages.
+/// All other room types allow any joined user to send.
+///
+/// Returns `Ok(())` if allowed, or `Err(reason)` if denied.
+/// Rooms without config (legacy single-room mode) are always allowed.
+pub(crate) fn check_send_permission(
+    username: &str,
+    config: Option<&RoomConfig>,
+) -> Result<(), String> {
+    let config = match config {
+        Some(c) => c,
+        None => return Ok(()), // Legacy rooms — always allow.
+    };
+
+    if config.visibility == RoomVisibility::Dm && !config.invite_list.contains(username) {
+        return Err(
+            "permission denied: only DM participants can send messages in this room".to_owned(),
+        );
+    }
+
+    Ok(())
+}
+
 /// Issue a session token for `username` if the name is not already taken.
 ///
 /// Returns the new token string on success, or an error message on collision.
@@ -316,6 +342,54 @@ mod tests {
     #[test]
     fn join_no_config_always_allowed() {
         assert!(check_join_permission("anyone", None).is_ok());
+    }
+
+    // ── check_send_permission ─────────────────────────────────────────────
+
+    #[test]
+    fn send_public_room_always_allowed() {
+        let config = RoomConfig::public("owner");
+        assert!(check_send_permission("anyone", Some(&config)).is_ok());
+    }
+
+    #[test]
+    fn send_dm_room_participants_allowed() {
+        let config = RoomConfig::dm("alice", "bob");
+        assert!(check_send_permission("alice", Some(&config)).is_ok());
+        assert!(check_send_permission("bob", Some(&config)).is_ok());
+    }
+
+    #[test]
+    fn send_dm_room_non_participant_denied() {
+        let config = RoomConfig::dm("alice", "bob");
+        let result = check_send_permission("eve", Some(&config));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("permission denied"));
+    }
+
+    #[test]
+    fn send_dm_room_host_denied() {
+        // Host can join read-only but must not be able to send
+        let config = RoomConfig::dm("alice", "bob");
+        assert!(check_send_permission("host-user", Some(&config)).is_err());
+    }
+
+    #[test]
+    fn send_private_room_any_member_allowed() {
+        let config = RoomConfig {
+            visibility: RoomVisibility::Private,
+            max_members: None,
+            invite_list: ["alice".to_owned()].into(),
+            created_by: "owner".to_owned(),
+            created_at: "2026-01-01T00:00:00Z".to_owned(),
+        };
+        // Private rooms don't restrict sends — only joins
+        assert!(check_send_permission("anyone", Some(&config)).is_ok());
+    }
+
+    #[test]
+    fn send_no_config_always_allowed() {
+        assert!(check_send_permission("anyone", None).is_ok());
     }
 
     // ── Token persistence ─────────────────────────────────────────────────

--- a/crates/room-cli/src/broker/mod.rs
+++ b/crates/room-cli/src/broker/mod.rs
@@ -360,6 +360,23 @@ pub(crate) async fn run_interactive_session(
                             }
                             Ok(CommandResult::Shutdown) => break,
                             Ok(CommandResult::Passthrough(msg)) => {
+                                // DM privacy: reject sends from non-participants
+                                if let Err(reason) = auth::check_send_permission(
+                                    &username_in,
+                                    state_in.config.as_ref(),
+                                ) {
+                                    let err = serde_json::json!({
+                                        "type": "error",
+                                        "code": "send_denied",
+                                        "message": reason
+                                    });
+                                    let _ = write_half_in
+                                        .lock()
+                                        .await
+                                        .write_all(format!("{err}\n").as_bytes())
+                                        .await;
+                                    continue;
+                                }
                                 let result = match &msg {
                                     Message::DirectMessage { to, .. } => {
                                         dm_and_persist(
@@ -441,6 +458,16 @@ pub(crate) async fn handle_oneshot_send(
             write_half.write_all(format!("{json}\n").as_bytes()).await?;
         }
         CommandResult::Passthrough(msg) => {
+            // DM privacy: reject sends from non-participants
+            if let Err(reason) = auth::check_send_permission(&username, state.config.as_ref()) {
+                let err = serde_json::json!({
+                    "type": "error",
+                    "code": "send_denied",
+                    "message": reason
+                });
+                write_half.write_all(format!("{err}\n").as_bytes()).await?;
+                return Ok(());
+            }
             let seq_msg = match &msg {
                 Message::DirectMessage { to, .. } => {
                     dm_and_persist(


### PR DESCRIPTION
## Summary

- Add `check_send_permission()` in auth.rs following the existing `check_join_permission` pattern
- DM rooms (`visibility == Dm`) only allow the two participants in `invite_list` to send
- All other room types (Public, Private, Unlisted) allow any joined user to send
- Wire the check into both the interactive session loop and oneshot send path in mod.rs
- Returns `{"type":"error","code":"send_denied","message":"..."}` on violation

## Breaking changes

- Non-participants in DM rooms now get `send_denied` errors instead of their messages going through
- Defense-in-depth: join checks already prevent non-participants from getting tokens, but this catches edge cases

## Test plan

- [x] `send_public_room_always_allowed` — public rooms unrestricted
- [x] `send_dm_room_participants_allowed` — alice and bob can send
- [x] `send_dm_room_non_participant_denied` — eve gets rejected
- [x] `send_dm_room_host_denied` — host cannot send to DM rooms
- [x] `send_private_room_any_member_allowed` — private rooms unrestricted on send
- [x] `send_no_config_always_allowed` — legacy rooms backward compatible
- [x] All existing tests pass (no regressions)

Closes #300