### PR TITLE
feat(tui): /dm command creates DM room and opens tab (#297)

### DIFF
--- a/crates/room-cli/src/client.rs
+++ b/crates/room-cli/src/client.rs
@@ -40,6 +40,7 @@ impl Client {
                 &self.room_id,
                 &self.username,
                 self.history_lines,
+                self.socket_path.clone(),
             )
             .await
         }

--- a/crates/room-cli/src/tui/input.rs
+++ b/crates/room-cli/src/tui/input.rs
@@ -41,6 +41,11 @@ pub(super) enum Action {
     PrevTab,
     /// Switch to a specific tab by index (Ctrl+1–9).
     SwitchTab(usize),
+    /// Open or reuse a DM room with the target user and send a message.
+    DmRoom {
+        target_user: String,
+        content: String,
+    },
 }
 
 /// Handle a single key event, mutating `state` in place.
@@ -108,6 +113,15 @@ pub(super) fn handle_key(
                 // Backslash + Enter: strip the trailing '\' and insert a newline.
                 state.cursor_pos = new_pos;
             } else if !state.input.is_empty() {
+                // Intercept `/dm <user> <msg>` to return a DmRoom action
+                // instead of sending an intra-room DM.
+                if let Some(dm) = parse_dm_input(&state.input) {
+                    state.input.clear();
+                    state.cursor_pos = 0;
+                    state.input_row_scroll = 0;
+                    state.scroll_offset = 0;
+                    return Some(dm);
+                }
                 let payload = build_payload(&state.input);
                 state.input.clear();
                 state.cursor_pos = 0;
@@ -529,9 +543,28 @@ pub(super) fn apply_backslash_enter(buf: &mut String, cursor_pos: usize) -> Opti
     }
 }
 
+/// Parse `/dm <user> <message>` input into a `DmRoom` action.
+///
+/// Returns `Some(Action::DmRoom { .. })` when the input is a valid `/dm`
+/// command with both a target user and message content. Returns `None` for
+/// incomplete input (missing user or message) — those fall through to
+/// `build_payload` for backwards-compatible intra-room DM handling.
+fn parse_dm_input(input: &str) -> Option<Action> {
+    let rest = input.strip_prefix("/dm ")?;
+    let mut parts = rest.splitn(2, ' ');
+    let target_user = parts.next().filter(|s| !s.is_empty())?;
+    let content = parts.next().filter(|s| !s.is_empty())?;
+    Some(Action::DmRoom {
+        target_user: target_user.to_owned(),
+        content: content.to_owned(),
+    })
+}
+
 /// Convert TUI input to a JSON envelope for the broker.
 pub(super) fn build_payload(input: &str) -> String {
     // `/dm <user> <message>` — preserve spaces in the message body.
+    // NOTE: This branch is now only reached when `parse_dm_input` returns
+    // None (e.g. `/dm user` with no message body).
     if let Some(rest) = input.strip_prefix("/dm ") {
         let mut parts = rest.splitn(2, ' ');
         let to = parts.next().unwrap_or("").to_owned();
@@ -831,6 +864,56 @@ mod tests {
         let payload = build_payload("/dm bob hello   world");
         let v: serde_json::Value = serde_json::from_str(&payload).unwrap();
         assert_eq!(v["content"], "hello   world");
+    }
+
+    // ── parse_dm_input tests ────────────────────────────────────────────────
+
+    #[test]
+    fn parse_dm_input_returns_dm_room_action() {
+        let action = parse_dm_input("/dm alice hello there").unwrap();
+        match action {
+            Action::DmRoom {
+                target_user,
+                content,
+            } => {
+                assert_eq!(target_user, "alice");
+                assert_eq!(content, "hello there");
+            }
+            _ => panic!("expected DmRoom action"),
+        }
+    }
+
+    #[test]
+    fn parse_dm_input_preserves_spaces_in_content() {
+        let action = parse_dm_input("/dm bob hello   world").unwrap();
+        match action {
+            Action::DmRoom { content, .. } => {
+                assert_eq!(content, "hello   world");
+            }
+            _ => panic!("expected DmRoom action"),
+        }
+    }
+
+    #[test]
+    fn parse_dm_input_returns_none_for_missing_content() {
+        assert!(parse_dm_input("/dm alice").is_none());
+    }
+
+    #[test]
+    fn parse_dm_input_returns_none_for_missing_user() {
+        assert!(parse_dm_input("/dm ").is_none());
+    }
+
+    #[test]
+    fn parse_dm_input_returns_none_for_non_dm() {
+        assert!(parse_dm_input("/who").is_none());
+        assert!(parse_dm_input("hello world").is_none());
+    }
+
+    #[test]
+    fn parse_dm_input_returns_none_for_user_only_with_trailing_space() {
+        // "/dm alice " has empty content after splitting
+        assert!(parse_dm_input("/dm alice ").is_none());
     }
 
     // ── wrap_input_display ──────────────────────────────────────────────────

--- a/crates/room-cli/src/tui/mod.rs
+++ b/crates/room-cli/src/tui/mod.rs
@@ -115,12 +115,108 @@ impl RoomTab {
     }
 }
 
+/// Create or reuse a DM room and return a connected `RoomTab`.
+///
+/// 1. Sends `CREATE:<dm_room_id>` to the daemon socket. If the room already
+///    exists, the daemon returns `room_already_exists` — this is fine, we proceed.
+/// 2. Connects to the daemon with `ROOM:<dm_room_id>:<username>` for an
+///    interactive session.
+/// 3. Spawns a reader task and returns a `RoomTab` ready for the tab list.
+async fn open_dm_tab(
+    socket_path: &std::path::Path,
+    dm_room_id: &str,
+    username: &str,
+    target_user: &str,
+    history_lines: usize,
+) -> anyhow::Result<RoomTab> {
+    use tokio::net::UnixStream;
+
+    // Step 1: Create the DM room (idempotent — ignore "already exists").
+    let config = room_protocol::RoomConfig::dm(username, target_user);
+    let config_json = serde_json::to_string(&config)?;
+    match crate::oneshot::transport::create_room(socket_path, dm_room_id, &config_json).await {
+        Ok(_) => {}
+        Err(e) if e.to_string().contains("already exists") => {}
+        Err(e) => return Err(e),
+    }
+
+    // Step 2: Join the DM room via the daemon socket.
+    let stream = UnixStream::connect(socket_path).await?;
+    let (read_half, mut write_half) = stream.into_split();
+    let handshake = format!("ROOM:{dm_room_id}:{username}\n");
+    write_half.write_all(handshake.as_bytes()).await?;
+
+    // Step 3: Spawn reader task for the new tab.
+    let (tx, rx) = mpsc::unbounded_channel::<Message>();
+    let username_owned = username.to_owned();
+    let reader = BufReader::new(read_half);
+
+    tokio::spawn(async move {
+        let mut reader = reader;
+        let mut history_buf: Vec<Message> = Vec::new();
+        let mut joined = false;
+        let mut line = String::new();
+
+        loop {
+            line.clear();
+            match reader.read_line(&mut line).await {
+                Ok(0) => break,
+                Ok(_) => {
+                    let trimmed = line.trim();
+                    if trimmed.is_empty() {
+                        continue;
+                    }
+                    let Ok(msg) = serde_json::from_str::<Message>(trimmed) else {
+                        continue;
+                    };
+
+                    if joined {
+                        let _ = tx.send(msg);
+                    } else {
+                        let is_own_join =
+                            matches!(&msg, Message::Join { user, .. } if user == &username_owned);
+                        if is_own_join {
+                            joined = true;
+                            let start = history_buf.len().saturating_sub(history_lines);
+                            for h in history_buf.drain(start..) {
+                                let _ = tx.send(h);
+                            }
+                            let _ = tx.send(msg);
+                        } else {
+                            history_buf.push(msg);
+                        }
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    // Request /who to seed the member panel.
+    let who_payload = build_payload("/who");
+    write_half
+        .write_all(format!("{who_payload}\n").as_bytes())
+        .await?;
+
+    Ok(RoomTab {
+        room_id: dm_room_id.to_owned(),
+        messages: Vec::new(),
+        online_users: Vec::new(),
+        user_statuses: HashMap::new(),
+        unread_count: 0,
+        scroll_offset: 0,
+        msg_rx: rx,
+        write_half,
+    })
+}
+
 pub async fn run(
     reader: BufReader<tokio::net::unix::OwnedReadHalf>,
     write_half: tokio::net::unix::OwnedWriteHalf,
     room_id: &str,
     username: &str,
     history_lines: usize,
+    socket_path: std::path::PathBuf,
 ) -> anyhow::Result<()> {
     let (msg_tx, msg_rx) = mpsc::unbounded_channel::<Message>();
     let username_owned = username.to_owned();
@@ -636,6 +732,99 @@ pub async fn run(
                                 active_tab = idx;
                                 tabs[active_tab].unread_count = 0;
                                 input_state.scroll_offset = tabs[active_tab].scroll_offset;
+                            }
+                        }
+                        Some(Action::DmRoom {
+                            target_user,
+                            content,
+                        }) => {
+                            match room_protocol::dm_room_id(username, &target_user) {
+                                Ok(dm_id) => {
+                                    // Check if a tab for this DM room already exists.
+                                    if let Some(idx) = tabs.iter().position(|t| t.room_id == dm_id)
+                                    {
+                                        // Switch to existing DM tab and send the message.
+                                        tabs[active_tab].scroll_offset = input_state.scroll_offset;
+                                        active_tab = idx;
+                                        tabs[active_tab].unread_count = 0;
+                                        input_state.scroll_offset = tabs[active_tab].scroll_offset;
+                                        let payload = build_payload(&content);
+                                        if let Err(e) = tabs[active_tab]
+                                            .write_half
+                                            .write_all(format!("{payload}\n").as_bytes())
+                                            .await
+                                        {
+                                            result = Err(e.into());
+                                            break 'main;
+                                        }
+                                    } else {
+                                        // Create/reuse DM room and open a new tab.
+                                        match open_dm_tab(
+                                            &socket_path,
+                                            &dm_id,
+                                            username,
+                                            &target_user,
+                                            history_lines,
+                                        )
+                                        .await
+                                        {
+                                            Ok(new_tab) => {
+                                                tabs.push(new_tab);
+                                                tabs[active_tab].scroll_offset =
+                                                    input_state.scroll_offset;
+                                                active_tab = tabs.len() - 1;
+                                                input_state.scroll_offset = 0;
+
+                                                // Send the message in the new DM tab.
+                                                let payload = build_payload(&content);
+                                                if let Err(e) = tabs[active_tab]
+                                                    .write_half
+                                                    .write_all(format!("{payload}\n").as_bytes())
+                                                    .await
+                                                {
+                                                    result = Err(e.into());
+                                                    break 'main;
+                                                }
+                                            }
+                                            Err(_) => {
+                                                // DM room creation failed — fall back to
+                                                // intra-room DM in the current tab.
+                                                let fallback = serde_json::json!({
+                                                    "type": "dm",
+                                                    "to": target_user,
+                                                    "content": content
+                                                })
+                                                .to_string();
+                                                if let Err(e) = tabs[active_tab]
+                                                    .write_half
+                                                    .write_all(format!("{fallback}\n").as_bytes())
+                                                    .await
+                                                {
+                                                    result = Err(e.into());
+                                                    break 'main;
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                                Err(_) => {
+                                    // Same user — cannot DM yourself. Send as intra-room DM
+                                    // which the broker will reject with a sensible error.
+                                    let fallback = serde_json::json!({
+                                        "type": "dm",
+                                        "to": target_user,
+                                        "content": content
+                                    })
+                                    .to_string();
+                                    if let Err(e) = tabs[active_tab]
+                                        .write_half
+                                        .write_all(format!("{fallback}\n").as_bytes())
+                                        .await
+                                    {
+                                        result = Err(e.into());
+                                        break 'main;
+                                    }
+                                }
                             }
                         }
                         None => {}


### PR DESCRIPTION
## Summary
- `/dm <user> <message>` in TUI now creates a dedicated DM room via daemon CREATE: protocol
- Computes canonical DM room ID (`dm-<sorted>`) using `room_protocol::dm_room_id`
- `open_dm_tab()` handles room creation (idempotent), daemon ROOM: handshake, reader task spawn, and /who seeding
- Reuses existing DM tab if already open (switches + sends message)
- Falls back to intra-room DM when daemon unavailable or DM-to-self
- `socket_path` threaded through `client.rs` to `tui::run()` for daemon connectivity

## Files modified
- `crates/room-cli/src/tui/input.rs` — `DmRoom` action variant, `parse_dm_input()` helper, +6 tests
- `crates/room-cli/src/tui/mod.rs` — `open_dm_tab()` helper, `DmRoom` action handler, `socket_path` param
- `crates/room-cli/src/client.rs` — pass `socket_path` to `tui::run()`

## Test plan
- [x] `parse_dm_input` returns DmRoom action for valid `/dm user msg`
- [x] `parse_dm_input` preserves spaces in content
- [x] `parse_dm_input` returns None for missing content/user/non-dm
- [x] `parse_dm_input` returns None for user-only with trailing space
- [x] All 218 TUI tests pass
- [x] Full test suite passes (913 tests)
- [x] cargo check, fmt, clippy clean

Closes #297