### PR TITLE
feat(cli): add room dm oneshot command

### DIFF
--- a/crates/room-cli/src/main.rs
+++ b/crates/room-cli/src/main.rs
@@ -98,6 +98,21 @@ enum Cmd {
         #[arg(long)]
         json: bool,
     },
+    /// Send a direct message to a user, creating the DM room if needed.
+    ///
+    /// Computes the canonical DM room ID (`dm-<sorted_a>-<sorted_b>`) and sends
+    /// the message. The caller's username is resolved from the token.
+    /// Prints the broadcast message JSON and exits.
+    Dm {
+        /// Recipient username
+        user: String,
+        /// Session token from `room join` (required)
+        #[arg(short = 't', long)]
+        token: String,
+        /// Message content; all remaining tokens are joined with spaces
+        #[arg(trailing_var_arg = true, num_args = 1..)]
+        message: Vec<String>,
+    },
     /// List active rooms with running brokers.
     ///
     /// Scans `/tmp` for `room-*.sock` files and probes each to verify the broker
@@ -219,6 +234,14 @@ async fn main() -> anyhow::Result<()> {
             json,
         }) => {
             oneshot::cmd_who(&room_id, &token, json).await?;
+        }
+        Some(Cmd::Dm {
+            user,
+            token,
+            message,
+        }) => {
+            let content = message.join(" ");
+            oneshot::cmd_dm(&user, &token, &content).await?;
         }
         Some(Cmd::List) => {
             oneshot::cmd_list().await?;

--- a/crates/room-cli/src/oneshot/mod.rs
+++ b/crates/room-cli/src/oneshot/mod.rs
@@ -9,12 +9,13 @@ pub use poll::{
     cmd_poll, cmd_poll_multi, cmd_pull, cmd_watch, poll_messages, poll_messages_multi,
     pull_messages,
 };
-pub use token::{cmd_join, token_file_path, username_from_token};
+pub use token::{cmd_join, token_file_path, username_from_token, username_from_token_any_room};
 pub use transport::{join_session, send_message, send_message_with_token};
 pub use who::cmd_who;
 
 use std::path::PathBuf;
 
+use room_protocol::dm_room_id;
 use transport::send_message_with_token as transport_send;
 
 /// One-shot send subcommand: connect, send, print echo JSON to stdout, exit.
@@ -43,6 +44,48 @@ pub async fn cmd_send(
         .map_err(|e| {
             if e.to_string().contains("invalid token") {
                 anyhow::anyhow!("invalid token — run: room join {room_id} <username>")
+            } else {
+                e
+            }
+        })?;
+    println!("{}", serde_json::to_string(&msg)?);
+    Ok(())
+}
+
+/// One-shot DM subcommand: compute canonical DM room ID, send message, exit.
+///
+/// Resolves the caller's username from the token file, then computes the
+/// deterministic DM room ID (`dm-<sorted_a>-<sorted_b>`). Sends the message
+/// to that room's broker socket. The DM room must already exist (room creation
+/// will be handled by E1-6 dynamic room creation).
+///
+/// Returns an error if the caller tries to DM themselves or if the DM room
+/// broker is not running.
+pub async fn cmd_dm(recipient: &str, token: &str, content: &str) -> anyhow::Result<()> {
+    // Resolve the caller's username from the token
+    let caller = username_from_token_any_room(token)?;
+
+    // Compute canonical DM room ID
+    let dm_id = dm_room_id(&caller, recipient).map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    // Build the wire payload as a DM message
+    let wire = serde_json::json!({"type": "dm", "to": recipient, "content": content}).to_string();
+
+    // Send via the DM room's socket
+    let socket_path = PathBuf::from(format!("/tmp/room-{dm_id}.sock"));
+    let msg = transport_send(&socket_path, token, &wire)
+        .await
+        .map_err(|e| {
+            if e.to_string().contains("No such file")
+                || e.to_string().contains("Connection refused")
+            {
+                anyhow::anyhow!(
+                    "DM room '{dm_id}' is not running — start it or use a daemon with the room pre-created"
+                )
+            } else if e.to_string().contains("invalid token") {
+                anyhow::anyhow!(
+                    "invalid token for DM room '{dm_id}' — you may need to join it first"
+                )
             } else {
                 e
             }

--- a/crates/room-cli/src/oneshot/token.rs
+++ b/crates/room-cli/src/oneshot/token.rs
@@ -61,6 +61,42 @@ pub fn username_from_token(room_id: &str, token: &str) -> anyhow::Result<String>
     anyhow::bail!("token not recognised — run: room join {room_id} <username> to get a fresh token")
 }
 
+/// Look up the username associated with `token` by scanning ALL token files in `/tmp`.
+///
+/// Unlike [`username_from_token`], this does not require a room_id. It scans every
+/// `room-*-*.token` file and returns the username from the first match. Used by
+/// `room dm` where the caller's room_id is unknown (the DM room_id depends on the
+/// caller's username, creating a chicken-and-egg problem).
+pub fn username_from_token_any_room(token: &str) -> anyhow::Result<String> {
+    let prefix = "room-";
+    let suffix = ".token";
+    let files: Vec<PathBuf> = std::fs::read_dir("/tmp")
+        .map_err(|e| anyhow::anyhow!("cannot read /tmp: {e}"))?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .map(|n| n.starts_with(prefix) && n.ends_with(suffix))
+                .unwrap_or(false)
+        })
+        .collect();
+
+    for path in files {
+        if let Ok(data) = std::fs::read_to_string(&path) {
+            if let Ok(v) = serde_json::from_str::<serde_json::Value>(data.trim()) {
+                if v["token"].as_str() == Some(token) {
+                    if let Some(u) = v["username"].as_str() {
+                        return Ok(u.to_owned());
+                    }
+                }
+            }
+        }
+    }
+
+    anyhow::bail!("token not recognised — run: room join <room-id> <username> to get a fresh token")
+}
+
 /// Read the cursor position from disk, returning `None` if the file is absent or empty.
 pub fn read_cursor(cursor_path: &Path) -> Option<String> {
     std::fs::read_to_string(cursor_path)
@@ -178,6 +214,96 @@ mod tests {
         assert_eq!(
             username_from_token_in(dir.path(), "r4", "tok-bob").unwrap(),
             "bob"
+        );
+    }
+
+    /// A version of username_from_token_any_room that scans a custom directory.
+    fn username_from_token_any_room_in(
+        dir: &std::path::Path,
+        token: &str,
+    ) -> anyhow::Result<String> {
+        let prefix = "room-";
+        let suffix = ".token";
+        let files: Vec<PathBuf> = fs::read_dir(dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| {
+                p.file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|n| n.starts_with(prefix) && n.ends_with(suffix))
+                    .unwrap_or(false)
+            })
+            .collect();
+
+        for path in files {
+            if let Ok(data) = fs::read_to_string(&path) {
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(data.trim()) {
+                    if v["token"].as_str() == Some(token) {
+                        if let Some(u) = v["username"].as_str() {
+                            return Ok(u.to_owned());
+                        }
+                    }
+                }
+            }
+        }
+        anyhow::bail!("token not recognised")
+    }
+
+    #[test]
+    fn any_room_finds_token_across_rooms() {
+        let dir = TempDir::new().unwrap();
+        write_token_file(dir.path(), "lobby", "alice", "tok-alice");
+        write_token_file(dir.path(), "dev", "alice", "tok-alice-dev");
+
+        assert_eq!(
+            username_from_token_any_room_in(dir.path(), "tok-alice").unwrap(),
+            "alice"
+        );
+        assert_eq!(
+            username_from_token_any_room_in(dir.path(), "tok-alice-dev").unwrap(),
+            "alice"
+        );
+    }
+
+    #[test]
+    fn any_room_unknown_token_errors() {
+        let dir = TempDir::new().unwrap();
+        write_token_file(dir.path(), "lobby", "alice", "tok-alice");
+        let err = username_from_token_any_room_in(dir.path(), "bogus").unwrap_err();
+        assert!(
+            err.to_string().contains("token not recognised"),
+            "expected error hint in: {err}"
+        );
+    }
+
+    #[test]
+    fn any_room_ignores_non_token_files() {
+        let dir = TempDir::new().unwrap();
+        // Write a non-token file that matches partially
+        fs::write(dir.path().join("room-lobby.sock"), "not a token").unwrap();
+        write_token_file(dir.path(), "lobby", "bob", "tok-bob");
+
+        assert_eq!(
+            username_from_token_any_room_in(dir.path(), "tok-bob").unwrap(),
+            "bob"
+        );
+    }
+
+    #[test]
+    fn any_room_same_user_different_tokens_per_room() {
+        let dir = TempDir::new().unwrap();
+        write_token_file(dir.path(), "r1", "carol", "tok-r1");
+        write_token_file(dir.path(), "r2", "carol", "tok-r2");
+
+        // Both tokens resolve to carol
+        assert_eq!(
+            username_from_token_any_room_in(dir.path(), "tok-r1").unwrap(),
+            "carol"
+        );
+        assert_eq!(
+            username_from_token_any_room_in(dir.path(), "tok-r2").unwrap(),
+            "carol"
         );
     }
 


### PR DESCRIPTION
## Summary

- Add `room dm <user> -t <token> <message>` oneshot CLI command for sending DMs without knowing the room ID
- Resolves the caller's username by scanning all token files (new `username_from_token_any_room`), then computes the canonical DM room ID (`dm-<sorted_a>-<sorted_b>`)
- Sends via the DM room's broker socket with proper error messages for missing rooms and invalid tokens

## Design note

The `room dm` command has a chicken-and-egg problem: the DM room ID requires the caller's username, but `username_from_token()` requires a room ID. Solved by adding `username_from_token_any_room()` which scans all `/tmp/room-*-*.token` files regardless of room prefix.

## Test plan

- [x] `any_room_finds_token_across_rooms` — finds user across multiple room token files
- [x] `any_room_unknown_token_errors` — returns error for unrecognised tokens
- [x] `any_room_ignores_non_token_files` — skips `.sock` and other non-token files
- [x] `any_room_same_user_different_tokens_per_room` — different tokens per room both resolve
- [x] All existing tests pass (no regressions)
- [x] `bash scripts/pre-push.sh` passes (check, fmt, clippy, test)

Closes #298
