### PR TITLE
feat(ralph): add --socket flag for broker socket passthrough

### DIFF
--- a/crates/room-ralph/src/lib.rs
+++ b/crates/room-ralph/src/lib.rs
@@ -86,6 +86,11 @@ pub struct Cli {
     #[arg(long, env = "RALPH_PROFILE", value_parser = parse_profile)]
     pub profile: Option<claude::Profile>,
 
+    /// Override the broker socket path (passed through to all `room` subcommands).
+    /// Useful for connecting to a daemon socket instead of the default per-room socket.
+    #[arg(long, env = "ROOM_SOCKET")]
+    pub socket: Option<PathBuf>,
+
     /// Print the prompt that would be sent, then exit
     #[arg(long)]
     pub dry_run: bool,
@@ -100,7 +105,7 @@ mod tests {
     /// Mutex to serialize env-var tests (env is process-global state).
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
-    /// Helper: clear all RALPH_* env vars to avoid cross-test contamination.
+    /// Helper: clear all RALPH_*/ROOM_* env vars to avoid cross-test contamination.
     fn clear_ralph_env() {
         for key in [
             "RALPH_ROOM",
@@ -109,6 +114,7 @@ mod tests {
             "RALPH_ISSUE",
             "RALPH_DISALLOWED_TOOLS",
             "RALPH_PROFILE",
+            "ROOM_SOCKET",
         ] {
             unsafe { std::env::remove_var(key) };
         }
@@ -282,6 +288,74 @@ mod tests {
         let cli =
             Cli::try_parse_from(["room-ralph", "myroom", "myuser", "--profile", "notion"]).unwrap();
         assert_eq!(cli.profile, Some(claude::Profile::Notion));
+        clear_ralph_env();
+    }
+
+    #[test]
+    fn socket_flag_sets_path() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_ralph_env();
+
+        let cli = Cli::try_parse_from([
+            "room-ralph",
+            "myroom",
+            "myuser",
+            "--socket",
+            "/tmp/roomd.sock",
+        ])
+        .unwrap();
+        assert_eq!(
+            cli.socket,
+            Some(PathBuf::from("/tmp/roomd.sock")),
+            "socket should be set from --socket flag"
+        );
+        clear_ralph_env();
+    }
+
+    #[test]
+    fn socket_defaults_to_none() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_ralph_env();
+
+        let cli = Cli::try_parse_from(["room-ralph", "myroom", "myuser"]).unwrap();
+        assert!(cli.socket.is_none(), "socket should default to None");
+        clear_ralph_env();
+    }
+
+    #[test]
+    fn socket_from_env_var() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_ralph_env();
+
+        unsafe { std::env::set_var("ROOM_SOCKET", "/tmp/daemon.sock") };
+        let cli = Cli::try_parse_from(["room-ralph", "myroom", "myuser"]).unwrap();
+        assert_eq!(
+            cli.socket,
+            Some(PathBuf::from("/tmp/daemon.sock")),
+            "socket should be set from ROOM_SOCKET env var"
+        );
+        clear_ralph_env();
+    }
+
+    #[test]
+    fn socket_flag_overrides_env() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_ralph_env();
+
+        unsafe { std::env::set_var("ROOM_SOCKET", "/tmp/env.sock") };
+        let cli = Cli::try_parse_from([
+            "room-ralph",
+            "myroom",
+            "myuser",
+            "--socket",
+            "/tmp/flag.sock",
+        ])
+        .unwrap();
+        assert_eq!(
+            cli.socket,
+            Some(PathBuf::from("/tmp/flag.sock")),
+            "CLI --socket should override ROOM_SOCKET env var"
+        );
         clear_ralph_env();
     }
 }

--- a/crates/room-ralph/src/loop_runner.rs
+++ b/crates/room-ralph/src/loop_runner.rs
@@ -16,6 +16,8 @@ pub async fn run_loop(cli: &Cli, token: String, running: &Arc<AtomicBool>) -> Re
     let progress_file = progress::progress_file_path(cli.issue.as_deref(), &cli.username);
     let mut iteration: u32 = 0;
     let mut token = token;
+    let socket_str = cli.socket.as_ref().map(|p| p.display().to_string());
+    let socket_ref = socket_str.as_deref();
 
     while running.load(Ordering::SeqCst) {
         iteration += 1;
@@ -26,6 +28,7 @@ pub async fn run_loop(cli: &Cli, token: String, running: &Arc<AtomicBool>) -> Re
                 &cli.room_id,
                 &token,
                 &format!("max iterations reached ({}), shutting down", cli.max_iter),
+                socket_ref,
             )
             .ok();
             break;
@@ -34,15 +37,15 @@ pub async fn run_loop(cli: &Cli, token: String, running: &Arc<AtomicBool>) -> Re
         tracing::info!("--- iteration {} ---", iteration);
 
         // Poll room for recent messages — re-join if token is stale (broker restart)
-        let messages = match room::poll_messages(&cli.room_id, &token) {
+        let messages = match room::poll_messages(&cli.room_id, &token, socket_ref) {
             Ok(msgs) => msgs,
             Err(e) if room::detect_token_expiry(&e) => {
                 tracing::warn!("token expired during poll, re-joining: {}", e);
-                match room::join_room(&cli.room_id, &cli.username) {
+                match room::join_room(&cli.room_id, &cli.username, socket_ref) {
                     Ok(new_token) => {
                         tracing::info!("re-joined with new token");
                         token = new_token;
-                        room::poll_messages(&cli.room_id, &token).unwrap_or_default()
+                        room::poll_messages(&cli.room_id, &token, socket_ref).unwrap_or_default()
                     }
                     Err(join_err) => {
                         tracing::error!("re-join failed: {}", join_err);
@@ -83,7 +86,7 @@ pub async fn run_loop(cli: &Cli, token: String, running: &Arc<AtomicBool>) -> Re
             Some(issue) => format!("running claude — iteration {iteration} for #{issue}"),
             None => format!("running claude — iteration {iteration}"),
         };
-        room::set_status(&cli.room_id, &token, &status_text).ok();
+        room::set_status(&cli.room_id, &token, &status_text, socket_ref).ok();
 
         // Run claude
         tracing::info!(
@@ -151,13 +154,14 @@ pub async fn run_loop(cli: &Cli, token: String, running: &Arc<AtomicBool>) -> Re
                 &cli.room_id,
                 &token,
                 &format!("restarting — context limit at iteration {iteration}"),
+                socket_ref,
             )
             .ok();
             let msg = format!(
                 "context limit at iteration {} (tokens: {}), restarting with fresh context",
                 iteration, input_tokens
             );
-            room::send_message(&cli.room_id, &token, &msg).ok();
+            room::send_message(&cli.room_id, &token, &msg, socket_ref).ok();
         } else if claude_output.exit_code != 0 {
             tracing::warn!(
                 "claude failed (exit {}), will retry after cooldown",
@@ -170,13 +174,14 @@ pub async fn run_loop(cli: &Cli, token: String, running: &Arc<AtomicBool>) -> Re
                     "retrying — claude error (code {}) at iteration {iteration}",
                     claude_output.exit_code
                 ),
+                socket_ref,
             )
             .ok();
             let msg = format!(
                 "claude exited with error (code {}), retrying in {}s",
                 claude_output.exit_code, cli.cooldown
             );
-            room::send_message(&cli.room_id, &token, &msg).ok();
+            room::send_message(&cli.room_id, &token, &msg, socket_ref).ok();
         }
 
         // Cooldown
@@ -184,11 +189,12 @@ pub async fn run_loop(cli: &Cli, token: String, running: &Arc<AtomicBool>) -> Re
     }
 
     tracing::info!("room-ralph stopped after {} iterations", iteration);
-    room::set_status(&cli.room_id, &token, "offline").ok();
+    room::set_status(&cli.room_id, &token, "offline", socket_ref).ok();
     room::send_message(
         &cli.room_id,
         &token,
         &format!("offline (room-ralph stopped after {iteration} iterations)"),
+        socket_ref,
     )
     .ok();
     Ok(())

--- a/crates/room-ralph/src/main.rs
+++ b/crates/room-ralph/src/main.rs
@@ -72,6 +72,10 @@ fn launch_tmux(cli: &Cli) -> Result<(), String> {
         args.push("--profile".into());
         args.push(profile.to_string());
     }
+    if let Some(socket) = &cli.socket {
+        args.push("--socket".into());
+        args.push(socket.display().to_string());
+    }
 
     let cmd_str = format!("{} {}", exe.display(), args.join(" "));
     std::process::Command::new("tmux")
@@ -167,7 +171,9 @@ async fn main() -> ExitCode {
         cli.max_iter,
     );
 
-    let token = match room::join_room(&cli.room_id, &cli.username) {
+    let socket_str = cli.socket.as_ref().map(|p| p.display().to_string());
+    let socket_ref = socket_str.as_deref();
+    let token = match room::join_room(&cli.room_id, &cli.username, socket_ref) {
         Ok(t) => t,
         Err(e) => {
             tracing::error!("failed to join room: {}", e);
@@ -179,7 +185,7 @@ async fn main() -> ExitCode {
         "online (room-ralph, model={}, iter limit={})",
         cli.model, cli.max_iter
     );
-    room::send_message(&cli.room_id, &token, &announce).ok();
+    room::send_message(&cli.room_id, &token, &announce, socket_ref).ok();
 
     match loop_runner::run_loop(&cli, token, &running).await {
         Ok(()) => ExitCode::SUCCESS,

--- a/crates/room-ralph/src/room.rs
+++ b/crates/room-ralph/src/room.rs
@@ -17,9 +17,14 @@ pub fn token_file_path(room_id: &str, username: &str) -> PathBuf {
 ///
 /// Runs `room join <room_id> <username>` and parses the token from JSON output.
 /// Falls back to cached token file if join fails.
-pub fn join_room(room_id: &str, username: &str) -> Result<String, String> {
-    let output = Command::new("room")
-        .args(["join", room_id, username])
+/// If `socket` is provided, passes `--socket <path>` to the `room` command.
+pub fn join_room(room_id: &str, username: &str, socket: Option<&str>) -> Result<String, String> {
+    let mut cmd = Command::new("room");
+    cmd.args(["join", room_id, username]);
+    if let Some(s) = socket {
+        cmd.args(["--socket", s]);
+    }
+    let output = cmd
         .output()
         .map_err(|e| format!("failed to run `room join`: {e}"))?;
 
@@ -40,9 +45,19 @@ pub fn join_room(room_id: &str, username: &str) -> Result<String, String> {
 /// Send a message to the room.
 ///
 /// Runs `room send <room_id> -t <token> <message>`.
-pub fn send_message(room_id: &str, token: &str, message: &str) -> Result<(), String> {
-    let output = Command::new("room")
-        .args(["send", room_id, "-t", token, message])
+/// If `socket` is provided, passes `--socket <path>` to the `room` command.
+pub fn send_message(
+    room_id: &str,
+    token: &str,
+    message: &str,
+    socket: Option<&str>,
+) -> Result<(), String> {
+    let mut cmd = Command::new("room");
+    cmd.args(["send", room_id, "-t", token, message]);
+    if let Some(s) = socket {
+        cmd.args(["--socket", s]);
+    }
+    let output = cmd
         .output()
         .map_err(|e| format!("failed to run `room send`: {e}"))?;
 
@@ -59,9 +74,18 @@ pub fn send_message(room_id: &str, token: &str, message: &str) -> Result<(), Str
 /// Runs `room poll <room_id> -t <token>` and parses NDJSON output into Messages.
 /// Returns `Err` on non-zero exit (e.g. invalid token) so the caller can detect
 /// token expiry and re-join.
-pub fn poll_messages(room_id: &str, token: &str) -> Result<Vec<Message>, String> {
-    let output = Command::new("room")
-        .args(["poll", room_id, "-t", token])
+/// If `socket` is provided, passes `--socket <path>` to the `room` command.
+pub fn poll_messages(
+    room_id: &str,
+    token: &str,
+    socket: Option<&str>,
+) -> Result<Vec<Message>, String> {
+    let mut cmd = Command::new("room");
+    cmd.args(["poll", room_id, "-t", token]);
+    if let Some(s) = socket {
+        cmd.args(["--socket", s]);
+    }
+    let output = cmd
         .output()
         .map_err(|e| format!("failed to run `room poll`: {e}"))?;
 
@@ -89,9 +113,15 @@ pub fn poll_messages(room_id: &str, token: &str) -> Result<Vec<Message>, String>
 ///
 /// Delegates to `send_message` with the formatted `/set_status` command.
 /// Pass an empty string to clear the status.
-pub fn set_status(room_id: &str, token: &str, status: &str) -> Result<(), String> {
+/// If `socket` is provided, passes it through to `send_message`.
+pub fn set_status(
+    room_id: &str,
+    token: &str,
+    status: &str,
+    socket: Option<&str>,
+) -> Result<(), String> {
     let message = build_set_status_message(status);
-    send_message(room_id, token, &message)
+    send_message(room_id, token, &message, socket)
 }
 
 fn build_set_status_message(status: &str) -> String {

--- a/crates/room-ralph/tests/integration.rs
+++ b/crates/room-ralph/tests/integration.rs
@@ -32,6 +32,7 @@ fn test_cli(f: impl FnOnce(&mut Cli)) -> Cli {
         allow_tools: vec![],
         disallow_tools: vec![],
         profile: None,
+        socket: None,
         dry_run: false,
     };
     f(&mut cli);
@@ -329,7 +330,7 @@ fn poll_messages_parses_ndjson() {
     create_mock_room(mock_dir.path(), ndjson);
 
     let original = prepend_path(mock_dir.path());
-    let messages = room::poll_messages("test-room", "mock-tok").unwrap();
+    let messages = room::poll_messages("test-room", "mock-tok", None).unwrap();
     restore_path(&original);
 
     assert_eq!(messages.len(), 2, "should parse 2 messages from NDJSON");
@@ -382,13 +383,14 @@ async fn personality_appears_in_dry_run_output() {
 async fn live_broker_join_and_announce() {
     let room_id = "ralph-live-test";
 
-    match room::join_room(room_id, "ralph-integ-agent") {
+    match room::join_room(room_id, "ralph-integ-agent", None) {
         Ok(token) => {
             assert!(!token.is_empty(), "token should be non-empty");
-            let result = room::send_message(room_id, &token, "integration test: hello from ralph");
+            let result =
+                room::send_message(room_id, &token, "integration test: hello from ralph", None);
             assert!(result.is_ok(), "send should succeed: {result:?}");
 
-            let messages = room::poll_messages(room_id, &token).unwrap();
+            let messages = room::poll_messages(room_id, &token, None).unwrap();
             // At minimum, we should see our own announce message
             assert!(
                 !messages.is_empty(),


### PR DESCRIPTION
## Summary

- Add `--socket <path>` CLI flag and `ROOM_SOCKET` env var to room-ralph
- Pass socket path through to all `room` CLI invocations: join, send, poll, set_status
- Forward socket flag through tmux re-launch for `--tmux` mode
- Enables ralph to connect to a daemon socket instead of the default per-room socket

## Files modified

- `crates/room-ralph/src/lib.rs` - Add socket field to Cli struct, add ROOM_SOCKET to env cleanup, 4 new tests
- `crates/room-ralph/src/room.rs` - Add `socket: Option<&str>` param to join_room, send_message, poll_messages, set_status
- `crates/room-ralph/src/main.rs` - Compute socket_ref from cli.socket, pass through to room calls and tmux launch
- `crates/room-ralph/src/loop_runner.rs` - Compute socket_ref once, pass to all room calls in the loop
- `crates/room-ralph/tests/integration.rs` - Add socket: None to test_cli helper, update room call sites

## Test plan

- [x] `socket_flag_sets_path` - --socket /tmp/roomd.sock sets cli.socket
- [x] `socket_defaults_to_none` - no flag means None
- [x] `socket_from_env_var` - ROOM_SOCKET env var works
- [x] `socket_flag_overrides_env` - CLI flag takes precedence over env
- [x] All 136 room-ralph unit tests pass
- [x] All 8 room-ralph integration tests pass
- [x] Full pre-push checks pass (cargo check + fmt + clippy + test)

Closes #309
