### PR TITLE
feat(broker): persist subscription map to disk (#311)

### DIFF
--- a/crates/room-cli/src/broker/commands.rs
+++ b/crates/room-cli/src/broker/commands.rs
@@ -1,3 +1,7 @@
+use std::{collections::HashMap, path::Path};
+
+use room_protocol::SubscriptionTier;
+
 use crate::{
     message::{make_system, Message},
     plugin::{
@@ -7,6 +11,46 @@ use crate::{
 };
 
 use super::{fanout::broadcast_and_persist, state::RoomState};
+
+// ── Subscription persistence ─────────────────────────────────────────────────
+
+/// Write a subscription map to disk as JSON.
+pub(crate) fn save_subscription_map(
+    map: &HashMap<String, SubscriptionTier>,
+    path: &Path,
+) -> Result<(), String> {
+    let json =
+        serde_json::to_string_pretty(map).map_err(|e| format!("serialize subscriptions: {e}"))?;
+    std::fs::write(path, json).map_err(|e| format!("write {}: {e}", path.display()))
+}
+
+/// Load a subscription map from disk. Returns an empty map if the file does
+/// not exist or contains invalid JSON.
+pub(crate) fn load_subscription_map(path: &Path) -> HashMap<String, SubscriptionTier> {
+    let contents = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(_) => return HashMap::new(),
+    };
+    serde_json::from_str(&contents).unwrap_or_else(|e| {
+        eprintln!(
+            "[broker] corrupt subscription file {}: {e} — starting empty",
+            path.display()
+        );
+        HashMap::new()
+    })
+}
+
+/// Persist the current subscription map to disk (fire-and-forget logging).
+///
+/// Called after every mutation to the in-memory map. Uses synchronous I/O
+/// because the file is tiny (a few KB at most) and consistency matters more
+/// than shaving microseconds.
+pub(crate) async fn persist_subscriptions(state: &RoomState) {
+    let snapshot = state.subscription_map.lock().await.clone();
+    if let Err(e) = save_subscription_map(&snapshot, &state.subscription_map_path) {
+        eprintln!("[broker] subscription persist failed: {e}");
+    }
+}
 
 /// Admin command names — routed through `handle_admin_cmd` when received as
 /// a `Message::Command` with one of these cmd values.
@@ -156,7 +200,7 @@ pub(crate) async fn route_command(
         // Subscription commands.
         if cmd == "subscribe" {
             let tier_str = params.first().map(String::as_str).unwrap_or("full");
-            let tier: room_protocol::SubscriptionTier = match tier_str.parse() {
+            let tier: SubscriptionTier = match tier_str.parse() {
                 Ok(t) => t,
                 Err(e) => {
                     let sys = make_system(&state.room_id, "broker", e);
@@ -169,6 +213,7 @@ pub(crate) async fn route_command(
                 .lock()
                 .await
                 .insert(username.to_owned(), tier);
+            persist_subscriptions(state).await;
             let display = format!("{username} subscribed to {} (tier: {tier})", state.room_id);
             let sys = make_system(&state.room_id, "broker", display);
             broadcast_and_persist(&sys, &state.clients, &state.chat_path, &state.seq_counter)
@@ -178,10 +223,12 @@ pub(crate) async fn route_command(
         }
 
         if cmd == "unsubscribe" {
-            state.subscription_map.lock().await.insert(
-                username.to_owned(),
-                room_protocol::SubscriptionTier::Unsubscribed,
-            );
+            state
+                .subscription_map
+                .lock()
+                .await
+                .insert(username.to_owned(), SubscriptionTier::Unsubscribed);
+            persist_subscriptions(state).await;
             let display = format!("{username} unsubscribed from {}", state.room_id);
             let sys = make_system(&state.room_id, "broker", display);
             broadcast_and_persist(&sys, &state.clients, &state.chat_path, &state.seq_counter)
@@ -548,6 +595,7 @@ mod tests {
         broker::state::RoomState,
         message::{make_command, make_dm, make_message},
     };
+    use room_protocol::SubscriptionTier;
     use std::{
         collections::HashMap,
         sync::{atomic::AtomicU64, Arc},
@@ -558,6 +606,7 @@ mod tests {
     fn make_state(chat_path: std::path::PathBuf) -> Arc<RoomState> {
         let (shutdown_tx, _) = watch::channel(false);
         let token_map_path = chat_path.with_extension("tokens");
+        let subscription_map_path = chat_path.with_extension("subscriptions");
         Arc::new(RoomState {
             clients: Arc::new(Mutex::new(HashMap::new())),
             status_map: Arc::new(Mutex::new(HashMap::new())),
@@ -567,6 +616,7 @@ mod tests {
             subscription_map: Arc::new(Mutex::new(HashMap::new())),
             chat_path: Arc::new(chat_path),
             token_map_path: Arc::new(token_map_path),
+            subscription_map_path: Arc::new(subscription_map_path),
             room_id: Arc::new("test-room".to_owned()),
             shutdown: Arc::new(shutdown_tx),
             seq_counter: Arc::new(AtomicU64::new(0)),
@@ -1134,6 +1184,7 @@ mod tests {
     ) -> Arc<RoomState> {
         let (shutdown_tx, _) = watch::channel(false);
         let token_map_path = chat_path.with_extension("tokens");
+        let subscription_map_path = chat_path.with_extension("subscriptions");
         Arc::new(RoomState {
             clients: Arc::new(Mutex::new(HashMap::new())),
             status_map: Arc::new(Mutex::new(HashMap::new())),
@@ -1143,6 +1194,7 @@ mod tests {
             subscription_map: Arc::new(Mutex::new(HashMap::new())),
             chat_path: Arc::new(chat_path),
             token_map_path: Arc::new(token_map_path),
+            subscription_map_path: Arc::new(subscription_map_path),
             room_id: Arc::new("test-room".to_owned()),
             shutdown: Arc::new(shutdown_tx),
             seq_counter: Arc::new(AtomicU64::new(0)),
@@ -1323,7 +1375,7 @@ mod tests {
         assert!(json.contains("full"));
         assert_eq!(
             *state.subscription_map.lock().await.get("alice").unwrap(),
-            room_protocol::SubscriptionTier::Full
+            SubscriptionTier::Full
         );
     }
 
@@ -1344,7 +1396,7 @@ mod tests {
         assert!(json.contains("mentions_only"));
         assert_eq!(
             *state.subscription_map.lock().await.get("bob").unwrap(),
-            room_protocol::SubscriptionTier::MentionsOnly
+            SubscriptionTier::MentionsOnly
         );
     }
 
@@ -1363,7 +1415,7 @@ mod tests {
         route_command(msg2, "alice", &state).await.unwrap();
         assert_eq!(
             *state.subscription_map.lock().await.get("alice").unwrap(),
-            room_protocol::SubscriptionTier::MentionsOnly,
+            SubscriptionTier::MentionsOnly,
             "second subscribe should overwrite the first"
         );
     }
@@ -1384,7 +1436,7 @@ mod tests {
         assert!(json.contains("unsubscribed"));
         assert_eq!(
             *state.subscription_map.lock().await.get("alice").unwrap(),
-            room_protocol::SubscriptionTier::Unsubscribed
+            SubscriptionTier::Unsubscribed
         );
     }
 
@@ -1398,7 +1450,7 @@ mod tests {
         assert!(matches!(result, CommandResult::HandledWithReply(_)));
         assert_eq!(
             *state.subscription_map.lock().await.get("alice").unwrap(),
-            room_protocol::SubscriptionTier::Unsubscribed
+            SubscriptionTier::Unsubscribed
         );
     }
 
@@ -1419,11 +1471,8 @@ mod tests {
         let state = make_state(tmp.path().to_path_buf());
         {
             let mut map = state.subscription_map.lock().await;
-            map.insert("zara".to_owned(), room_protocol::SubscriptionTier::Full);
-            map.insert(
-                "alice".to_owned(),
-                room_protocol::SubscriptionTier::MentionsOnly,
-            );
+            map.insert("zara".to_owned(), SubscriptionTier::Full);
+            map.insert("alice".to_owned(), SubscriptionTier::MentionsOnly);
         }
         let msg = make_command("test-room", "alice", "subscriptions", vec![]);
         let CommandResult::Reply(json) = route_command(msg, "alice", &state).await.unwrap() else {
@@ -1475,5 +1524,143 @@ mod tests {
         let history = std::fs::read_to_string(tmp.path()).unwrap();
         assert!(history.contains("unsubscribed"));
         assert!(history.contains("alice"));
+    }
+
+    // ── subscription persistence ─────────────────────────────────────────
+
+    #[test]
+    fn load_subscription_map_missing_file_returns_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nonexistent.subscriptions");
+        let map = super::load_subscription_map(&path);
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn save_and_load_subscription_map_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.subscriptions");
+
+        let mut original = HashMap::new();
+        original.insert("alice".to_owned(), SubscriptionTier::Full);
+        original.insert("bob".to_owned(), SubscriptionTier::MentionsOnly);
+        original.insert("carol".to_owned(), SubscriptionTier::Unsubscribed);
+
+        super::save_subscription_map(&original, &path).unwrap();
+        let loaded = super::load_subscription_map(&path);
+        assert_eq!(loaded, original);
+    }
+
+    #[test]
+    fn load_subscription_map_corrupt_file_returns_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("corrupt.subscriptions");
+        std::fs::write(&path, "not json{{{").unwrap();
+        let map = super::load_subscription_map(&path);
+        assert!(map.is_empty());
+    }
+
+    #[tokio::test]
+    async fn subscribe_persists_to_disk() {
+        let tmp = NamedTempFile::new().unwrap();
+        let state = make_state(tmp.path().to_path_buf());
+        let msg = make_command("test-room", "alice", "subscribe", vec![]);
+        route_command(msg, "alice", &state).await.unwrap();
+
+        let loaded = super::load_subscription_map(&state.subscription_map_path);
+        assert_eq!(loaded.get("alice"), Some(&SubscriptionTier::Full));
+    }
+
+    #[tokio::test]
+    async fn unsubscribe_persists_to_disk() {
+        let tmp = NamedTempFile::new().unwrap();
+        let state = make_state(tmp.path().to_path_buf());
+
+        // Subscribe first, then unsubscribe.
+        let msg = make_command("test-room", "alice", "subscribe", vec![]);
+        route_command(msg, "alice", &state).await.unwrap();
+        let msg = make_command("test-room", "alice", "unsubscribe", vec![]);
+        route_command(msg, "alice", &state).await.unwrap();
+
+        let loaded = super::load_subscription_map(&state.subscription_map_path);
+        assert_eq!(loaded.get("alice"), Some(&SubscriptionTier::Unsubscribed));
+    }
+
+    #[tokio::test]
+    async fn subscribe_accumulates_on_disk() {
+        let tmp = NamedTempFile::new().unwrap();
+        let state = make_state(tmp.path().to_path_buf());
+
+        let msg = make_command("test-room", "alice", "subscribe", vec![]);
+        route_command(msg, "alice", &state).await.unwrap();
+        let msg = make_command(
+            "test-room",
+            "bob",
+            "subscribe",
+            vec!["mentions_only".to_owned()],
+        );
+        route_command(msg, "bob", &state).await.unwrap();
+
+        let loaded = super::load_subscription_map(&state.subscription_map_path);
+        assert_eq!(loaded.len(), 2);
+        assert_eq!(loaded.get("alice"), Some(&SubscriptionTier::Full));
+        assert_eq!(loaded.get("bob"), Some(&SubscriptionTier::MentionsOnly));
+    }
+
+    #[tokio::test]
+    async fn subscribe_survives_simulated_restart() {
+        let tmp = NamedTempFile::new().unwrap();
+        let state = make_state(tmp.path().to_path_buf());
+
+        let msg = make_command("test-room", "alice", "subscribe", vec![]);
+        route_command(msg, "alice", &state).await.unwrap();
+
+        // Simulate restart: new state, load from disk.
+        let loaded = super::load_subscription_map(&state.subscription_map_path);
+        assert_eq!(loaded.get("alice"), Some(&SubscriptionTier::Full));
+
+        // Verify it can be populated into a new RoomState.
+        let state2 = {
+            let (shutdown_tx, _) = watch::channel(false);
+            Arc::new(RoomState {
+                clients: Arc::new(Mutex::new(HashMap::new())),
+                status_map: Arc::new(Mutex::new(HashMap::new())),
+                host_user: Arc::new(Mutex::new(None)),
+                token_map: Arc::new(Mutex::new(HashMap::new())),
+                claim_map: Arc::new(Mutex::new(HashMap::new())),
+                subscription_map: Arc::new(Mutex::new(loaded)),
+                chat_path: state.chat_path.clone(),
+                token_map_path: state.token_map_path.clone(),
+                subscription_map_path: state.subscription_map_path.clone(),
+                room_id: state.room_id.clone(),
+                shutdown: Arc::new(shutdown_tx),
+                seq_counter: Arc::new(AtomicU64::new(0)),
+                plugin_registry: Arc::new(crate::plugin::PluginRegistry::new()),
+                config: None,
+            })
+        };
+        assert_eq!(
+            *state2.subscription_map.lock().await.get("alice").unwrap(),
+            SubscriptionTier::Full
+        );
+    }
+
+    #[tokio::test]
+    async fn subscribe_overwrite_persists_latest_tier() {
+        let tmp = NamedTempFile::new().unwrap();
+        let state = make_state(tmp.path().to_path_buf());
+
+        let msg = make_command("test-room", "alice", "subscribe", vec![]);
+        route_command(msg, "alice", &state).await.unwrap();
+        let msg = make_command(
+            "test-room",
+            "alice",
+            "subscribe",
+            vec!["mentions_only".to_owned()],
+        );
+        route_command(msg, "alice", &state).await.unwrap();
+
+        let loaded = super::load_subscription_map(&state.subscription_map_path);
+        assert_eq!(loaded.get("alice"), Some(&SubscriptionTier::MentionsOnly));
     }
 }

--- a/crates/room-cli/src/broker/daemon.rs
+++ b/crates/room-cli/src/broker/daemon.rs
@@ -108,6 +108,11 @@ impl DaemonConfig {
     pub fn system_tokens_path(&self) -> PathBuf {
         self.state_dir.join("tokens.json")
     }
+
+    /// Resolve the subscription-map persistence path for a given room.
+    pub fn subscription_map_path(&self, room_id: &str) -> PathBuf {
+        crate::paths::broker_subscriptions_path(&self.state_dir, room_id)
+    }
 }
 
 impl Default for DaemonConfig {
@@ -165,6 +170,7 @@ impl DaemonState {
         }
 
         let chat_path = self.config.chat_path(room_id);
+        let subscription_map_path = self.config.subscription_map_path(room_id);
         let (shutdown_tx, _) = watch::channel(false);
 
         let mut registry = PluginRegistry::new();
@@ -175,6 +181,9 @@ impl DaemonState {
             .register(Box::new(plugin::stats::StatsPlugin))
             .map_err(|e| format!("plugin error: {e}"))?;
 
+        // Load persisted subscriptions from previous session (if any).
+        let persisted_subs = super::commands::load_subscription_map(&subscription_map_path);
+
         let state = Arc::new(RoomState {
             clients: Arc::new(Mutex::new(HashMap::new())),
             status_map: Arc::new(Mutex::new(HashMap::new())),
@@ -183,9 +192,10 @@ impl DaemonState {
             // issued in any room is valid in all rooms.
             token_map: Arc::clone(&self.system_token_map),
             claim_map: Arc::new(Mutex::new(HashMap::new())),
-            subscription_map: Arc::new(Mutex::new(HashMap::new())),
+            subscription_map: Arc::new(Mutex::new(persisted_subs)),
             chat_path: Arc::new(chat_path),
             token_map_path: Arc::new(self.config.system_tokens_path()),
+            subscription_map_path: Arc::new(subscription_map_path),
             room_id: Arc::new(room_id.to_owned()),
             shutdown: Arc::new(shutdown_tx),
             seq_counter: Arc::new(AtomicU64::new(0)),
@@ -211,6 +221,7 @@ impl DaemonState {
         }
 
         let chat_path = self.config.chat_path(room_id);
+        let subscription_map_path = self.config.subscription_map_path(room_id);
         let (shutdown_tx, _) = watch::channel(false);
 
         let mut registry = PluginRegistry::new();
@@ -221,8 +232,12 @@ impl DaemonState {
             .register(Box::new(plugin::stats::StatsPlugin))
             .map_err(|e| format!("plugin error: {e}"))?;
 
-        // Auto-subscribe DM participants at Full tier.
-        let initial_subs = build_initial_subscriptions(&config);
+        // Merge persisted subscriptions with config defaults (DM auto-subscribe).
+        // Config defaults seed any missing entries; persisted values take precedence
+        // because a user may have explicitly changed their tier after room creation.
+        let mut merged_subs = build_initial_subscriptions(&config);
+        let persisted_subs = super::commands::load_subscription_map(&subscription_map_path);
+        merged_subs.extend(persisted_subs);
 
         let state = Arc::new(RoomState {
             clients: Arc::new(Mutex::new(HashMap::new())),
@@ -232,9 +247,10 @@ impl DaemonState {
             // issued in any room is valid in all rooms.
             token_map: Arc::clone(&self.system_token_map),
             claim_map: Arc::new(Mutex::new(HashMap::new())),
-            subscription_map: Arc::new(Mutex::new(initial_subs)),
+            subscription_map: Arc::new(Mutex::new(merged_subs)),
             chat_path: Arc::new(chat_path),
             token_map_path: Arc::new(self.config.system_tokens_path()),
+            subscription_map_path: Arc::new(subscription_map_path),
             room_id: Arc::new(room_id.to_owned()),
             shutdown: Arc::new(shutdown_tx),
             seq_counter: Arc::new(AtomicU64::new(0)),

--- a/crates/room-cli/src/broker/mod.rs
+++ b/crates/room-cli/src/broker/mod.rs
@@ -38,6 +38,8 @@ pub struct Broker {
     chat_path: PathBuf,
     /// Path to the persisted token-map file (e.g. `~/.room/state/<room_id>.tokens`).
     token_map_path: PathBuf,
+    /// Path to the persisted subscription-map file (e.g. `~/.room/state/<room_id>.subscriptions`).
+    subscription_map_path: PathBuf,
     socket_path: PathBuf,
     ws_port: Option<u16>,
 }
@@ -47,6 +49,7 @@ impl Broker {
         room_id: &str,
         chat_path: PathBuf,
         token_map_path: PathBuf,
+        subscription_map_path: PathBuf,
         socket_path: PathBuf,
         ws_port: Option<u16>,
     ) -> Self {
@@ -54,6 +57,7 @@ impl Broker {
             room_id: room_id.to_owned(),
             chat_path,
             token_map_path,
+            subscription_map_path,
             socket_path,
             ws_port,
         }
@@ -76,12 +80,19 @@ impl Broker {
         registry.register(Box::new(plugin::help::HelpPlugin))?;
         registry.register(Box::new(plugin::stats::StatsPlugin))?;
 
-        // Load persisted tokens from a previous broker session (if any).
+        // Load persisted state from a previous broker session (if any).
         let persisted_tokens = auth::load_token_map(&self.token_map_path);
         if !persisted_tokens.is_empty() {
             eprintln!(
                 "[broker] loaded {} persisted token(s)",
                 persisted_tokens.len()
+            );
+        }
+        let persisted_subs = commands::load_subscription_map(&self.subscription_map_path);
+        if !persisted_subs.is_empty() {
+            eprintln!(
+                "[broker] loaded {} persisted subscription(s)",
+                persisted_subs.len()
             );
         }
 
@@ -91,9 +102,10 @@ impl Broker {
             host_user: Arc::new(Mutex::new(None)),
             token_map: Arc::new(Mutex::new(persisted_tokens)),
             claim_map: Arc::new(Mutex::new(HashMap::new())),
-            subscription_map: Arc::new(Mutex::new(HashMap::new())),
+            subscription_map: Arc::new(Mutex::new(persisted_subs)),
             chat_path: Arc::new(self.chat_path.clone()),
             token_map_path: Arc::new(self.token_map_path.clone()),
+            subscription_map_path: Arc::new(self.subscription_map_path.clone()),
             room_id: Arc::new(self.room_id.clone()),
             shutdown: Arc::new(shutdown_tx),
             seq_counter: Arc::new(AtomicU64::new(0)),
@@ -549,6 +561,13 @@ async fn auto_subscribe_mentioned(msg: &Message, state: &RoomState) {
         newly_subscribed
     };
 
+    if auto_subscribed.is_empty() {
+        return;
+    }
+
+    // Persist the updated subscription map to disk.
+    commands::persist_subscriptions(state).await;
+
     // Phase 2: broadcast notices (no locks held).
     for username in &auto_subscribed {
         let notice = format!(
@@ -579,6 +598,7 @@ mod tests {
             subscription_map: Arc::new(Mutex::new(HashMap::new())),
             chat_path: Arc::new(chat_path.clone()),
             token_map_path: Arc::new(chat_path.with_extension("tokens")),
+            subscription_map_path: Arc::new(chat_path.with_extension("subscriptions")),
             room_id: Arc::new("test-room".to_owned()),
             shutdown: Arc::new(shutdown_tx),
             seq_counter: Arc::new(AtomicU64::new(0)),
@@ -735,5 +755,21 @@ mod tests {
         assert!(history.contains("auto-subscribed"));
         assert!(history.contains("alice"));
         assert!(history.contains("mentions_only"));
+    }
+
+    #[tokio::test]
+    async fn auto_subscribe_persists_to_disk() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let state = make_test_state(tmp.path().to_path_buf());
+        state
+            .token_map
+            .lock()
+            .await
+            .insert("tok-alice".to_owned(), "alice".to_owned());
+        let msg = make_message("test-room", "bob", "hey @alice");
+        auto_subscribe_mentioned(&msg, &state).await;
+        // Verify subscriptions were persisted to the .subscriptions file.
+        let loaded = commands::load_subscription_map(&state.subscription_map_path);
+        assert_eq!(loaded.get("alice"), Some(&SubscriptionTier::MentionsOnly));
     }
 }

--- a/crates/room-cli/src/broker/state.rs
+++ b/crates/room-cli/src/broker/state.rs
@@ -28,8 +28,9 @@ pub(crate) type TokenMap = Arc<Mutex<HashMap<String, String>>>;
 /// Users can hold at most one claim at a time (new claim replaces old).
 pub(crate) type ClaimMap = Arc<Mutex<HashMap<String, String>>>;
 
-/// Maps username → subscription tier for this room. Ephemeral; persistence
-/// is handled by E3-2 (#311) once the durable state directory lands.
+/// Maps username → subscription tier for this room. Persisted as JSON at
+/// `~/.room/state/<room_id>.subscriptions` on every mutation; loaded on
+/// broker/daemon startup.
 /// DM rooms auto-subscribe both participants at `Full` on creation.
 pub(crate) type SubscriptionMap = Arc<Mutex<HashMap<String, SubscriptionTier>>>;
 
@@ -44,6 +45,8 @@ pub(crate) struct RoomState {
     pub(crate) chat_path: Arc<PathBuf>,
     /// Path to the persisted token-map file (e.g. `~/.room/state/<room_id>.tokens`).
     pub(crate) token_map_path: Arc<PathBuf>,
+    /// Path to the persisted subscription-map file (e.g. `~/.room/state/<room_id>.subscriptions`).
+    pub(crate) subscription_map_path: Arc<PathBuf>,
     pub(crate) room_id: Arc<String>,
     /// Set to `true` by the `/exit` admin command to shut down the broker.
     /// Using watch so receivers that check after the fact see `true` immediately

--- a/crates/room-cli/src/main.rs
+++ b/crates/room-cli/src/main.rs
@@ -570,11 +570,14 @@ async fn run_join(
             resolved_chat_path.display()
         );
 
-        let token_map_path = paths::broker_tokens_path(&paths::room_state_dir(), &room_id);
+        let state_dir = paths::room_state_dir();
+        let token_map_path = paths::broker_tokens_path(&state_dir, &room_id);
+        let subscription_map_path = paths::broker_subscriptions_path(&state_dir, &room_id);
         let broker = Broker::new(
             &room_id,
             resolved_chat_path,
             token_map_path,
+            subscription_map_path,
             socket_path.clone(),
             ws_port,
         );

--- a/crates/room-cli/src/paths.rs
+++ b/crates/room-cli/src/paths.rs
@@ -83,6 +83,14 @@ pub fn system_tokens_path() -> PathBuf {
     room_state_dir().join("tokens.json")
 }
 
+/// Broker subscription-map file path: `<state_dir>/<room_id>.subscriptions`.
+///
+/// The broker persists per-user subscription tiers here on every mutation
+/// (subscribe, unsubscribe, auto-subscribe on @mention).
+pub fn broker_subscriptions_path(state_dir: &Path, room_id: &str) -> PathBuf {
+    state_dir.join(format!("{room_id}.subscriptions"))
+}
+
 // ── Directory initialisation ──────────────────────────────────────────────────
 
 /// Ensure `~/.room/state/` and `~/.room/data/` exist.
@@ -186,6 +194,13 @@ mod tests {
         let base = PathBuf::from("/tmp/state");
         let p = broker_tokens_path(&base, "test-room");
         assert_eq!(p, base.join("test-room.tokens"));
+    }
+
+    #[test]
+    fn broker_subscriptions_path_contains_room_id() {
+        let base = PathBuf::from("/tmp/state");
+        let p = broker_subscriptions_path(&base, "test-room");
+        assert_eq!(p, base.join("test-room.subscriptions"));
     }
 
     #[test]

--- a/crates/room-cli/tests/integration.rs
+++ b/crates/room-cli/tests/integration.rs
@@ -54,6 +54,7 @@ impl TestBroker {
             room_id,
             chat_path.clone(),
             chat_path.with_extension("tokens"),
+            chat_path.with_extension("subscriptions"),
             socket_path.clone(),
             ws_port,
         );
@@ -462,6 +463,7 @@ async fn pre_existing_history_is_replayed() {
         "pre",
         chat_path.clone(),
         chat_path.with_extension("tokens"),
+        chat_path.with_extension("subscriptions"),
         socket_path.clone(),
         None,
     );
@@ -509,6 +511,7 @@ async fn stale_socket_is_cleaned_up() {
         "stale",
         chat_path.clone(),
         chat_path.with_extension("tokens"),
+        chat_path.with_extension("subscriptions"),
         socket_path.clone(),
         None,
     );
@@ -1174,6 +1177,7 @@ async fn history_replay_filters_dm_for_non_party() {
         "replay_dm",
         chat_path.clone(),
         chat_path.with_extension("tokens"),
+        chat_path.with_extension("subscriptions"),
         socket_path.clone(),
         None,
     );


### PR DESCRIPTION
## Summary
- Persist per-user subscription tiers as JSON at `~/.room/state/<room_id>.subscriptions`
- Load persisted subscriptions on broker/daemon startup; save on every mutation (subscribe, unsubscribe, auto-subscribe on @mention)
- For DM rooms, persisted tiers override config defaults (a user who explicitly unsubscribed stays unsubscribed across restarts)

## Changes
- `paths.rs`: add `broker_subscriptions_path()` accessor
- `state.rs`: add `subscription_map_path` field to `RoomState`, update doc comment
- `commands.rs`: add `save_subscription_map`, `load_subscription_map`, `persist_subscriptions` helpers; call persist after subscribe/unsubscribe
- `mod.rs`: load persisted subs in `Broker::run`; persist after `auto_subscribe_mentioned`; add `subscription_map_path` to Broker struct/constructor
- `daemon.rs`: load persisted subs in `create_room` and `create_room_with_config` (merged with DM defaults)
- `main.rs`: pass `subscription_map_path` to `Broker::new`
- `integration.rs`: update all `Broker::new` call sites with new parameter

## Test plan
- [x] `load_subscription_map_missing_file_returns_empty` — graceful no-op on fresh install
- [x] `save_and_load_subscription_map_round_trip` — Full, MentionsOnly, Unsubscribed survive serialization
- [x] `load_subscription_map_corrupt_file_returns_empty` — corrupted file handled gracefully
- [x] `subscribe_persists_to_disk` — /subscribe writes to .subscriptions file
- [x] `unsubscribe_persists_to_disk` — /unsubscribe writes Unsubscribed tier
- [x] `subscribe_accumulates_on_disk` — multiple users accumulate in file
- [x] `subscribe_survives_simulated_restart` — new RoomState loaded from file matches original
- [x] `subscribe_overwrite_persists_latest_tier` — tier change overwrites previous value
- [x] `auto_subscribe_persists_to_disk` — @mention auto-subscribe writes to .subscriptions file
- [x] `broker_subscriptions_path_contains_room_id` — path format check
- [x] All 834 Rust tests pass, cargo check/fmt/clippy clean

Closes #311
