### PR TITLE
feat(paths): durable state dir — move tokens/cursors to ~/.room/ (#285)

### DIFF
--- a/crates/room-cli/src/broker/auth.rs
+++ b/crates/room-cli/src/broker/auth.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use room_protocol::{RoomConfig, RoomVisibility};
 use tokio::{io::AsyncWriteExt, net::unix::OwnedWriteHalf};
@@ -9,13 +9,6 @@ use super::state::TokenMap;
 
 // ── Token persistence ────────────────────────────────────────────────────────
 
-/// Derive the token file path from a chat file path.
-///
-/// Given `/tmp/myroom.chat`, returns `/tmp/myroom.tokens`.
-pub(crate) fn token_file_path(chat_path: &Path) -> PathBuf {
-    chat_path.with_extension("tokens")
-}
-
 /// Write a token map to disk as JSON.
 fn save_token_map(map: &HashMap<String, String>, path: &Path) -> Result<(), String> {
     let json = serde_json::to_string_pretty(&map).map_err(|e| format!("serialize tokens: {e}"))?;
@@ -23,14 +16,18 @@ fn save_token_map(map: &HashMap<String, String>, path: &Path) -> Result<(), Stri
 }
 
 /// Load a token map from disk. Returns an empty map if the file does not exist.
-pub(crate) fn load_token_map(chat_path: &Path) -> HashMap<String, String> {
-    let path = token_file_path(chat_path);
-    let contents = match std::fs::read_to_string(&path) {
+///
+/// `token_map_path` is the `.tokens` file (see [`crate::paths::broker_tokens_path`]).
+pub(crate) fn load_token_map(token_map_path: &Path) -> HashMap<String, String> {
+    let contents = match std::fs::read_to_string(token_map_path) {
         Ok(c) => c,
         Err(_) => return HashMap::new(),
     };
     serde_json::from_str(&contents).unwrap_or_else(|e| {
-        eprintln!("[auth] corrupt token file {}: {e}", path.display());
+        eprintln!(
+            "[auth] corrupt token file {}: {e}",
+            token_map_path.display()
+        );
         HashMap::new()
     })
 }
@@ -96,8 +93,9 @@ pub(crate) fn check_send_permission(
 /// Issue a session token for `username` if the name is not already taken.
 ///
 /// Returns the new token string on success, or an error message on collision.
-/// If `persist_to` is `Some(chat_path)`, the updated token map is saved to
-/// disk alongside the chat file so tokens survive broker restarts.
+/// If `persist_to` is `Some(token_map_path)`, the updated token map is saved to
+/// `token_map_path` so tokens survive broker restarts.
+/// `token_map_path` should be the file returned by [`crate::paths::broker_tokens_path`].
 pub(crate) async fn issue_token(
     username: &str,
     token_map: &TokenMap,
@@ -109,8 +107,8 @@ pub(crate) async fn issue_token(
     }
     let token = Uuid::new_v4().to_string();
     map.insert(token.clone(), username.to_owned());
-    if let Some(chat_path) = persist_to {
-        if let Err(e) = save_token_map(&map, &token_file_path(chat_path)) {
+    if let Some(token_map_path) = persist_to {
+        if let Err(e) = save_token_map(&map, token_map_path) {
             eprintln!("[auth] token persist failed: {e}");
         }
     }
@@ -130,14 +128,15 @@ pub(crate) async fn validate_token(token: &str, token_map: &TokenMap) -> Option<
 ///
 /// Checks join permission against the room config, then calls `issue_token`
 /// and writes the response JSON to the socket. Rejects unauthorized joins
-/// with an error envelope. If `chat_path` is provided, the token map is
+/// with an error envelope. If `token_map_path` is provided, the token map is
 /// persisted to disk after a successful issuance.
+/// `token_map_path` should be the file returned by [`crate::paths::broker_tokens_path`].
 pub(crate) async fn handle_oneshot_join(
     username: String,
     mut write_half: OwnedWriteHalf,
     token_map: &TokenMap,
     config: Option<&RoomConfig>,
-    chat_path: Option<&Path>,
+    token_map_path: Option<&Path>,
 ) -> anyhow::Result<()> {
     // Check visibility/ACL before issuing a token.
     if let Err(reason) = check_join_permission(&username, config) {
@@ -151,7 +150,7 @@ pub(crate) async fn handle_oneshot_join(
         return Ok(());
     }
 
-    match issue_token(&username, token_map, chat_path).await {
+    match issue_token(&username, token_map, token_map_path).await {
         Ok(token) => {
             let resp = serde_json::json!({"type":"token","token": token,"username": username});
             write_half.write_all(format!("{resp}\n").as_bytes()).await?;
@@ -395,80 +394,66 @@ mod tests {
     // ── Token persistence ─────────────────────────────────────────────────
 
     #[test]
-    fn token_file_path_replaces_extension() {
-        let chat = std::path::PathBuf::from("/tmp/myroom.chat");
-        assert_eq!(
-            token_file_path(&chat),
-            std::path::PathBuf::from("/tmp/myroom.tokens")
-        );
-    }
-
-    #[test]
-    fn token_file_path_no_extension() {
-        let chat = std::path::PathBuf::from("/tmp/myroom");
-        assert_eq!(
-            token_file_path(&chat),
-            std::path::PathBuf::from("/tmp/myroom.tokens")
-        );
-    }
-
-    #[test]
     fn load_token_map_missing_file_returns_empty() {
         let dir = tempfile::tempdir().unwrap();
-        let chat = dir.path().join("nonexistent.chat");
-        let map = load_token_map(&chat);
+        let token_map_path = dir.path().join("nonexistent.tokens");
+        let map = load_token_map(&token_map_path);
         assert!(map.is_empty());
     }
 
     #[test]
     fn save_and_load_round_trip() {
         let dir = tempfile::tempdir().unwrap();
-        let chat = dir.path().join("test.chat");
-        let token_path = token_file_path(&chat);
+        let token_map_path = dir.path().join("test.tokens");
 
         let mut original = HashMap::new();
         original.insert("tok-1".to_owned(), "alice".to_owned());
         original.insert("tok-2".to_owned(), "bob".to_owned());
 
-        save_token_map(&original, &token_path).unwrap();
-        let loaded = load_token_map(&chat);
+        save_token_map(&original, &token_map_path).unwrap();
+        let loaded = load_token_map(&token_map_path);
         assert_eq!(loaded, original);
     }
 
     #[test]
     fn load_token_map_corrupt_file_returns_empty() {
         let dir = tempfile::tempdir().unwrap();
-        let chat = dir.path().join("corrupt.chat");
-        let token_path = token_file_path(&chat);
-        std::fs::write(token_path, "not json{{{").unwrap();
+        let token_map_path = dir.path().join("corrupt.tokens");
+        std::fs::write(&token_map_path, "not json{{{").unwrap();
 
-        let map = load_token_map(&chat);
+        let map = load_token_map(&token_map_path);
         assert!(map.is_empty());
     }
 
     #[tokio::test]
     async fn issue_token_persists_to_disk() {
         let dir = tempfile::tempdir().unwrap();
-        let chat = dir.path().join("persist.chat");
+        let token_map_path = dir.path().join("persist.tokens");
 
         let map = make_token_map();
-        let token = issue_token("alice", &map, Some(&chat)).await.unwrap();
+        let token = issue_token("alice", &map, Some(&token_map_path))
+            .await
+            .unwrap();
 
         // Verify the file was written and contains the token
-        let loaded = load_token_map(&chat);
+        let loaded = load_token_map(&token_map_path);
         assert_eq!(loaded.get(&token).map(String::as_str), Some("alice"));
     }
 
     #[tokio::test]
     async fn issue_token_accumulates_on_disk() {
         let dir = tempfile::tempdir().unwrap();
-        let chat = dir.path().join("accum.chat");
+        let token_map_path = dir.path().join("accum.tokens");
 
         let map = make_token_map();
-        let t1 = issue_token("alice", &map, Some(&chat)).await.unwrap();
-        let t2 = issue_token("bob", &map, Some(&chat)).await.unwrap();
+        let t1 = issue_token("alice", &map, Some(&token_map_path))
+            .await
+            .unwrap();
+        let t2 = issue_token("bob", &map, Some(&token_map_path))
+            .await
+            .unwrap();
 
-        let loaded = load_token_map(&chat);
+        let loaded = load_token_map(&token_map_path);
         assert_eq!(loaded.len(), 2);
         assert_eq!(loaded.get(&t1).map(String::as_str), Some("alice"));
         assert_eq!(loaded.get(&t2).map(String::as_str), Some("bob"));
@@ -477,14 +462,16 @@ mod tests {
     #[tokio::test]
     async fn persisted_tokens_survive_new_token_map() {
         let dir = tempfile::tempdir().unwrap();
-        let chat = dir.path().join("survive.chat");
+        let token_map_path = dir.path().join("survive.tokens");
 
         // Issue tokens and persist
         let map1 = make_token_map();
-        let token = issue_token("alice", &map1, Some(&chat)).await.unwrap();
+        let token = issue_token("alice", &map1, Some(&token_map_path))
+            .await
+            .unwrap();
 
         // Simulate restart: new empty token map, load from disk
-        let loaded = load_token_map(&chat);
+        let loaded = load_token_map(&token_map_path);
         assert_eq!(loaded.get(&token).map(String::as_str), Some("alice"));
 
         // Populate a new token map from loaded data

--- a/crates/room-cli/src/broker/commands.rs
+++ b/crates/room-cli/src/broker/commands.rs
@@ -557,6 +557,7 @@ mod tests {
 
     fn make_state(chat_path: std::path::PathBuf) -> Arc<RoomState> {
         let (shutdown_tx, _) = watch::channel(false);
+        let token_map_path = chat_path.with_extension("tokens");
         Arc::new(RoomState {
             clients: Arc::new(Mutex::new(HashMap::new())),
             status_map: Arc::new(Mutex::new(HashMap::new())),
@@ -565,6 +566,7 @@ mod tests {
             claim_map: Arc::new(Mutex::new(HashMap::new())),
             subscription_map: Arc::new(Mutex::new(HashMap::new())),
             chat_path: Arc::new(chat_path),
+            token_map_path: Arc::new(token_map_path),
             room_id: Arc::new("test-room".to_owned()),
             shutdown: Arc::new(shutdown_tx),
             seq_counter: Arc::new(AtomicU64::new(0)),
@@ -1131,6 +1133,7 @@ mod tests {
         config: room_protocol::RoomConfig,
     ) -> Arc<RoomState> {
         let (shutdown_tx, _) = watch::channel(false);
+        let token_map_path = chat_path.with_extension("tokens");
         Arc::new(RoomState {
             clients: Arc::new(Mutex::new(HashMap::new())),
             status_map: Arc::new(Mutex::new(HashMap::new())),
@@ -1139,6 +1142,7 @@ mod tests {
             claim_map: Arc::new(Mutex::new(HashMap::new())),
             subscription_map: Arc::new(Mutex::new(HashMap::new())),
             chat_path: Arc::new(chat_path),
+            token_map_path: Arc::new(token_map_path),
             room_id: Arc::new("test-room".to_owned()),
             shutdown: Arc::new(shutdown_tx),
             seq_counter: Arc::new(AtomicU64::new(0)),

--- a/crates/room-cli/src/broker/daemon.rs
+++ b/crates/room-cli/src/broker/daemon.rs
@@ -77,10 +77,14 @@ pub fn validate_room_id(room_id: &str) -> Result<(), String> {
 /// Configuration for the daemon.
 #[derive(Debug, Clone)]
 pub struct DaemonConfig {
-    /// Path to the daemon UDS socket.
+    /// Path to the daemon UDS socket (ephemeral, platform-native temp dir).
     pub socket_path: PathBuf,
     /// Directory for chat files. Each room gets `<data_dir>/<room_id>.chat`.
+    /// Defaults to `~/.room/data/`; overridable with `--data-dir`.
     pub data_dir: PathBuf,
+    /// Directory for state files (token maps, cursors, subscriptions).
+    /// Defaults to `~/.room/state/`.
+    pub state_dir: PathBuf,
     /// Optional WebSocket/REST port.
     pub ws_port: Option<u16>,
 }
@@ -90,13 +94,19 @@ impl DaemonConfig {
     pub fn chat_path(&self, room_id: &str) -> PathBuf {
         self.data_dir.join(format!("{room_id}.chat"))
     }
+
+    /// Resolve the token-map persistence path for a given room.
+    pub fn token_map_path(&self, room_id: &str) -> PathBuf {
+        crate::paths::broker_tokens_path(&self.state_dir, room_id)
+    }
 }
 
 impl Default for DaemonConfig {
     fn default() -> Self {
         Self {
-            socket_path: PathBuf::from("/tmp/roomd.sock"),
-            data_dir: PathBuf::from("/tmp"),
+            socket_path: crate::paths::room_socket_path(),
+            data_dir: crate::paths::room_data_dir(),
+            state_dir: crate::paths::room_state_dir(),
             ws_port: None,
         }
     }
@@ -137,6 +147,7 @@ impl DaemonState {
         }
 
         let chat_path = self.config.chat_path(room_id);
+        let token_map_path = self.config.token_map_path(room_id);
         let (shutdown_tx, _) = watch::channel(false);
 
         let mut registry = PluginRegistry::new();
@@ -147,14 +158,18 @@ impl DaemonState {
             .register(Box::new(plugin::stats::StatsPlugin))
             .map_err(|e| format!("plugin error: {e}"))?;
 
+        // Load persisted tokens from previous session (if any).
+        let persisted_tokens = super::auth::load_token_map(&token_map_path);
+
         let state = Arc::new(RoomState {
             clients: Arc::new(Mutex::new(HashMap::new())),
             status_map: Arc::new(Mutex::new(HashMap::new())),
             host_user: Arc::new(Mutex::new(None)),
-            token_map: Arc::new(Mutex::new(HashMap::new())),
+            token_map: Arc::new(Mutex::new(persisted_tokens)),
             claim_map: Arc::new(Mutex::new(HashMap::new())),
             subscription_map: Arc::new(Mutex::new(HashMap::new())),
             chat_path: Arc::new(chat_path),
+            token_map_path: Arc::new(token_map_path),
             room_id: Arc::new(room_id.to_owned()),
             shutdown: Arc::new(shutdown_tx),
             seq_counter: Arc::new(AtomicU64::new(0)),
@@ -180,6 +195,7 @@ impl DaemonState {
         }
 
         let chat_path = self.config.chat_path(room_id);
+        let token_map_path = self.config.token_map_path(room_id);
         let (shutdown_tx, _) = watch::channel(false);
 
         let mut registry = PluginRegistry::new();
@@ -192,15 +208,17 @@ impl DaemonState {
 
         // Auto-subscribe DM participants at Full tier.
         let initial_subs = build_initial_subscriptions(&config);
+        let persisted_tokens = super::auth::load_token_map(&token_map_path);
 
         let state = Arc::new(RoomState {
             clients: Arc::new(Mutex::new(HashMap::new())),
             status_map: Arc::new(Mutex::new(HashMap::new())),
             host_user: Arc::new(Mutex::new(None)),
-            token_map: Arc::new(Mutex::new(HashMap::new())),
+            token_map: Arc::new(Mutex::new(persisted_tokens)),
             claim_map: Arc::new(Mutex::new(HashMap::new())),
             subscription_map: Arc::new(Mutex::new(initial_subs)),
             chat_path: Arc::new(chat_path),
+            token_map_path: Arc::new(token_map_path),
             room_id: Arc::new(room_id.to_owned()),
             shutdown: Arc::new(shutdown_tx),
             seq_counter: Arc::new(AtomicU64::new(0)),
@@ -414,7 +432,7 @@ async fn dispatch_connection(
             write_half,
             &state.token_map,
             state.config.as_ref(),
-            Some(&state.chat_path),
+            Some(&state.token_map_path),
         )
         .await;
     }
@@ -627,7 +645,7 @@ mod tests {
     #[test]
     fn config_default_socket_path() {
         let config = DaemonConfig::default();
-        assert_eq!(config.socket_path, PathBuf::from("/tmp/roomd.sock"));
+        assert_eq!(config.socket_path, crate::paths::room_socket_path());
     }
 
     // ── create_room_with_config ───────────────────────────────────────────

--- a/crates/room-cli/src/broker/mod.rs
+++ b/crates/room-cli/src/broker/mod.rs
@@ -36,6 +36,8 @@ use tokio::{
 pub struct Broker {
     room_id: String,
     chat_path: PathBuf,
+    /// Path to the persisted token-map file (e.g. `~/.room/state/<room_id>.tokens`).
+    token_map_path: PathBuf,
     socket_path: PathBuf,
     ws_port: Option<u16>,
 }
@@ -44,12 +46,14 @@ impl Broker {
     pub fn new(
         room_id: &str,
         chat_path: PathBuf,
+        token_map_path: PathBuf,
         socket_path: PathBuf,
         ws_port: Option<u16>,
     ) -> Self {
         Self {
             room_id: room_id.to_owned(),
             chat_path,
+            token_map_path,
             socket_path,
             ws_port,
         }
@@ -73,7 +77,7 @@ impl Broker {
         registry.register(Box::new(plugin::stats::StatsPlugin))?;
 
         // Load persisted tokens from a previous broker session (if any).
-        let persisted_tokens = auth::load_token_map(&self.chat_path);
+        let persisted_tokens = auth::load_token_map(&self.token_map_path);
         if !persisted_tokens.is_empty() {
             eprintln!(
                 "[broker] loaded {} persisted token(s)",
@@ -89,6 +93,7 @@ impl Broker {
             claim_map: Arc::new(Mutex::new(HashMap::new())),
             subscription_map: Arc::new(Mutex::new(HashMap::new())),
             chat_path: Arc::new(self.chat_path.clone()),
+            token_map_path: Arc::new(self.token_map_path.clone()),
             room_id: Arc::new(self.room_id.clone()),
             shutdown: Arc::new(shutdown_tx),
             seq_counter: Arc::new(AtomicU64::new(0)),
@@ -187,7 +192,7 @@ async fn handle_client(
             write_half,
             &token_map,
             state.config.as_ref(),
-            Some(&state.chat_path),
+            Some(&state.token_map_path),
         )
         .await;
     }
@@ -572,7 +577,8 @@ mod tests {
             token_map: Arc::new(Mutex::new(HashMap::new())),
             claim_map: Arc::new(Mutex::new(HashMap::new())),
             subscription_map: Arc::new(Mutex::new(HashMap::new())),
-            chat_path: Arc::new(chat_path),
+            chat_path: Arc::new(chat_path.clone()),
+            token_map_path: Arc::new(chat_path.with_extension("tokens")),
             room_id: Arc::new("test-room".to_owned()),
             shutdown: Arc::new(shutdown_tx),
             seq_counter: Arc::new(AtomicU64::new(0)),

--- a/crates/room-cli/src/broker/state.rs
+++ b/crates/room-cli/src/broker/state.rs
@@ -42,6 +42,8 @@ pub(crate) struct RoomState {
     pub(crate) claim_map: ClaimMap,
     pub(crate) subscription_map: SubscriptionMap,
     pub(crate) chat_path: Arc<PathBuf>,
+    /// Path to the persisted token-map file (e.g. `~/.room/state/<room_id>.tokens`).
+    pub(crate) token_map_path: Arc<PathBuf>,
     pub(crate) room_id: Arc<String>,
     /// Set to `true` by the `/exit` admin command to shut down the broker.
     /// Using watch so receivers that check after the fact see `true` immediately

--- a/crates/room-cli/src/broker/ws.rs
+++ b/crates/room-cli/src/broker/ws.rs
@@ -339,7 +339,7 @@ async fn ws_oneshot_join(
         let _ = ws_tx.send(WsMessage::Close(None)).await;
         return Ok(());
     }
-    match issue_token(username, &state.token_map, Some(&state.chat_path)).await {
+    match issue_token(username, &state.token_map, Some(&state.token_map_path)).await {
         Ok(token) => {
             let resp = serde_json::json!({"type":"token","token": token, "username": username});
             let _ = ws_tx.send(WsMessage::Text(resp.to_string().into())).await;
@@ -438,7 +438,7 @@ async fn api_join(
     match issue_token(
         &body.username,
         &state.room_state.token_map,
-        Some(&state.room_state.chat_path),
+        Some(&state.room_state.token_map_path),
     )
     .await
     {
@@ -722,7 +722,7 @@ async fn daemon_api_join(
         )
             .into_response();
     }
-    match issue_token(&body.username, &room.token_map, Some(&room.chat_path)).await {
+    match issue_token(&body.username, &room.token_map, Some(&room.token_map_path)).await {
         Ok(token) => {
             let resp = serde_json::json!({
                 "type":"token","token": token, "username": body.username

--- a/crates/room-cli/src/lib.rs
+++ b/crates/room-cli/src/lib.rs
@@ -3,6 +3,7 @@ pub mod client;
 pub mod history;
 pub mod message;
 pub mod oneshot;
+pub mod paths;
 pub mod plugin;
 pub mod query;
 pub mod registry;

--- a/crates/room-cli/src/main.rs
+++ b/crates/room-cli/src/main.rs
@@ -11,6 +11,7 @@ use room_cli::{
     history::default_chat_path,
     message::parse_message_id,
     oneshot::{self, QueryOptions},
+    paths,
     query::{has_narrowing_filter, QueryFilter},
 };
 use tokio::net::UnixStream;
@@ -189,16 +190,20 @@ enum Cmd {
     List,
     /// Start a multi-room daemon that manages N rooms in a single process.
     ///
-    /// Listens on a single UDS socket (default: `/tmp/roomd.sock`) and dispatches
-    /// connections to rooms based on the `ROOM:<room_id>:` handshake prefix.
+    /// Listens on a single UDS socket (default: platform-native temp dir) and
+    /// dispatches connections to rooms based on the `ROOM:<room_id>:` handshake prefix.
     /// Rooms can be created dynamically via `room create` or the REST API.
     Daemon {
-        /// Path to the daemon UDS socket
-        #[arg(long, default_value = "/tmp/roomd.sock")]
-        socket: PathBuf,
-        /// Directory for chat files (one per room)
-        #[arg(long, default_value = "/tmp")]
-        data_dir: PathBuf,
+        /// Path to the daemon UDS socket (default: $TMPDIR/roomd.sock on macOS,
+        /// $XDG_RUNTIME_DIR/room/roomd.sock on Linux)
+        #[arg(long)]
+        socket: Option<PathBuf>,
+        /// Directory for chat files (default: ~/.room/data/)
+        #[arg(long)]
+        data_dir: Option<PathBuf>,
+        /// Directory for state files — tokens, cursors (default: ~/.room/state/)
+        #[arg(long)]
+        state_dir: Option<PathBuf>,
         /// Enable WebSocket/REST transport on this port
         #[arg(long)]
         ws_port: Option<u16>,
@@ -470,10 +475,18 @@ async fn main() -> anyhow::Result<()> {
         Some(Cmd::Daemon {
             socket,
             data_dir,
+            state_dir,
             ws_port,
             rooms,
         }) => {
-            run_daemon(socket, data_dir, ws_port, rooms).await?;
+            run_daemon(
+                socket.unwrap_or_else(paths::room_socket_path),
+                data_dir.unwrap_or_else(paths::room_data_dir),
+                state_dir.unwrap_or_else(paths::room_state_dir),
+                ws_port,
+                rooms,
+            )
+            .await?;
         }
         None => {
             let room_id = args.room_id.unwrap_or_else(|| {
@@ -507,8 +520,9 @@ async fn run_join(
     agent: bool,
     ws_port: Option<u16>,
 ) -> anyhow::Result<()> {
-    let socket_path = PathBuf::from(format!("/tmp/room-{}.sock", room_id));
-    let meta_path = PathBuf::from(format!("/tmp/room-{}.meta", room_id));
+    paths::ensure_room_dirs().map_err(|e| anyhow::anyhow!("cannot create ~/.room dirs: {e}"))?;
+    let socket_path = paths::room_single_socket_path(&room_id);
+    let meta_path = paths::room_meta_path(&room_id);
 
     let become_broker = match UnixStream::connect(&socket_path).await {
         Ok(_) => false,
@@ -535,7 +549,14 @@ async fn run_join(
             resolved_chat_path.display()
         );
 
-        let broker = Broker::new(&room_id, resolved_chat_path, socket_path.clone(), ws_port);
+        let token_map_path = paths::broker_tokens_path(&paths::room_state_dir(), &room_id);
+        let broker = Broker::new(
+            &room_id,
+            resolved_chat_path,
+            token_map_path,
+            socket_path.clone(),
+            ws_port,
+        );
 
         tokio::spawn(async move {
             if let Err(e) = broker.run().await {
@@ -602,12 +623,15 @@ fn resolve_chat_path(chat_file: &Option<PathBuf>, meta_path: &PathBuf, room_id: 
 async fn run_daemon(
     socket: PathBuf,
     data_dir: PathBuf,
+    state_dir: PathBuf,
     ws_port: Option<u16>,
     rooms: Vec<String>,
 ) -> anyhow::Result<()> {
+    paths::ensure_room_dirs().map_err(|e| anyhow::anyhow!("cannot create ~/.room dirs: {e}"))?;
     let config = DaemonConfig {
         socket_path: socket,
         data_dir,
+        state_dir,
         ws_port,
     };
 

--- a/crates/room-cli/src/oneshot/mod.rs
+++ b/crates/room-cli/src/oneshot/mod.rs
@@ -13,8 +13,6 @@ pub use token::{cmd_join, token_file_path, username_from_token, username_from_to
 pub use transport::{join_session, send_message, send_message_with_token};
 pub use who::cmd_who;
 
-use std::path::PathBuf;
-
 use room_protocol::dm_room_id;
 use transport::send_message_with_token as transport_send;
 
@@ -32,7 +30,7 @@ pub async fn cmd_send(
     to: Option<&str>,
     content: &str,
 ) -> anyhow::Result<()> {
-    let socket_path = PathBuf::from(format!("/tmp/room-{room_id}.sock"));
+    let socket_path = crate::paths::room_single_socket_path(room_id);
     let wire = match to {
         Some(recipient) => {
             serde_json::json!({"type": "dm", "to": recipient, "content": content}).to_string()
@@ -72,7 +70,7 @@ pub async fn cmd_dm(recipient: &str, token: &str, content: &str) -> anyhow::Resu
     let wire = serde_json::json!({"type": "dm", "to": recipient, "content": content}).to_string();
 
     // Send via the DM room's socket
-    let socket_path = PathBuf::from(format!("/tmp/room-{dm_id}.sock"));
+    let socket_path = crate::paths::room_single_socket_path(&dm_id);
     let msg = transport_send(&socket_path, token, &wire)
         .await
         .map_err(|e| {

--- a/crates/room-cli/src/oneshot/poll.rs
+++ b/crates/room-cli/src/oneshot/poll.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use crate::{history, message::Message, query::QueryFilter};
+use crate::{history, message::Message, paths, query::QueryFilter};
 
 use super::token::{read_cursor, username_from_token, write_cursor};
 
@@ -102,7 +102,7 @@ pub async fn pull_messages(
 /// Does **not** update the poll cursor.
 pub async fn cmd_pull(room_id: &str, token: &str, n: usize) -> anyhow::Result<()> {
     let username = username_from_token(room_id, token)?;
-    let meta_path = PathBuf::from(format!("/tmp/room-{room_id}.meta"));
+    let meta_path = paths::room_meta_path(room_id);
     let chat_path = chat_path_from_meta(room_id, &meta_path);
 
     let messages = pull_messages(&chat_path, n, Some(&username)).await?;
@@ -121,9 +121,9 @@ pub async fn cmd_pull(room_id: &str, token: &str, n: usize) -> anyhow::Result<()
 /// the same message.
 pub async fn cmd_watch(room_id: &str, token: &str, interval_secs: u64) -> anyhow::Result<()> {
     let username = username_from_token(room_id, token)?;
-    let meta_path = PathBuf::from(format!("/tmp/room-{room_id}.meta"));
+    let meta_path = paths::room_meta_path(room_id);
     let chat_path = chat_path_from_meta(room_id, &meta_path);
-    let cursor_path = PathBuf::from(format!("/tmp/room-{room_id}-{username}.cursor"));
+    let cursor_path = paths::cursor_path(room_id, &username);
 
     loop {
         let messages = poll_messages(&chat_path, &cursor_path, Some(&username), None).await?;
@@ -160,9 +160,9 @@ pub async fn cmd_poll(
     mentions_only: bool,
 ) -> anyhow::Result<()> {
     let username = username_from_token(room_id, token)?;
-    let meta_path = PathBuf::from(format!("/tmp/room-{room_id}.meta"));
+    let meta_path = paths::room_meta_path(room_id);
     let chat_path = chat_path_from_meta(room_id, &meta_path);
-    let cursor_path = PathBuf::from(format!("/tmp/room-{room_id}-{username}.cursor"));
+    let cursor_path = paths::cursor_path(room_id, &username);
 
     let messages =
         poll_messages(&chat_path, &cursor_path, Some(&username), since.as_deref()).await?;
@@ -177,7 +177,7 @@ pub async fn cmd_poll(
 
 /// Poll multiple rooms, returning messages merged by timestamp.
 ///
-/// Each room uses its own cursor file (`/tmp/room-{room_id}-{username}.cursor`).
+/// Each room uses its own cursor file under `~/.room/state/`.
 /// Messages are sorted by timestamp across all rooms. Each message already carries
 /// a `room` field, so the caller can distinguish sources.
 pub async fn poll_messages_multi(
@@ -187,7 +187,7 @@ pub async fn poll_messages_multi(
     let mut all_messages: Vec<Message> = Vec::new();
 
     for &(room_id, chat_path) in rooms {
-        let cursor_path = PathBuf::from(format!("/tmp/room-{room_id}-{username}.cursor"));
+        let cursor_path = paths::cursor_path(room_id, username);
         let msgs = poll_messages(chat_path, &cursor_path, Some(username), None).await?;
         all_messages.extend(msgs);
     }
@@ -211,7 +211,7 @@ pub async fn cmd_poll_multi(
     // Resolve chat paths for all rooms
     let mut rooms: Vec<(&str, PathBuf)> = Vec::new();
     for room_id in room_ids {
-        let meta_path = PathBuf::from(format!("/tmp/room-{room_id}.meta"));
+        let meta_path = paths::room_meta_path(room_id);
         let chat_path = chat_path_from_meta(room_id, &meta_path);
         rooms.push((room_id.as_str(), chat_path));
     }
@@ -275,9 +275,9 @@ async fn cmd_query_new(
     loop {
         let messages: Vec<Message> = if room_ids.len() == 1 {
             let room_id = &room_ids[0];
-            let meta_path = PathBuf::from(format!("/tmp/room-{room_id}.meta"));
+            let meta_path = paths::room_meta_path(room_id);
             let chat_path = chat_path_from_meta(room_id, &meta_path);
-            let cursor_path = PathBuf::from(format!("/tmp/room-{room_id}-{username}.cursor"));
+            let cursor_path = paths::cursor_path(room_id, username);
             poll_messages(
                 &chat_path,
                 &cursor_path,
@@ -288,7 +288,7 @@ async fn cmd_query_new(
         } else {
             let mut rooms_info: Vec<(String, PathBuf)> = Vec::new();
             for room_id in room_ids {
-                let meta_path = PathBuf::from(format!("/tmp/room-{room_id}.meta"));
+                let meta_path = paths::room_meta_path(room_id);
                 let chat_path = chat_path_from_meta(room_id, &meta_path);
                 rooms_info.push((room_id.clone(), chat_path));
             }
@@ -344,7 +344,7 @@ async fn cmd_query_history(
     let mut all_messages: Vec<Message> = Vec::new();
 
     for room_id in room_ids {
-        let meta_path = PathBuf::from(format!("/tmp/room-{room_id}.meta"));
+        let meta_path = paths::room_meta_path(room_id);
         let chat_path = chat_path_from_meta(room_id, &meta_path);
         let messages = history::load(&chat_path).await?;
         all_messages.extend(messages);
@@ -603,8 +603,8 @@ mod tests {
         assert_eq!(result[0].room(), &rid_a);
 
         // Clean up cursor files
-        let _ = std::fs::remove_file(format!("/tmp/room-{rid_a}-viewer.cursor"));
-        let _ = std::fs::remove_file(format!("/tmp/room-{rid_b}-viewer.cursor"));
+        let _ = std::fs::remove_file(crate::paths::cursor_path(&rid_a, "viewer"));
+        let _ = std::fs::remove_file(crate::paths::cursor_path(&rid_b, "viewer"));
     }
 
     /// Multi-room poll uses per-room cursors (second call returns nothing).
@@ -639,8 +639,8 @@ mod tests {
         );
 
         // Clean up cursor files
-        let _ = std::fs::remove_file(format!("/tmp/room-{rid_a}-viewer.cursor"));
-        let _ = std::fs::remove_file(format!("/tmp/room-{rid_b}-viewer.cursor"));
+        let _ = std::fs::remove_file(crate::paths::cursor_path(&rid_a, "viewer"));
+        let _ = std::fs::remove_file(crate::paths::cursor_path(&rid_b, "viewer"));
     }
 
     /// Multi-room poll with one empty room still returns messages from the other.
@@ -665,8 +665,8 @@ mod tests {
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].room(), &rid_a);
 
-        let _ = std::fs::remove_file(format!("/tmp/room-{rid_a}-viewer.cursor"));
-        let _ = std::fs::remove_file(format!("/tmp/room-{rid_b}-viewer.cursor"));
+        let _ = std::fs::remove_file(crate::paths::cursor_path(&rid_a, "viewer"));
+        let _ = std::fs::remove_file(crate::paths::cursor_path(&rid_b, "viewer"));
     }
 
     /// Multi-room poll with no rooms returns nothing.
@@ -707,8 +707,8 @@ mod tests {
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].room(), &rid_a);
 
-        let _ = std::fs::remove_file(format!("/tmp/room-{rid_a}-bob.cursor"));
-        let _ = std::fs::remove_file(format!("/tmp/room-{rid_b}-bob.cursor"));
+        let _ = std::fs::remove_file(crate::paths::cursor_path(&rid_a, "bob"));
+        let _ = std::fs::remove_file(crate::paths::cursor_path(&rid_b, "bob"));
     }
 
     // ── cmd_query unit tests ───────────────────────────────────────────────────
@@ -747,7 +747,7 @@ mod tests {
         };
 
         // cursor should NOT advance (historical mode)
-        let cursor_path = PathBuf::from(format!("/tmp/room-{room_id}-alice.cursor"));
+        let cursor_path = crate::paths::cursor_path(&room_id, "alice");
         let _ = std::fs::remove_file(&cursor_path);
 
         // Run cmd_query — captures stdout indirectly by ensuring cursor unchanged.
@@ -761,7 +761,7 @@ mod tests {
             "historical query must not write a cursor file"
         );
 
-        let _ = std::fs::remove_file(format!("/tmp/room-{room_id}.meta"));
+        let _ = std::fs::remove_file(crate::paths::room_meta_path(&room_id));
         let _ = std::fs::remove_file(&token_path(&room_id, "alice"));
     }
 
@@ -814,7 +814,7 @@ mod tests {
             "second query should return nothing (cursor advanced)"
         );
 
-        let _ = std::fs::remove_file(format!("/tmp/room-{room_id}.meta"));
+        let _ = std::fs::remove_file(crate::paths::room_meta_path(&room_id));
         let _ = std::fs::remove_file(&token_path(&room_id, "alice"));
     }
 
@@ -857,7 +857,7 @@ mod tests {
         assert_eq!(result.len(), 1);
         assert!(result[0].content().unwrap().contains("hello"));
 
-        let _ = std::fs::remove_file(format!("/tmp/room-{room_id}.meta"));
+        let _ = std::fs::remove_file(crate::paths::room_meta_path(&room_id));
         let _ = std::fs::remove_file(&token_path(&room_id, "alice"));
     }
 
@@ -900,7 +900,7 @@ mod tests {
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].user(), "bob");
 
-        let _ = std::fs::remove_file(format!("/tmp/room-{room_id}.meta"));
+        let _ = std::fs::remove_file(crate::paths::room_meta_path(&room_id));
         let _ = std::fs::remove_file(&token_path(&room_id, "alice"));
     }
 
@@ -944,14 +944,14 @@ mod tests {
                 .unwrap();
         assert_eq!(result.len(), 2, "limit should restrict to 2 messages");
 
-        let _ = std::fs::remove_file(format!("/tmp/room-{room_id}.meta"));
+        let _ = std::fs::remove_file(crate::paths::room_meta_path(&room_id));
         let _ = std::fs::remove_file(&token_path(&room_id, "alice"));
     }
 
     // ── Test helpers ──────────────────────────────────────────────────────────
 
     fn token_path(room_id: &str, username: &str) -> PathBuf {
-        PathBuf::from(format!("/tmp/room-{room_id}-{username}.token"))
+        crate::paths::token_path(room_id, username)
     }
 
     fn write_token_file(_dir: &TempDir, room_id: &str, username: &str, token: &str) {
@@ -961,7 +961,10 @@ mod tests {
     }
 
     fn write_meta_file(room_id: &str, chat_path: &Path) {
-        let meta_path = PathBuf::from(format!("/tmp/room-{room_id}.meta"));
+        let meta_path = crate::paths::room_meta_path(room_id);
+        if let Some(parent) = meta_path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
         let meta = serde_json::json!({ "chat_path": chat_path.to_string_lossy() });
         std::fs::write(&meta_path, format!("{meta}\n")).unwrap();
     }
@@ -986,7 +989,7 @@ mod tests {
                 super::super::token::username_from_token(id, token)
                     .ok()
                     .map(|u| {
-                        let p = PathBuf::from(format!("/tmp/room-{id}-{u}.cursor"));
+                        let p = crate::paths::cursor_path(id, &u);
                         std::fs::read_to_string(&p).ok()
                     })
                     .flatten()
@@ -1003,7 +1006,7 @@ mod tests {
                 super::super::token::username_from_token(id, token)
                     .ok()
                     .map(|u| {
-                        let p = PathBuf::from(format!("/tmp/room-{id}-{u}.cursor"));
+                        let p = crate::paths::cursor_path(id, &u);
                         std::fs::read_to_string(&p).ok()
                     })
                     .flatten()
@@ -1017,7 +1020,7 @@ mod tests {
             // Historical: reload and reapply filter.
             let mut all: Vec<Message> = Vec::new();
             for room_id in room_ids {
-                let meta_path = PathBuf::from(format!("/tmp/room-{room_id}.meta"));
+                let meta_path = crate::paths::room_meta_path(room_id);
                 let chat_path = chat_path_from_meta(room_id, &meta_path);
                 let msgs = history::load(&chat_path).await?;
                 all.extend(msgs);
@@ -1039,7 +1042,7 @@ mod tests {
             let advanced = cursor_after != cursor_before;
             if advanced {
                 let room_id = &room_ids[0];
-                let meta_path = PathBuf::from(format!("/tmp/room-{room_id}.meta"));
+                let meta_path = crate::paths::room_meta_path(room_id);
                 let chat_path = chat_path_from_meta(room_id, &meta_path);
                 let all = history::load(&chat_path).await?;
                 // Find start from the pre-run cursor UUID.

--- a/crates/room-cli/src/oneshot/token.rs
+++ b/crates/room-cli/src/oneshot/token.rs
@@ -1,22 +1,26 @@
 use std::path::{Path, PathBuf};
 
 use super::transport::join_session;
+use crate::paths;
 
-/// Returns the canonical token file path: `/tmp/room-<room_id>-<username>.token`.
+/// Returns the canonical token file path for a given room/user pair.
 ///
+/// Resolves to `~/.room/state/room-<room_id>-<username>.token`.
 /// One file per (room, user) pair — multiple agents on the same machine never
 /// overwrite each other's tokens.
 pub fn token_file_path(room_id: &str, username: &str) -> PathBuf {
-    PathBuf::from(format!("/tmp/room-{room_id}-{username}.token"))
+    paths::token_path(room_id, username)
 }
 
 /// One-shot join subcommand: register username, receive token, write token file.
 ///
-/// Writes to `/tmp/room-<room_id>-<username>.token` so agents sharing a machine
-/// do not clobber each other. Subsequent `send`, `poll`, and `watch` calls find
-/// the file automatically (single-agent) or via `--user <username>` (multi-agent).
+/// Writes to `~/.room/state/room-<room_id>-<username>.token` so agents sharing
+/// a machine do not clobber each other. Subsequent `send`, `poll`, and `watch`
+/// calls find the file automatically (single-agent) or via `--user <username>`
+/// (multi-agent).
 pub async fn cmd_join(room_id: &str, username: &str) -> anyhow::Result<()> {
-    let socket_path = PathBuf::from(format!("/tmp/room-{room_id}.sock"));
+    paths::ensure_room_dirs().map_err(|e| anyhow::anyhow!("cannot create ~/.room: {e}"))?;
+    let socket_path = paths::room_single_socket_path(room_id);
     let (returned_user, token) = join_session(&socket_path, username).await?;
     let token_data = serde_json::json!({"username": returned_user, "token": token});
     let token_path = token_file_path(room_id, &returned_user);
@@ -27,15 +31,16 @@ pub async fn cmd_join(room_id: &str, username: &str) -> anyhow::Result<()> {
 
 /// Look up the username associated with `token` by scanning stored token files for `room_id`.
 ///
-/// `room join` writes `/tmp/room-<room_id>-<username>.token` for each session.
+/// `room join` writes `~/.room/state/room-<room_id>-<username>.token` for each session.
 /// This function finds the file whose `token` field matches the given value and
 /// returns the corresponding username. Used by `poll` and `watch` to resolve the
 /// cursor file path without requiring the caller to pass a username explicitly.
 pub fn username_from_token(room_id: &str, token: &str) -> anyhow::Result<String> {
+    let state_dir = paths::room_state_dir();
     let prefix = format!("room-{room_id}-");
     let suffix = ".token";
-    let files: Vec<PathBuf> = std::fs::read_dir("/tmp")
-        .map_err(|e| anyhow::anyhow!("cannot read /tmp: {e}"))?
+    let files: Vec<PathBuf> = std::fs::read_dir(&state_dir)
+        .map_err(|e| anyhow::anyhow!("cannot read {}: {e}", state_dir.display()))?
         .filter_map(|e| e.ok())
         .map(|e| e.path())
         .filter(|p| {
@@ -61,17 +66,18 @@ pub fn username_from_token(room_id: &str, token: &str) -> anyhow::Result<String>
     anyhow::bail!("token not recognised — run: room join {room_id} <username> to get a fresh token")
 }
 
-/// Look up the username associated with `token` by scanning ALL token files in `/tmp`.
+/// Look up the username associated with `token` by scanning ALL token files in the state dir.
 ///
 /// Unlike [`username_from_token`], this does not require a room_id. It scans every
-/// `room-*-*.token` file and returns the username from the first match. Used by
-/// `room dm` where the caller's room_id is unknown (the DM room_id depends on the
+/// `room-*-*.token` file in `~/.room/state/` and returns the username from the first match.
+/// Used by `room dm` where the caller's room_id is unknown (the DM room_id depends on the
 /// caller's username, creating a chicken-and-egg problem).
 pub fn username_from_token_any_room(token: &str) -> anyhow::Result<String> {
+    let state_dir = crate::paths::room_state_dir();
     let prefix = "room-";
     let suffix = ".token";
-    let files: Vec<PathBuf> = std::fs::read_dir("/tmp")
-        .map_err(|e| anyhow::anyhow!("cannot read /tmp: {e}"))?
+    let files: Vec<PathBuf> = std::fs::read_dir(&state_dir)
+        .map_err(|e| anyhow::anyhow!("cannot read {}: {e}", state_dir.display()))?
         .filter_map(|e| e.ok())
         .map(|e| e.path())
         .filter(|p| {
@@ -106,7 +112,12 @@ pub fn read_cursor(cursor_path: &Path) -> Option<String> {
 }
 
 /// Persist the cursor position to disk.
+///
+/// Creates parent directories if they do not exist (e.g. `~/.room/state/` on first run).
 pub fn write_cursor(cursor_path: &Path, id: &str) -> anyhow::Result<()> {
+    if let Some(parent) = cursor_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
     std::fs::write(cursor_path, id)?;
     Ok(())
 }

--- a/crates/room-cli/src/oneshot/who.rs
+++ b/crates/room-cli/src/oneshot/who.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use super::transport::send_message_with_token as transport_send;
 use crate::message::Message;
 
@@ -8,7 +6,7 @@ use crate::message::Message;
 /// By default prints just the human-readable content line. With `json = true`,
 /// prints the full JSON response for machine consumption.
 pub async fn cmd_who(room_id: &str, token: &str, json: bool) -> anyhow::Result<()> {
-    let socket_path = PathBuf::from(format!("/tmp/room-{room_id}.sock"));
+    let socket_path = crate::paths::room_single_socket_path(room_id);
     let wire = serde_json::json!({"type": "command", "cmd": "who", "params": []}).to_string();
     let msg = transport_send(&socket_path, token, &wire)
         .await

--- a/crates/room-cli/src/paths.rs
+++ b/crates/room-cli/src/paths.rs
@@ -1,0 +1,220 @@
+//! Room filesystem path resolution.
+//!
+//! All persistent state lives under `~/.room/`:
+//! - `~/.room/state/` — tokens, cursors, subscriptions (0700)
+//! - `~/.room/data/`  — chat files (default, overridable via `--data-dir`)
+//!
+//! Ephemeral runtime files (sockets, PID, meta) use the platform-native
+//! temporary directory:
+//! - macOS: `$TMPDIR` (per-user, e.g. `/var/folders/...`)
+//! - Linux: `$XDG_RUNTIME_DIR/room/` or `/tmp/` fallback
+
+use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+use std::os::unix::fs::DirBuilderExt;
+
+// ── Public path accessors ─────────────────────────────────────────────────────
+
+/// Root of all persistent room state: `~/.room/`.
+pub fn room_home() -> PathBuf {
+    home_dir().join(".room")
+}
+
+/// Directory for persistent state files (tokens, cursors, subscriptions).
+///
+/// Returns `~/.room/state/`.
+pub fn room_state_dir() -> PathBuf {
+    room_home().join("state")
+}
+
+/// Default directory for chat files: `~/.room/data/`.
+///
+/// Overridable at daemon startup with `--data-dir`.
+pub fn room_data_dir() -> PathBuf {
+    room_home().join("data")
+}
+
+/// Platform-native socket path for the multi-room daemon.
+///
+/// - macOS: `$TMPDIR/roomd.sock`
+/// - Linux: `$XDG_RUNTIME_DIR/room/roomd.sock` (falls back to `/tmp/roomd.sock`)
+pub fn room_socket_path() -> PathBuf {
+    runtime_dir().join("roomd.sock")
+}
+
+/// Platform-native socket path for a single-room broker.
+pub fn room_single_socket_path(room_id: &str) -> PathBuf {
+    runtime_dir().join(format!("room-{room_id}.sock"))
+}
+
+/// Platform-native meta file path for a single-room broker.
+pub fn room_meta_path(room_id: &str) -> PathBuf {
+    runtime_dir().join(format!("room-{room_id}.meta"))
+}
+
+/// Token file path for a given room/user pair.
+///
+/// Returns `~/.room/state/room-<room_id>-<username>.token`.
+pub fn token_path(room_id: &str, username: &str) -> PathBuf {
+    room_state_dir().join(format!("room-{room_id}-{username}.token"))
+}
+
+/// Cursor file path for a given room/user pair.
+///
+/// Returns `~/.room/state/room-<room_id>-<username>.cursor`.
+pub fn cursor_path(room_id: &str, username: &str) -> PathBuf {
+    room_state_dir().join(format!("room-{room_id}-{username}.cursor"))
+}
+
+/// Broker token-map file path: `<state_dir>/<room_id>.tokens`.
+///
+/// The broker persists its in-memory `TokenMap` here on every token issuance.
+pub fn broker_tokens_path(state_dir: &Path, room_id: &str) -> PathBuf {
+    state_dir.join(format!("{room_id}.tokens"))
+}
+
+// ── Directory initialisation ──────────────────────────────────────────────────
+
+/// Ensure `~/.room/state/` and `~/.room/data/` exist.
+///
+/// Both directories are created with mode `0700` on Unix to protect token
+/// files from other users on the same machine. `recursive(true)` means the
+/// call is idempotent — safe to call on every daemon/broker start.
+pub fn ensure_room_dirs() -> std::io::Result<()> {
+    create_dir_0700(&room_state_dir())?;
+    create_dir_0700(&room_data_dir())?;
+    Ok(())
+}
+
+// ── Internals ────────────────────────────────────────────────────────────────
+
+fn home_dir() -> PathBuf {
+    std::env::var("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("/tmp"))
+}
+
+fn runtime_dir() -> PathBuf {
+    // macOS: $TMPDIR is per-user and secure (/var/folders/...)
+    // Linux: prefer $XDG_RUNTIME_DIR if set, fall back to /tmp
+    #[cfg(target_os = "macos")]
+    {
+        std::env::var("TMPDIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from("/tmp"))
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        std::env::var("XDG_RUNTIME_DIR")
+            .map(|d| PathBuf::from(d).join("room"))
+            .unwrap_or_else(|_| PathBuf::from("/tmp"))
+    }
+}
+
+fn create_dir_0700(path: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        std::fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o700)
+            .create(path)
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::create_dir_all(path)
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn room_home_ends_with_dot_room() {
+        let h = room_home();
+        assert!(
+            h.ends_with(".room"),
+            "expected path ending in .room, got: {h:?}"
+        );
+    }
+
+    #[test]
+    fn room_state_dir_under_room_home() {
+        assert!(room_state_dir().starts_with(room_home()));
+        assert!(room_state_dir().ends_with("state"));
+    }
+
+    #[test]
+    fn room_data_dir_under_room_home() {
+        assert!(room_data_dir().starts_with(room_home()));
+        assert!(room_data_dir().ends_with("data"));
+    }
+
+    #[test]
+    fn token_path_is_per_room_and_user() {
+        let alice_r1 = token_path("room1", "alice");
+        let bob_r1 = token_path("room1", "bob");
+        let alice_r2 = token_path("room2", "alice");
+        assert_ne!(alice_r1, bob_r1);
+        assert_ne!(alice_r1, alice_r2);
+        assert!(alice_r1.to_str().unwrap().contains("alice"));
+        assert!(alice_r1.to_str().unwrap().contains("room1"));
+    }
+
+    #[test]
+    fn cursor_path_is_per_room_and_user() {
+        let p = cursor_path("myroom", "bob");
+        assert!(p.to_str().unwrap().contains("bob"));
+        assert!(p.to_str().unwrap().contains("myroom"));
+        assert!(p.to_str().unwrap().ends_with(".cursor"));
+    }
+
+    #[test]
+    fn broker_tokens_path_contains_room_id() {
+        let base = PathBuf::from("/tmp/state");
+        let p = broker_tokens_path(&base, "test-room");
+        assert_eq!(p, base.join("test-room.tokens"));
+    }
+
+    #[test]
+    fn create_dir_0700_is_idempotent() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let target = dir.path().join("nested").join("deep");
+        create_dir_0700(&target).unwrap();
+        // Second call must not error (recursive=true).
+        create_dir_0700(&target).unwrap();
+        assert!(target.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_dir_0700_sets_correct_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::TempDir::new().unwrap();
+        let target = dir.path().join("secret");
+        create_dir_0700(&target).unwrap();
+        let perms = std::fs::metadata(&target).unwrap().permissions();
+        assert_eq!(
+            perms.mode() & 0o777,
+            0o700,
+            "expected 0700, got {:o}",
+            perms.mode() & 0o777
+        );
+    }
+
+    #[test]
+    fn ensure_room_dirs_creates_state_and_data() {
+        // We cannot call ensure_room_dirs() directly without writing to ~/.room,
+        // so test the underlying create_dir_0700 with a temp directory.
+        let dir = tempfile::TempDir::new().unwrap();
+        let state = dir.path().join("state");
+        let data = dir.path().join("data");
+        create_dir_0700(&state).unwrap();
+        create_dir_0700(&data).unwrap();
+        assert!(state.exists());
+        assert!(data.exists());
+    }
+}

--- a/crates/room-cli/tests/integration.rs
+++ b/crates/room-cli/tests/integration.rs
@@ -11,6 +11,7 @@ use room_cli::{
     broker::Broker,
     history,
     message::{self, Message},
+    paths,
 };
 use tempfile::TempDir;
 use tokio::{
@@ -49,7 +50,13 @@ impl TestBroker {
         let socket_path = dir.path().join(format!("{room_id}.sock"));
         let chat_path = dir.path().join(format!("{room_id}.chat"));
 
-        let broker = Broker::new(room_id, chat_path.clone(), socket_path.clone(), ws_port);
+        let broker = Broker::new(
+            room_id,
+            chat_path.clone(),
+            chat_path.with_extension("tokens"),
+            socket_path.clone(),
+            ws_port,
+        );
         tokio::spawn(async move {
             broker.run().await.ok();
         });
@@ -451,7 +458,13 @@ async fn pre_existing_history_is_replayed() {
         history::append(&chat_path, m).await.unwrap();
     }
 
-    let broker = Broker::new("pre", chat_path.clone(), socket_path.clone(), None);
+    let broker = Broker::new(
+        "pre",
+        chat_path.clone(),
+        chat_path.with_extension("tokens"),
+        socket_path.clone(),
+        None,
+    );
     tokio::spawn(async move { broker.run().await.ok() });
     for _ in 0..100 {
         if socket_path.exists() {
@@ -492,7 +505,13 @@ async fn stale_socket_is_cleaned_up() {
     assert!(socket_path.exists());
 
     // Broker should remove the stale file and bind
-    let broker = Broker::new("stale", chat_path, socket_path.clone(), None);
+    let broker = Broker::new(
+        "stale",
+        chat_path.clone(),
+        chat_path.with_extension("tokens"),
+        socket_path.clone(),
+        None,
+    );
     tokio::spawn(async move { broker.run().await.ok() });
 
     for _ in 0..100 {
@@ -1151,7 +1170,13 @@ async fn history_replay_filters_dm_for_non_party() {
     let dm = room_cli::message::make_dm("replay_dm", "bob", "carol", "for bob and carol only");
     room_cli::history::append(&chat_path, &dm).await.unwrap();
 
-    let broker = Broker::new("replay_dm", chat_path, socket_path.clone(), None);
+    let broker = Broker::new(
+        "replay_dm",
+        chat_path.clone(),
+        chat_path.with_extension("tokens"),
+        socket_path.clone(),
+        None,
+    );
     tokio::spawn(async move { broker.run().await.ok() });
     for _ in 0..100 {
         if socket_path.exists() {
@@ -1717,7 +1742,8 @@ async fn pull_messages_does_not_update_cursor() {
     let broker = TestBroker::start(room_id).await;
 
     // Write the meta file so cmd_poll / cmd_pull can locate the chat file.
-    let meta_path = PathBuf::from(format!("/tmp/room-{room_id}.meta"));
+    paths::ensure_room_dirs().unwrap();
+    let meta_path = paths::room_meta_path(room_id);
     let meta = serde_json::json!({ "chat_path": broker.chat_path.to_string_lossy() });
     std::fs::write(&meta_path, format!("{meta}\n")).unwrap();
 
@@ -1744,7 +1770,7 @@ async fn pull_messages_does_not_update_cursor() {
         .await
         .unwrap();
 
-    let cursor_path = PathBuf::from(format!("/tmp/room-{room_id}-alice.cursor"));
+    let cursor_path = paths::cursor_path(room_id, "alice");
     let cursor_after_poll = std::fs::read_to_string(&cursor_path).unwrap();
 
     // Send a second message after the cursor.
@@ -1765,7 +1791,7 @@ async fn pull_messages_does_not_update_cursor() {
     let cursor_after_pull = std::fs::read_to_string(&cursor_path).unwrap();
     assert_eq!(
         cursor_after_poll, cursor_after_pull,
-        "cmd_pull must not advance the poll cursor at /tmp/room-{room_id}-alice.cursor"
+        "cmd_pull must not advance the poll cursor"
     );
 
     // Verify poll still returns "second" (cursor was not consumed by pull).
@@ -2649,6 +2675,7 @@ impl TestDaemon {
         let config = DaemonConfig {
             socket_path: socket_path.clone(),
             data_dir: dir.path().to_owned(),
+            state_dir: dir.path().to_owned(),
             ws_port: None,
         };
 

--- a/crates/room-cli/tests/ws_smoke.rs
+++ b/crates/room-cli/tests/ws_smoke.rs
@@ -16,6 +16,7 @@ use std::{
 };
 
 use futures_util::{SinkExt, StreamExt};
+use room_cli::paths;
 use tokio::time::timeout;
 use tokio_tungstenite::{connect_async, tungstenite::Message as TungsteniteMsg};
 
@@ -47,7 +48,10 @@ async fn spawn_broker(room_id: &str) -> (tokio::process::Child, u16) {
     let chat_file = format!("/tmp/ws_smoke_{room_id}.chat");
     let token_file = format!("/tmp/ws_smoke_{room_id}.tokens");
     let socket_path = format!("/tmp/room-{room_id}.sock");
+    // Also clean up the durable broker token map (moved to ~/.room/state/ in #285).
+    let durable_token_map = paths::broker_tokens_path(&paths::room_state_dir(), room_id);
     common::cleanup_stale_files(&[&chat_file, &token_file, &socket_path]);
+    let _ = std::fs::remove_file(&durable_token_map);
 
     let mut child = tokio::process::Command::new(&bin)
         .args([


### PR DESCRIPTION
Implements #285 — durable state directory for all persistent room files.

- All tokens, cursors, and broker token maps move from /tmp/ to ~/.room/state/ (0700 permissions)
- Default chat files move from /tmp/ to ~/.room/data/
- UDS sockets use platform-native temp dir ($TMPDIR on macOS, $XDG_RUNTIME_DIR/room/ on Linux)
- New crates/room-cli/src/paths.rs module centralises every room filesystem path

New paths module (paths.rs):

  room_home()                    -> ~/.room/
  room_state_dir()               -> ~/.room/state/
  room_data_dir()                -> ~/.room/data/
  room_socket_path()             -> $TMPDIR/roomd.sock (macOS) / $XDG_RUNTIME_DIR/room/roomd.sock (Linux)
  room_single_socket_path(id)    -> $TMPDIR/room-{id}.sock
  room_meta_path(id)             -> ~/.room/state/room-{id}.meta
  token_path(id, user)           -> ~/.room/state/room-{id}-{user}.token
  cursor_path(id, user)          -> ~/.room/state/room-{id}-{user}.cursor
  broker_tokens_path(dir, id)    -> {dir}/broker-{id}.tokens
  ensure_room_dirs()             -> creates ~/.room/{state,data}/ with mode 0700

Breaking changes (noted in issue):

- Token files move: /tmp/room-<id>-<user>.token -> ~/.room/state/room-<id>-<user>.token
- Cursor files move: /tmp/room-<id>-<user>.cursor -> ~/.room/state/room-<id>-<user>.cursor
- Broker token maps: previously <chat_path>.tokens sibling, now ~/.room/state/broker-<room_id>.tokens
  Agents with saved tokens will need to re-run `room join` after upgrading.
- Broker::new signature: gains token_map_path: PathBuf as 3rd argument
- DaemonConfig: gains state_dir: PathBuf field
- DaemonConfig::default() socket path: was /tmp/roomd.sock, now $TMPDIR/roomd.sock

Files changed:

  src/paths.rs (NEW)       central path resolution, 10 unit tests
  src/lib.rs               export paths module
  src/broker/auth.rs       load_token_map/issue_token take token map path directly
  src/broker/mod.rs        Broker::new gains token_map_path param
  src/broker/state.rs      RoomState gains token_map_path: Arc<PathBuf>
  src/broker/daemon.rs     DaemonConfig gains state_dir; create_room() uses it
  src/broker/ws.rs         issue_token calls use state.token_map_path
  src/main.rs              Daemon gets --state-dir; run_join/run_daemon call ensure_room_dirs()
  src/oneshot/token.rs     Token/cursor paths use paths module; write_cursor creates parent dirs
  src/oneshot/poll.rs      Meta/cursor paths use paths module; test cleanup updated
  tests/integration.rs     Updated for new Broker::new signature and DaemonConfig
  tests/ws_smoke.rs        Cleanup now removes durable token map from ~/.room/state/

Test plan:

- cargo check: clean
- cargo fmt: no changes
- cargo clippy -- -D warnings: clean
- cargo test: 709 tests pass (421 unit + 91 integration + 5 smoke + 47 protocol + 140 ralph + 5 agentroom)
- write_cursor creates parent dirs automatically (fixes cold-start failure)
- ws_smoke tests clean up durable token maps between runs (prevents stale-username 409s)

Closes #285
