### PR TITLE
feat(daemon): system-level tokens shared across all rooms (#293)

### DIFF
--- a/crates/room-cli/src/broker/daemon.rs
+++ b/crates/room-cli/src/broker/daemon.rs
@@ -38,7 +38,7 @@ use crate::plugin::{self, PluginRegistry};
 
 use super::{
     handle_oneshot_send,
-    state::RoomState,
+    state::{RoomState, TokenMap},
     ws::{self, DaemonWsState},
 };
 
@@ -99,6 +99,15 @@ impl DaemonConfig {
     pub fn token_map_path(&self, room_id: &str) -> PathBuf {
         crate::paths::broker_tokens_path(&self.state_dir, room_id)
     }
+
+    /// System-level token persistence path: `<state_dir>/tokens.json`.
+    ///
+    /// Used by the daemon to share a single token store across all rooms.
+    /// Production default is `~/.room/state/tokens.json`; tests override
+    /// `state_dir` with a temp directory.
+    pub fn system_tokens_path(&self) -> PathBuf {
+        self.state_dir.join("tokens.json")
+    }
 }
 
 impl Default for DaemonConfig {
@@ -123,17 +132,26 @@ pub struct DaemonState {
     pub(crate) next_client_id: Arc<AtomicU64>,
     /// Daemon-level shutdown signal.
     pub(crate) shutdown: Arc<watch::Sender<bool>>,
+    /// System-level token map shared across all rooms.
+    ///
+    /// A single `Arc<Mutex<HashMap>>` instance is cloned into every room's
+    /// `token_map`. Tokens issued in any room are valid in all rooms managed
+    /// by this daemon. Persisted to `~/.room/state/tokens.json`.
+    pub(crate) system_token_map: TokenMap,
 }
 
 impl DaemonState {
     /// Create a new daemon with the given configuration and no rooms.
     pub fn new(config: DaemonConfig) -> Self {
         let (shutdown_tx, _) = watch::channel(false);
+        // Load persisted system-level tokens from previous session (if any).
+        let persisted = super::auth::load_token_map(&config.system_tokens_path());
         Self {
             rooms: Arc::new(Mutex::new(HashMap::new())),
             config,
             next_client_id: Arc::new(AtomicU64::new(0)),
             shutdown: Arc::new(shutdown_tx),
+            system_token_map: Arc::new(Mutex::new(persisted)),
         }
     }
 
@@ -147,7 +165,6 @@ impl DaemonState {
         }
 
         let chat_path = self.config.chat_path(room_id);
-        let token_map_path = self.config.token_map_path(room_id);
         let (shutdown_tx, _) = watch::channel(false);
 
         let mut registry = PluginRegistry::new();
@@ -158,18 +175,17 @@ impl DaemonState {
             .register(Box::new(plugin::stats::StatsPlugin))
             .map_err(|e| format!("plugin error: {e}"))?;
 
-        // Load persisted tokens from previous session (if any).
-        let persisted_tokens = super::auth::load_token_map(&token_map_path);
-
         let state = Arc::new(RoomState {
             clients: Arc::new(Mutex::new(HashMap::new())),
             status_map: Arc::new(Mutex::new(HashMap::new())),
             host_user: Arc::new(Mutex::new(None)),
-            token_map: Arc::new(Mutex::new(persisted_tokens)),
+            // All rooms in this daemon share the same token map so a token
+            // issued in any room is valid in all rooms.
+            token_map: Arc::clone(&self.system_token_map),
             claim_map: Arc::new(Mutex::new(HashMap::new())),
             subscription_map: Arc::new(Mutex::new(HashMap::new())),
             chat_path: Arc::new(chat_path),
-            token_map_path: Arc::new(token_map_path),
+            token_map_path: Arc::new(self.config.system_tokens_path()),
             room_id: Arc::new(room_id.to_owned()),
             shutdown: Arc::new(shutdown_tx),
             seq_counter: Arc::new(AtomicU64::new(0)),
@@ -195,7 +211,6 @@ impl DaemonState {
         }
 
         let chat_path = self.config.chat_path(room_id);
-        let token_map_path = self.config.token_map_path(room_id);
         let (shutdown_tx, _) = watch::channel(false);
 
         let mut registry = PluginRegistry::new();
@@ -208,17 +223,18 @@ impl DaemonState {
 
         // Auto-subscribe DM participants at Full tier.
         let initial_subs = build_initial_subscriptions(&config);
-        let persisted_tokens = super::auth::load_token_map(&token_map_path);
 
         let state = Arc::new(RoomState {
             clients: Arc::new(Mutex::new(HashMap::new())),
             status_map: Arc::new(Mutex::new(HashMap::new())),
             host_user: Arc::new(Mutex::new(None)),
-            token_map: Arc::new(Mutex::new(persisted_tokens)),
+            // All rooms in this daemon share the same token map so a token
+            // issued in any room is valid in all rooms.
+            token_map: Arc::clone(&self.system_token_map),
             claim_map: Arc::new(Mutex::new(HashMap::new())),
             subscription_map: Arc::new(Mutex::new(initial_subs)),
             chat_path: Arc::new(chat_path),
-            token_map_path: Arc::new(token_map_path),
+            token_map_path: Arc::new(self.config.system_tokens_path()),
             room_id: Arc::new(room_id.to_owned()),
             shutdown: Arc::new(shutdown_tx),
             seq_counter: Arc::new(AtomicU64::new(0)),

--- a/crates/room-cli/src/paths.rs
+++ b/crates/room-cli/src/paths.rs
@@ -74,6 +74,15 @@ pub fn broker_tokens_path(state_dir: &Path, room_id: &str) -> PathBuf {
     state_dir.join(format!("{room_id}.tokens"))
 }
 
+/// System-level token persistence path: `~/.room/state/tokens.json`.
+///
+/// Tokens in a daemon are system-level — a single token issued by `room join`
+/// in any room is valid in all rooms managed by the same daemon. This file
+/// stores the complete token → username mapping across all rooms.
+pub fn system_tokens_path() -> PathBuf {
+    room_state_dir().join("tokens.json")
+}
+
 // ── Directory initialisation ──────────────────────────────────────────────────
 
 /// Ensure `~/.room/state/` and `~/.room/data/` exist.

--- a/crates/room-cli/tests/integration.rs
+++ b/crates/room-cli/tests/integration.rs
@@ -2918,28 +2918,27 @@ async fn daemon_multi_room_message_isolation() {
     );
 }
 
-// ── Test: token from room-alpha is invalid in room-beta ───────────────────
+// ── Test: system-level tokens are valid across all rooms in a daemon ──────
+//
+// Tokens are daemon-scoped (not room-scoped): a token issued by any room JOIN
+// can be used to send to any other room managed by the same daemon (#293).
 
 #[tokio::test]
-async fn daemon_token_scoped_to_room() {
+async fn daemon_token_valid_across_rooms() {
     let td = TestDaemon::start(&["room-x", "room-y"]).await;
 
+    // Join room-x — the resulting token is system-level.
     let token_x = daemon_join(&td.socket_path, "room-x", "user-x").await;
 
-    // Try to use token_x in room-y — should fail with invalid_token.
-    let stream = UnixStream::connect(&td.socket_path).await.unwrap();
-    let (r, mut w) = stream.into_split();
-    w.write_all(format!("ROOM:room-y:TOKEN:{token_x}\n").as_bytes())
-        .await
-        .unwrap();
-    w.write_all(b"cross-room attempt\n").await.unwrap();
-
-    let mut reader = BufReader::new(r);
-    let mut line = String::new();
-    reader.read_line(&mut line).await.unwrap();
-    let v: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
-    assert_eq!(v["type"], "error");
-    assert_eq!(v["code"], "invalid_token");
+    // Use the token issued in room-x to send to room-y.
+    let resp = daemon_send(&td.socket_path, "room-y", &token_x, "cross-room msg").await;
+    assert_eq!(
+        resp["type"], "message",
+        "system-level token should be valid in a different room: {resp}"
+    );
+    assert_eq!(resp["content"], "cross-room msg");
+    assert_eq!(resp["user"], "user-x");
+    assert_eq!(resp["room"], "room-y");
 }
 
 // ── DM room visibility integration tests ─────────────────────────────────


### PR DESCRIPTION
## Summary

- Add `system_token_map: TokenMap` to `DaemonState` — a single `Arc<Mutex<HashMap>>` shared across all rooms via `Arc::clone`
- Tokens issued by any room JOIN are valid in all rooms managed by the same daemon
- Add `DaemonConfig::system_tokens_path()` → `<state_dir>/tokens.json` so tests use their temp dir and production uses `~/.room/state/tokens.json`
- Add `paths::system_tokens_path()` for standalone CLI use
- Replace `daemon_token_scoped_to_room` test (old per-room behavior) with `daemon_token_valid_across_rooms` asserting the new cross-room validity

## Motivation

Prior to this change, a token issued via `room join room-x alice` could only authenticate sends to `room-x`. In multi-room daemon deployments (the normal production case), users had to re-join every room separately. System-level tokens eliminate this friction — join once, send anywhere.

Standalone `Broker` mode (single-room, direct UDS) is unaffected: it keeps its own per-room token map.

## Test plan

- [x] `cargo check && cargo fmt && cargo clippy -- -D warnings` pass
- [x] All 824 tests pass (`cargo test`)
- [x] New test `daemon_token_valid_across_rooms`: join room-x, use that token in room-y, assert message is accepted
- [x] Existing daemon isolation test (`daemon_multi_room_message_isolation`) still green

Closes #293
