### PR TITLE
feat(cli): --persistent flag for daemon subcommand

### DIFF
--- a/crates/room-cli/src/main.rs
+++ b/crates/room-cli/src/main.rs
@@ -226,8 +226,14 @@ enum Cmd {
         rooms: Vec<String>,
         /// Seconds to wait after the last connection closes before shutting down.
         /// Set to 0 for immediate shutdown. Default: 30.
+        /// Ignored when --persistent is set.
         #[arg(long, default_value_t = 30)]
         grace_period: u64,
+        /// Keep the daemon running indefinitely after the last connection closes.
+        /// Equivalent to --grace-period with the maximum possible value.
+        /// Mutually exclusive with --grace-period.
+        #[arg(long, conflicts_with = "grace_period")]
+        persistent: bool,
     },
 }
 
@@ -520,14 +526,16 @@ async fn main() -> anyhow::Result<()> {
             ws_port,
             rooms,
             grace_period,
+            persistent,
         }) => {
+            let effective_grace = if persistent { u64::MAX } else { grace_period };
             run_daemon(
                 socket.unwrap_or_else(paths::room_socket_path),
                 data_dir.unwrap_or_else(paths::room_data_dir),
                 state_dir.unwrap_or_else(paths::room_state_dir),
                 ws_port,
                 rooms,
-                grace_period,
+                effective_grace,
             )
             .await?;
         }

--- a/crates/room-cli/src/oneshot/transport.rs
+++ b/crates/room-cli/src/oneshot/transport.rs
@@ -360,8 +360,17 @@ mod tests {
         bin
     }
 
+    /// Global lock that serialises subprocess-spawning tests so they don't
+    /// compete with each other (and with integration tests) for OS process
+    /// start-up resources when the full suite runs in parallel.
+    fn subprocess_lock() -> &'static std::sync::Mutex<()> {
+        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(std::sync::Mutex::default)
+    }
+
     #[tokio::test]
     async fn ensure_daemon_noop_when_socket_connectable() {
+        let _guard = subprocess_lock().lock().unwrap();
         // Start a real daemon at a temp socket, verify ensure_daemon_running_at
         // returns Ok without spawning a second process.
         let dir = tempfile::TempDir::new().unwrap();
@@ -397,6 +406,7 @@ mod tests {
 
     #[tokio::test]
     async fn ensure_daemon_starts_daemon_and_writes_pid() {
+        let _guard = subprocess_lock().lock().unwrap();
         let dir = tempfile::TempDir::new().unwrap();
         let socket = dir.path().join("autostart.sock");
         let exe = room_bin();


### PR DESCRIPTION
## Summary

- `room daemon --persistent` keeps the daemon alive indefinitely after the last connection closes (equivalent to `--grace-period` with `u64::MAX`)
- Mutually exclusive with `--grace-period` (clap `conflicts_with`)
- Also fixes a pre-existing flakiness: subprocess-spawning unit tests now use a static `Mutex` to avoid competing for OS process resources under parallel test load

## Changes

- `main.rs`: add `--persistent` flag to `Daemon` subcommand; if set, `effective_grace = u64::MAX`; otherwise use `--grace-period` value (default 30)
- `transport.rs`: add `subprocess_lock()` static mutex; `ensure_daemon_noop_when_socket_connectable` and `ensure_daemon_starts_daemon_and_writes_pid` acquire it to prevent races

No changes to `daemon.rs` or test counts — this is purely a CLI flag wiring change.

Closes #289
