### PR TITLE
feat(cli): add --socket flag to join/send/who/dm subcommands

### DIFF
--- a/crates/room-cli/src/main.rs
+++ b/crates/room-cli/src/main.rs
@@ -20,11 +20,16 @@ use tokio::net::UnixStream;
 enum Cmd {
     /// Register a username with the broker and receive a session token.
     ///
-    /// Writes the token to `/tmp/room-<room_id>-<username>.token`. Subsequent `send`,
-    /// `poll`, and `watch` calls read the username and token from that file —
-    /// no username argument required. Returns an error if the username is
-    /// already in use in the room.
-    Join { room_id: String, username: String },
+    /// Writes the token to `~/.room/state/room-<room_id>-<username>.token`. Subsequent
+    /// `send`, `poll`, and `watch` calls read the username and token from that file —
+    /// no username argument required. Returns an error if the username is already in use.
+    Join {
+        room_id: String,
+        username: String,
+        /// Override the broker socket path (default: auto-discover daemon or per-room socket)
+        #[arg(long)]
+        socket: Option<PathBuf>,
+    },
     /// One-shot send a message to a room (requires a running broker).
     ///
     /// The broker resolves the sender's identity from the token issued by `room join`.
@@ -37,6 +42,9 @@ enum Cmd {
         /// Recipient username for a direct message
         #[arg(long)]
         to: Option<String>,
+        /// Override the broker socket path (default: auto-discover daemon or per-room socket)
+        #[arg(long)]
+        socket: Option<PathBuf>,
         /// Message content; all remaining tokens are joined with spaces
         #[arg(trailing_var_arg = true, num_args = 1..)]
         message: Vec<String>,
@@ -167,6 +175,9 @@ enum Cmd {
         /// Print raw JSON instead of human-readable text
         #[arg(long)]
         json: bool,
+        /// Override the broker socket path (default: auto-discover daemon or per-room socket)
+        #[arg(long)]
+        socket: Option<PathBuf>,
     },
     /// Send a direct message to a user, creating the DM room if needed.
     ///
@@ -179,6 +190,9 @@ enum Cmd {
         /// Session token from `room join` (required)
         #[arg(short = 't', long)]
         token: String,
+        /// Override the broker socket path (default: auto-discover daemon or per-room socket)
+        #[arg(long)]
+        socket: Option<PathBuf>,
         /// Message content; all remaining tokens are joined with spaces
         #[arg(trailing_var_arg = true, num_args = 1..)]
         message: Vec<String>,
@@ -256,17 +270,22 @@ async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
     match args.command {
-        Some(Cmd::Join { room_id, username }) => {
-            oneshot::cmd_join(&room_id, &username).await?;
+        Some(Cmd::Join {
+            room_id,
+            username,
+            socket,
+        }) => {
+            oneshot::cmd_join(&room_id, &username, socket.as_deref()).await?;
         }
         Some(Cmd::Send {
             room_id,
             token,
             to,
+            socket,
             message,
         }) => {
             let content = message.join(" ");
-            oneshot::cmd_send(&room_id, &token, to.as_deref(), &content).await?;
+            oneshot::cmd_send(&room_id, &token, to.as_deref(), &content, socket.as_deref()).await?;
         }
         Some(Cmd::Query {
             room_id,
@@ -458,16 +477,18 @@ async fn main() -> anyhow::Result<()> {
             room_id,
             token,
             json,
+            socket,
         }) => {
-            oneshot::cmd_who(&room_id, &token, json).await?;
+            oneshot::cmd_who(&room_id, &token, json, socket.as_deref()).await?;
         }
         Some(Cmd::Dm {
             user,
             token,
+            socket,
             message,
         }) => {
             let content = message.join(" ");
-            oneshot::cmd_dm(&user, &token, &content).await?;
+            oneshot::cmd_dm(&user, &token, &content, socket.as_deref()).await?;
         }
         Some(Cmd::List) => {
             oneshot::cmd_list().await?;

--- a/crates/room-cli/src/oneshot/mod.rs
+++ b/crates/room-cli/src/oneshot/mod.rs
@@ -10,11 +10,14 @@ pub use poll::{
     pull_messages, QueryOptions,
 };
 pub use token::{cmd_join, token_file_path, username_from_token, username_from_token_any_room};
-pub use transport::{join_session, send_message, send_message_with_token};
+pub use transport::{
+    join_session, join_session_target, resolve_socket_target, send_message,
+    send_message_with_token, send_message_with_token_target, SocketTarget,
+};
 pub use who::cmd_who;
 
 use room_protocol::dm_room_id;
-use transport::send_message_with_token as transport_send;
+use transport::send_message_with_token_target as transport_send_target;
 
 /// One-shot send subcommand: connect, send, print echo JSON to stdout, exit.
 ///
@@ -24,20 +27,23 @@ use transport::send_message_with_token as transport_send;
 ///
 /// Slash commands (e.g. `/who`, `/dm user msg`) are automatically converted to the
 /// appropriate JSON envelope, matching TUI behaviour.
+///
+/// `socket` overrides the default socket path (auto-discovered if `None`).
 pub async fn cmd_send(
     room_id: &str,
     token: &str,
     to: Option<&str>,
     content: &str,
+    socket: Option<&std::path::Path>,
 ) -> anyhow::Result<()> {
-    let socket_path = crate::paths::room_single_socket_path(room_id);
+    let target = resolve_socket_target(room_id, socket);
     let wire = match to {
         Some(recipient) => {
             serde_json::json!({"type": "dm", "to": recipient, "content": content}).to_string()
         }
         None => build_wire_payload(content),
     };
-    let msg = transport_send(&socket_path, token, &wire)
+    let msg = transport_send_target(&target, token, &wire)
         .await
         .map_err(|e| {
             if e.to_string().contains("invalid token") {
@@ -59,7 +65,14 @@ pub async fn cmd_send(
 ///
 /// Returns an error if the caller tries to DM themselves or if the DM room
 /// broker is not running.
-pub async fn cmd_dm(recipient: &str, token: &str, content: &str) -> anyhow::Result<()> {
+///
+/// `socket` overrides the default socket path (auto-discovered if `None`).
+pub async fn cmd_dm(
+    recipient: &str,
+    token: &str,
+    content: &str,
+    socket: Option<&std::path::Path>,
+) -> anyhow::Result<()> {
     // Resolve the caller's username from the token
     let caller = username_from_token_any_room(token)?;
 
@@ -69,9 +82,9 @@ pub async fn cmd_dm(recipient: &str, token: &str, content: &str) -> anyhow::Resu
     // Build the wire payload as a DM message
     let wire = serde_json::json!({"type": "dm", "to": recipient, "content": content}).to_string();
 
-    // Send via the DM room's socket
-    let socket_path = crate::paths::room_single_socket_path(&dm_id);
-    let msg = transport_send(&socket_path, token, &wire)
+    // Resolve socket target for the DM room.
+    let target = resolve_socket_target(&dm_id, socket);
+    let msg = transport_send_target(&target, token, &wire)
         .await
         .map_err(|e| {
             if e.to_string().contains("No such file")

--- a/crates/room-cli/src/oneshot/token.rs
+++ b/crates/room-cli/src/oneshot/token.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use super::transport::join_session;
+use super::transport::{join_session_target, resolve_socket_target};
 use crate::paths;
 
 /// Returns the canonical token file path for a given room/user pair.
@@ -18,10 +18,16 @@ pub fn token_file_path(room_id: &str, username: &str) -> PathBuf {
 /// a machine do not clobber each other. Subsequent `send`, `poll`, and `watch`
 /// calls find the file automatically (single-agent) or via `--user <username>`
 /// (multi-agent).
-pub async fn cmd_join(room_id: &str, username: &str) -> anyhow::Result<()> {
+///
+/// `socket` overrides the default socket path (auto-discovered if `None`).
+pub async fn cmd_join(
+    room_id: &str,
+    username: &str,
+    socket: Option<&std::path::Path>,
+) -> anyhow::Result<()> {
     paths::ensure_room_dirs().map_err(|e| anyhow::anyhow!("cannot create ~/.room: {e}"))?;
-    let socket_path = paths::room_single_socket_path(room_id);
-    let (returned_user, token) = join_session(&socket_path, username).await?;
+    let target = resolve_socket_target(room_id, socket);
+    let (returned_user, token) = join_session_target(&target, username).await?;
     let token_data = serde_json::json!({"username": returned_user, "token": token});
     let token_path = token_file_path(room_id, &returned_user);
     std::fs::write(&token_path, format!("{token_data}\n"))?;

--- a/crates/room-cli/src/oneshot/transport.rs
+++ b/crates/room-cli/src/oneshot/transport.rs
@@ -7,6 +7,82 @@ use tokio::{
 
 use crate::message::Message;
 
+// ── SocketTarget ──────────────────────────────────────────────────────────────
+
+/// Resolved connection target for a broker.
+///
+/// When `daemon_room` is `Some(room_id)`, the client is connecting to the
+/// multi-room daemon (`roomd`) and must prepend `ROOM:<room_id>:` before every
+/// handshake token so the daemon can route the connection to the correct room.
+///
+/// When `daemon_room` is `None`, the client is connecting to a single-room
+/// broker socket and sends handshake tokens directly (e.g. `TOKEN:<uuid>`).
+#[derive(Debug, Clone)]
+pub struct SocketTarget {
+    /// Path to the UDS socket.
+    pub path: std::path::PathBuf,
+    /// If `Some(room_id)`, prepend `ROOM:<room_id>:` before each handshake token.
+    pub daemon_room: Option<String>,
+}
+
+impl SocketTarget {
+    /// Construct the full first line to send for a given handshake token.
+    ///
+    /// - Per-room: `TOKEN:<uuid>` → `"TOKEN:<uuid>"`
+    /// - Daemon: `TOKEN:<uuid>` → `"ROOM:<room_id>:TOKEN:<uuid>"`
+    fn handshake_line(&self, token_line: &str) -> String {
+        match &self.daemon_room {
+            Some(room_id) => format!("ROOM:{room_id}:{token_line}"),
+            None => token_line.to_owned(),
+        }
+    }
+}
+
+// ── Socket target resolution ──────────────────────────────────────────────────
+
+/// Resolve the effective socket target for a given room.
+///
+/// Resolution order:
+/// 1. If `explicit` is given, use it. If the path is not the per-room socket
+///    for this room, assume it is a daemon socket and use the `ROOM:` prefix.
+/// 2. Otherwise (auto-discovery): try the platform-native daemon socket first
+///    (`room_socket_path()`); fall back to the per-room socket if the daemon
+///    socket does not exist.
+pub fn resolve_socket_target(room_id: &str, explicit: Option<&Path>) -> SocketTarget {
+    let per_room = crate::paths::room_single_socket_path(room_id);
+    let daemon = crate::paths::room_socket_path();
+
+    if let Some(path) = explicit {
+        // If the caller gave us the per-room socket path, use per-room mode.
+        // Any other explicit path is treated as a daemon socket.
+        if path == per_room {
+            return SocketTarget {
+                path: path.to_owned(),
+                daemon_room: None,
+            };
+        }
+        return SocketTarget {
+            path: path.to_owned(),
+            daemon_room: Some(room_id.to_owned()),
+        };
+    }
+
+    // Auto-discovery: prefer daemon if it is running.
+    if daemon.exists() {
+        SocketTarget {
+            path: daemon,
+            daemon_room: Some(room_id.to_owned()),
+        }
+    } else {
+        SocketTarget {
+            path: per_room,
+            daemon_room: None,
+        }
+    }
+}
+
+// ── Transport functions ───────────────────────────────────────────────────────
+
 /// Connect to a running broker and deliver a single message without joining the room.
 /// Returns the broadcast echo (with broker-assigned id/ts) so callers have the message ID.
 pub async fn send_message(
@@ -31,18 +107,39 @@ pub async fn send_message(
 
 /// Connect to a running broker and deliver a single message authenticated by token.
 ///
-/// Sends `TOKEN:<token>\n` as the handshake (instead of `SEND:<username>\n`).
-/// The broker resolves the username from its in-memory token map.
+/// When `target.daemon_room` is `Some(room_id)`, sends
+/// `ROOM:<room_id>:TOKEN:<token>` as the handshake so the daemon routes
+/// the connection to the correct room. For a per-room socket the handshake
+/// is simply `TOKEN:<token>`.
 pub async fn send_message_with_token(
     socket_path: &Path,
     token: &str,
     content: &str,
 ) -> anyhow::Result<Message> {
-    let stream = UnixStream::connect(socket_path).await.map_err(|e| {
-        anyhow::anyhow!("cannot connect to broker at {}: {e}", socket_path.display())
+    send_message_with_token_target(
+        &SocketTarget {
+            path: socket_path.to_owned(),
+            daemon_room: None,
+        },
+        token,
+        content,
+    )
+    .await
+}
+
+/// Variant of [`send_message_with_token`] that takes a fully-resolved
+/// [`SocketTarget`], including daemon routing prefix when required.
+pub async fn send_message_with_token_target(
+    target: &SocketTarget,
+    token: &str,
+    content: &str,
+) -> anyhow::Result<Message> {
+    let stream = UnixStream::connect(&target.path).await.map_err(|e| {
+        anyhow::anyhow!("cannot connect to broker at {}: {e}", target.path.display())
     })?;
     let (r, mut w) = stream.into_split();
-    w.write_all(format!("TOKEN:{token}\n").as_bytes()).await?;
+    let handshake = target.handshake_line(&format!("TOKEN:{token}"));
+    w.write_all(format!("{handshake}\n").as_bytes()).await?;
     // content is already a JSON envelope from cmd_send; newlines are escaped by serde.
     w.write_all(format!("{content}\n").as_bytes()).await?;
 
@@ -55,7 +152,7 @@ pub async fn send_message_with_token(
     if v["type"] == "error" {
         let code = v["code"].as_str().unwrap_or("unknown");
         if code == "invalid_token" {
-            anyhow::bail!("invalid token — run: room join {}", socket_path.display());
+            anyhow::bail!("invalid token — run: room join {}", target.path.display());
         }
         anyhow::bail!("broker error: {code}");
     }
@@ -69,11 +166,27 @@ pub async fn send_message_with_token(
 /// The broker checks for username collisions. On success it returns a token
 /// envelope; on collision it returns an error envelope.
 pub async fn join_session(socket_path: &Path, username: &str) -> anyhow::Result<(String, String)> {
-    let stream = UnixStream::connect(socket_path).await.map_err(|e| {
-        anyhow::anyhow!("cannot connect to broker at {}: {e}", socket_path.display())
+    join_session_target(
+        &SocketTarget {
+            path: socket_path.to_owned(),
+            daemon_room: None,
+        },
+        username,
+    )
+    .await
+}
+
+/// Variant of [`join_session`] that takes a fully-resolved [`SocketTarget`].
+pub async fn join_session_target(
+    target: &SocketTarget,
+    username: &str,
+) -> anyhow::Result<(String, String)> {
+    let stream = UnixStream::connect(&target.path).await.map_err(|e| {
+        anyhow::anyhow!("cannot connect to broker at {}: {e}", target.path.display())
     })?;
     let (r, mut w) = stream.into_split();
-    w.write_all(format!("JOIN:{username}\n").as_bytes()).await?;
+    let handshake = target.handshake_line(&format!("JOIN:{username}"));
+    w.write_all(format!("{handshake}\n").as_bytes()).await?;
 
     let mut reader = BufReader::new(r);
     let mut line = String::new();
@@ -96,4 +209,107 @@ pub async fn join_session(socket_path: &Path, username: &str) -> anyhow::Result<
         .ok_or_else(|| anyhow::anyhow!("broker response missing 'username' field"))?
         .to_owned();
     Ok((returned_user, token))
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn per_room_target(room_id: &str) -> SocketTarget {
+        SocketTarget {
+            path: PathBuf::from(format!("/tmp/room-{room_id}.sock")),
+            daemon_room: None,
+        }
+    }
+
+    fn daemon_target(room_id: &str) -> SocketTarget {
+        SocketTarget {
+            path: PathBuf::from("/tmp/roomd.sock"),
+            daemon_room: Some(room_id.to_owned()),
+        }
+    }
+
+    // ── SocketTarget::handshake_line ──────────────────────────────────────────
+
+    #[test]
+    fn per_room_token_handshake_no_prefix() {
+        let t = per_room_target("myroom");
+        assert_eq!(t.handshake_line("TOKEN:abc-123"), "TOKEN:abc-123");
+    }
+
+    #[test]
+    fn daemon_token_handshake_has_room_prefix() {
+        let t = daemon_target("myroom");
+        assert_eq!(
+            t.handshake_line("TOKEN:abc-123"),
+            "ROOM:myroom:TOKEN:abc-123"
+        );
+    }
+
+    #[test]
+    fn per_room_join_handshake_no_prefix() {
+        let t = per_room_target("chat");
+        assert_eq!(t.handshake_line("JOIN:alice"), "JOIN:alice");
+    }
+
+    #[test]
+    fn daemon_join_handshake_has_room_prefix() {
+        let t = daemon_target("chat");
+        assert_eq!(t.handshake_line("JOIN:alice"), "ROOM:chat:JOIN:alice");
+    }
+
+    #[test]
+    fn daemon_handshake_with_hyphen_room_id() {
+        let t = daemon_target("agent-room-2");
+        assert_eq!(
+            t.handshake_line("TOKEN:uuid"),
+            "ROOM:agent-room-2:TOKEN:uuid"
+        );
+    }
+
+    // ── resolve_socket_target ─────────────────────────────────────────────────
+
+    #[test]
+    fn resolve_explicit_per_room_socket_is_not_daemon() {
+        let per_room = crate::paths::room_single_socket_path("myroom");
+        let target = resolve_socket_target("myroom", Some(&per_room));
+        assert_eq!(target.path, per_room);
+        assert!(
+            target.daemon_room.is_none(),
+            "per-room socket should not set daemon_room"
+        );
+    }
+
+    #[test]
+    fn resolve_explicit_daemon_socket_is_daemon() {
+        let daemon_sock = PathBuf::from("/tmp/roomd.sock");
+        let target = resolve_socket_target("myroom", Some(&daemon_sock));
+        assert_eq!(target.path, daemon_sock);
+        assert_eq!(target.daemon_room.as_deref(), Some("myroom"));
+    }
+
+    #[test]
+    fn resolve_explicit_custom_path_is_daemon() {
+        let custom = PathBuf::from("/var/run/roomd-test.sock");
+        let target = resolve_socket_target("chat", Some(&custom));
+        assert_eq!(target.path, custom);
+        assert_eq!(target.daemon_room.as_deref(), Some("chat"));
+    }
+
+    #[test]
+    fn resolve_auto_no_daemon_falls_back_to_per_room() {
+        // When no daemon socket exists (we check the real daemon path, which
+        // is unlikely to exist during CI), auto-discovery should fall back.
+        // We can only test this if the daemon socket is NOT running.
+        let daemon_path = crate::paths::room_socket_path();
+        if !daemon_path.exists() {
+            let target = resolve_socket_target("myroom", None);
+            assert_eq!(target.path, crate::paths::room_single_socket_path("myroom"));
+            assert!(target.daemon_room.is_none());
+        }
+        // If daemon IS running, skip (we can't test both branches in one call).
+    }
 }

--- a/crates/room-cli/src/oneshot/who.rs
+++ b/crates/room-cli/src/oneshot/who.rs
@@ -1,22 +1,27 @@
-use super::transport::send_message_with_token as transport_send;
+use super::transport::{resolve_socket_target, send_message_with_token_target as transport_send};
 use crate::message::Message;
 
 /// One-shot who subcommand: send `/who` to the broker, print the response, exit.
 ///
 /// By default prints just the human-readable content line. With `json = true`,
 /// prints the full JSON response for machine consumption.
-pub async fn cmd_who(room_id: &str, token: &str, json: bool) -> anyhow::Result<()> {
-    let socket_path = crate::paths::room_single_socket_path(room_id);
+///
+/// `socket` overrides the default socket path (auto-discovered if `None`).
+pub async fn cmd_who(
+    room_id: &str,
+    token: &str,
+    json: bool,
+    socket: Option<&std::path::Path>,
+) -> anyhow::Result<()> {
+    let target = resolve_socket_target(room_id, socket);
     let wire = serde_json::json!({"type": "command", "cmd": "who", "params": []}).to_string();
-    let msg = transport_send(&socket_path, token, &wire)
-        .await
-        .map_err(|e| {
-            if e.to_string().contains("invalid token") {
-                anyhow::anyhow!("invalid token — run: room join {room_id} <username>")
-            } else {
-                e
-            }
-        })?;
+    let msg = transport_send(&target, token, &wire).await.map_err(|e| {
+        if e.to_string().contains("invalid token") {
+            anyhow::anyhow!("invalid token — run: room join {room_id} <username>")
+        } else {
+            e
+        }
+    })?;
 
     if json {
         println!("{}", serde_json::to_string(&msg)?);


### PR DESCRIPTION
## Summary

- Adds `--socket <path>` flag to `join`, `send`, `who`, and `dm` subcommands, letting callers override the default auto-discovered socket
- Introduces `SocketTarget` struct in `transport.rs` encapsulating per-room vs daemon-routing mode; auto-discovery prefers `$TMPDIR/roomd.sock` (daemon), falls back to per-room socket
- Adds `send_message_with_token_target` and `join_session_target` functions that accept a `SocketTarget`; original functions preserved as thin wrappers
- When an explicit `--socket` path is provided that is not the per-room socket, it is treated as a daemon socket with `ROOM:<id>:` handshake prefix

## Test plan

- [x] 9 new unit tests in `transport.rs` covering `handshake_line` (per-room, daemon, daemon with hyphen room-id) and `resolve_socket_target` (explicit per-room, explicit daemon, explicit custom, auto-fallback)
- [x] `cargo test` passes (520+ tests)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` no changes

Closes #308
