### PR TITLE
feat(query): add -p/--public flag and --id room:seq lookup

### DIFF
--- a/crates/room-cli/src/main.rs
+++ b/crates/room-cli/src/main.rs
@@ -11,7 +11,7 @@ use room_cli::{
     history::default_chat_path,
     message::parse_message_id,
     oneshot::{self, QueryOptions},
-    query::QueryFilter,
+    query::{has_narrowing_filter, QueryFilter},
 };
 use tokio::net::UnixStream;
 
@@ -93,6 +93,18 @@ enum Cmd {
         /// Poll interval in seconds when --wait is used (default: 5)
         #[arg(long, default_value_t = 5)]
         interval: u64,
+        /// Bypass subscription filter — query any public room regardless of subscription.
+        ///
+        /// Must be combined with at least one narrowing filter (-n, -r, --user, --from,
+        /// --to, --since, --until, --id, or a content search). DM privacy is still
+        /// enforced regardless of this flag.
+        #[arg(short = 'p', long = "public")]
+        public: bool,
+        /// Look up a single message by ID — format `<room>:<seq>` (e.g. `dev:42`).
+        ///
+        /// Returns the message with that exact sequence number, or an error if not found.
+        #[arg(long)]
+        id: Option<String>,
     },
     /// Poll for new messages — alias for `room query --new`.
     ///
@@ -267,6 +279,8 @@ async fn main() -> anyhow::Result<()> {
             asc,
             desc,
             interval,
+            public,
+            id,
         }) => {
             // Resolve the effective room list.
             let effective_rooms: Vec<String> = if !rooms.is_empty() {
@@ -325,6 +339,14 @@ async fn main() -> anyhow::Result<()> {
                 })
                 .transpose()?;
 
+            // Parse --id as room:seq.
+            let target_id = id
+                .as_deref()
+                .map(|s| {
+                    parse_message_id(s).map_err(|e| anyhow::anyhow!("invalid --id value: {e}"))
+                })
+                .transpose()?;
+
             // Default sort: ascending when --new/--wait, descending otherwise.
             let ascending = if asc {
                 true
@@ -343,8 +365,18 @@ async fn main() -> anyhow::Result<()> {
                 before_ts,
                 limit: count,
                 ascending,
+                public_only: public,
+                target_id,
                 ..Default::default()
             };
+
+            // -p/--public requires at least one narrowing filter.
+            if public && !has_narrowing_filter(&filter) {
+                anyhow::bail!(
+                    "-p/--public requires at least one narrowing filter (-n, -r, --user, \
+                     --from, --to, --since, --until, --id, or a content search)"
+                );
+            }
 
             let opts = QueryOptions {
                 new_only: new || wait,

--- a/crates/room-cli/src/oneshot/poll.rs
+++ b/crates/room-cli/src/oneshot/poll.rs
@@ -362,6 +362,17 @@ async fn cmd_query_history(
 
     apply_sort_and_limit(&mut filtered, &filter);
 
+    // If a specific target_id was requested and nothing was found, report an error.
+    if filtered.is_empty() {
+        if let Some((ref target_room, target_seq)) = filter.target_id {
+            use room_protocol::format_message_id;
+            anyhow::bail!(
+                "message not found: {}",
+                format_message_id(target_room, target_seq)
+            );
+        }
+    }
+
     for msg in &filtered {
         println!("{}", serde_json::to_string(msg)?);
     }

--- a/crates/room-cli/src/query.rs
+++ b/crates/room-cli/src/query.rs
@@ -44,6 +44,11 @@ pub struct QueryFilter {
     pub mention_user: Option<String>,
     /// Exclude `DirectMessage` variants (public-channel filter).
     pub public_only: bool,
+    /// Only include the single message with this exact `(room_id, seq)`.
+    ///
+    /// When set, all other seq-based filters are ignored; the match is exact.
+    /// DM privacy is still enforced externally by the caller.
+    pub target_id: Option<(String, u64)>,
     /// Maximum number of messages to return. Applied externally by the caller.
     pub limit: Option<usize>,
     /// If `true`, return messages oldest-first. If `false`, newest-first.
@@ -100,6 +105,19 @@ impl QueryFilter {
             }
         }
 
+        // ── target_id: exact (room, seq) match ───────────────────────────────
+        if let Some((ref target_room, target_seq)) = self.target_id {
+            if room_id != target_room {
+                return false;
+            }
+            match msg.seq() {
+                Some(seq) if seq == target_seq => {}
+                _ => return false,
+            }
+            // When target_id is set, skip the range seq filters below.
+            return true;
+        }
+
         // ── seq range filter ──────────────────────────────────────────────────
         // Constraints only apply when the message's room matches the filter room.
         if let Some((ref filter_room, filter_seq)) = self.after_seq {
@@ -135,6 +153,26 @@ impl QueryFilter {
 
         true
     }
+}
+
+/// Returns `true` if `filter` contains at least one narrowing criterion.
+///
+/// Used to validate that the `-p/--public` flag is not used alone. The
+/// narrowing criteria are: rooms, users, content_search, content_regex,
+/// after_seq, before_seq, after_ts, before_ts, mention_user, target_id,
+/// or a `limit`.
+pub fn has_narrowing_filter(filter: &QueryFilter) -> bool {
+    !filter.rooms.is_empty()
+        || !filter.users.is_empty()
+        || filter.content_search.is_some()
+        || filter.content_regex.is_some()
+        || filter.after_seq.is_some()
+        || filter.before_seq.is_some()
+        || filter.after_ts.is_some()
+        || filter.before_ts.is_some()
+        || filter.mention_user.is_some()
+        || filter.target_id.is_some()
+        || filter.limit.is_some()
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -541,6 +579,110 @@ mod tests {
         };
         let msg = msg_with_ts("r", "u", "x", cutoff);
         assert!(!f.matches(&msg, "r"));
+    }
+
+    // ── target_id filter ──────────────────────────────────────────────────────
+
+    #[test]
+    fn target_id_passes_exact_match() {
+        let f = QueryFilter {
+            target_id: Some(("r".into(), 7)),
+            ..Default::default()
+        };
+        assert!(f.matches(&msg_with_seq("r", "u", "x", 7), "r"));
+    }
+
+    #[test]
+    fn target_id_rejects_wrong_seq() {
+        let f = QueryFilter {
+            target_id: Some(("r".into(), 7)),
+            ..Default::default()
+        };
+        assert!(!f.matches(&msg_with_seq("r", "u", "x", 8), "r"));
+        assert!(!f.matches(&msg_with_seq("r", "u", "x", 6), "r"));
+    }
+
+    #[test]
+    fn target_id_rejects_wrong_room() {
+        let f = QueryFilter {
+            target_id: Some(("dev".into(), 7)),
+            ..Default::default()
+        };
+        assert!(!f.matches(&msg_with_seq("prod", "u", "x", 7), "prod"));
+    }
+
+    #[test]
+    fn target_id_rejects_no_seq() {
+        let f = QueryFilter {
+            target_id: Some(("r".into(), 1)),
+            ..Default::default()
+        };
+        let msg = make_message("r", "u", "no seq");
+        assert!(!f.matches(&msg, "r"));
+    }
+
+    #[test]
+    fn target_id_short_circuits_other_seq_filters() {
+        // after_seq would reject seq=7, but target_id=7 should still pass.
+        let f = QueryFilter {
+            target_id: Some(("r".into(), 7)),
+            after_seq: Some(("r".into(), 10)),
+            ..Default::default()
+        };
+        assert!(f.matches(&msg_with_seq("r", "u", "x", 7), "r"));
+    }
+
+    // ── has_narrowing_filter ───────────────────────────────────────────────────
+
+    #[test]
+    fn has_narrowing_filter_empty_is_false() {
+        assert!(!has_narrowing_filter(&QueryFilter::default()));
+    }
+
+    #[test]
+    fn has_narrowing_filter_rooms_is_true() {
+        let f = QueryFilter {
+            rooms: vec!["r".into()],
+            ..Default::default()
+        };
+        assert!(has_narrowing_filter(&f));
+    }
+
+    #[test]
+    fn has_narrowing_filter_limit_is_true() {
+        let f = QueryFilter {
+            limit: Some(10),
+            ..Default::default()
+        };
+        assert!(has_narrowing_filter(&f));
+    }
+
+    #[test]
+    fn has_narrowing_filter_target_id_is_true() {
+        let f = QueryFilter {
+            target_id: Some(("r".into(), 1)),
+            ..Default::default()
+        };
+        assert!(has_narrowing_filter(&f));
+    }
+
+    #[test]
+    fn has_narrowing_filter_content_search_is_true() {
+        let f = QueryFilter {
+            content_search: Some("foo".into()),
+            ..Default::default()
+        };
+        assert!(has_narrowing_filter(&f));
+    }
+
+    #[test]
+    fn has_narrowing_filter_public_only_alone_is_false() {
+        // public_only by itself is not a narrowing filter.
+        let f = QueryFilter {
+            public_only: true,
+            ..Default::default()
+        };
+        assert!(!has_narrowing_filter(&f));
     }
 
     // ── combined filters ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add `-p/--public` flag to `room query` to bypass subscription filtering (#314)
- Add `--id <room>:<seq>` flag to `room query` for exact message lookup (#315)

### `-p/--public` flag (#314)

| Behaviour | Details |
|---|---|
| Sets `public_only = true` | DMs excluded from results |
| Bypasses subscription filter | Allows querying rooms regardless of subscription (enforcement deferred to #311) |
| DM privacy still enforced | `cmd_query_history` still filters DMs to sender/recipient only |
| Requires narrowing filter | `-p` alone errors: must combine with `-n`, `-r`, `--user`, `--from`, `--to`, `--since`, `--until`, `--id`, or a content search |

Validation uses `has_narrowing_filter(filter)` helper in `query.rs` (unit-tested).

### `--id room:seq` lookup (#315)

- `QueryFilter.target_id: Option<(String, u64)>` carries the exact `(room, seq)` pair
- `matches()` short-circuits all other seq-range filters when `target_id` is set — exact match only
- `cmd_query_history` returns an error when `target_id` is requested but no message found: `"message not found: <room>:<seq>"`
- Parse via `parse_message_id` (from #317) — invalid format errors cleanly

## Test plan

- [x] `target_id_passes_exact_match` — correct room+seq passes
- [x] `target_id_rejects_wrong_seq` — off-by-one rejected
- [x] `target_id_rejects_wrong_room` — different room rejected
- [x] `target_id_rejects_no_seq` — message with no seq rejected
- [x] `target_id_short_circuits_other_seq_filters` — target_id overrides after_seq
- [x] `has_narrowing_filter_empty_is_false` — default filter is not narrowing
- [x] `has_narrowing_filter_rooms_is_true` — rooms constraint qualifies
- [x] `has_narrowing_filter_limit_is_true` — limit qualifies
- [x] `has_narrowing_filter_target_id_is_true` — --id qualifies
- [x] `has_narrowing_filter_content_search_is_true` — content_search qualifies
- [x] `has_narrowing_filter_public_only_alone_is_false` — public_only alone is not a narrowing filter

11 new tests. All 498 unit + 91 integration + 5 smoke pass.

Closes #314
Closes #315
