### PR TITLE
feat(ws): add POST /api/rooms REST endpoint for dynamic room creation (#291)

### DIFF
--- a/crates/room-cli/src/broker/daemon.rs
+++ b/crates/room-cli/src/broker/daemon.rs
@@ -209,48 +209,14 @@ impl DaemonState {
     /// Create a room and register it. Returns `Err` if the room ID is invalid
     /// or the room already exists.
     pub async fn create_room(&self, room_id: &str) -> Result<(), String> {
-        validate_room_id(room_id)?;
-        let mut rooms = self.rooms.lock().await;
-        if rooms.contains_key(room_id) {
-            return Err(format!("room already exists: {room_id}"));
-        }
-
-        let chat_path = self.config.chat_path(room_id);
-        let subscription_map_path = self.config.subscription_map_path(room_id);
-        let (shutdown_tx, _) = watch::channel(false);
-
-        let mut registry = PluginRegistry::new();
-        registry
-            .register(Box::new(plugin::help::HelpPlugin))
-            .map_err(|e| format!("plugin error: {e}"))?;
-        registry
-            .register(Box::new(plugin::stats::StatsPlugin))
-            .map_err(|e| format!("plugin error: {e}"))?;
-
-        // Load persisted subscriptions from previous session (if any).
-        let persisted_subs = super::commands::load_subscription_map(&subscription_map_path);
-
-        let state = Arc::new(RoomState {
-            clients: Arc::new(Mutex::new(HashMap::new())),
-            status_map: Arc::new(Mutex::new(HashMap::new())),
-            host_user: Arc::new(Mutex::new(None)),
-            // All rooms in this daemon share the same token map so a token
-            // issued in any room is valid in all rooms.
-            token_map: Arc::clone(&self.system_token_map),
-            claim_map: Arc::new(Mutex::new(HashMap::new())),
-            subscription_map: Arc::new(Mutex::new(persisted_subs)),
-            chat_path: Arc::new(chat_path),
-            token_map_path: Arc::new(self.config.system_tokens_path()),
-            subscription_map_path: Arc::new(subscription_map_path),
-            room_id: Arc::new(room_id.to_owned()),
-            shutdown: Arc::new(shutdown_tx),
-            seq_counter: Arc::new(AtomicU64::new(0)),
-            plugin_registry: Arc::new(registry),
-            config: None,
-        });
-
-        rooms.insert(room_id.to_owned(), state);
-        Ok(())
+        create_room_entry(
+            room_id,
+            None,
+            &self.rooms,
+            &self.config,
+            &self.system_token_map,
+        )
+        .await
     }
 
     /// Create a room with explicit configuration. Returns `Err` if the room ID
@@ -260,52 +226,14 @@ impl DaemonState {
         room_id: &str,
         config: room_protocol::RoomConfig,
     ) -> Result<(), String> {
-        validate_room_id(room_id)?;
-        let mut rooms = self.rooms.lock().await;
-        if rooms.contains_key(room_id) {
-            return Err(format!("room already exists: {room_id}"));
-        }
-
-        let chat_path = self.config.chat_path(room_id);
-        let subscription_map_path = self.config.subscription_map_path(room_id);
-        let (shutdown_tx, _) = watch::channel(false);
-
-        let mut registry = PluginRegistry::new();
-        registry
-            .register(Box::new(plugin::help::HelpPlugin))
-            .map_err(|e| format!("plugin error: {e}"))?;
-        registry
-            .register(Box::new(plugin::stats::StatsPlugin))
-            .map_err(|e| format!("plugin error: {e}"))?;
-
-        // Merge persisted subscriptions with config defaults (DM auto-subscribe).
-        // Config defaults seed any missing entries; persisted values take precedence
-        // because a user may have explicitly changed their tier after room creation.
-        let mut merged_subs = build_initial_subscriptions(&config);
-        let persisted_subs = super::commands::load_subscription_map(&subscription_map_path);
-        merged_subs.extend(persisted_subs);
-
-        let state = Arc::new(RoomState {
-            clients: Arc::new(Mutex::new(HashMap::new())),
-            status_map: Arc::new(Mutex::new(HashMap::new())),
-            host_user: Arc::new(Mutex::new(None)),
-            // All rooms in this daemon share the same token map so a token
-            // issued in any room is valid in all rooms.
-            token_map: Arc::clone(&self.system_token_map),
-            claim_map: Arc::new(Mutex::new(HashMap::new())),
-            subscription_map: Arc::new(Mutex::new(merged_subs)),
-            chat_path: Arc::new(chat_path),
-            token_map_path: Arc::new(self.config.system_tokens_path()),
-            subscription_map_path: Arc::new(subscription_map_path),
-            room_id: Arc::new(room_id.to_owned()),
-            shutdown: Arc::new(shutdown_tx),
-            seq_counter: Arc::new(AtomicU64::new(0)),
-            plugin_registry: Arc::new(registry),
-            config: Some(config),
-        });
-
-        rooms.insert(room_id.to_owned(), state);
-        Ok(())
+        create_room_entry(
+            room_id,
+            Some(config),
+            &self.rooms,
+            &self.config,
+            &self.system_token_map,
+        )
+        .await
     }
 
     /// Get a room's config, if it exists.
@@ -399,6 +327,8 @@ impl DaemonState {
             let ws_state = DaemonWsState {
                 rooms: self.rooms.clone(),
                 next_client_id: self.next_client_id.clone(),
+                config: self.config.clone(),
+                system_token_map: self.system_token_map.clone(),
             };
             let app = ws::create_daemon_router(ws_state);
             let tcp = tokio::net::TcpListener::bind(("0.0.0.0", port)).await?;
@@ -629,6 +559,70 @@ fn build_initial_subscriptions(
     subs
 }
 
+/// Core room-creation logic shared by UDS and REST paths.
+///
+/// Validates the room ID, checks for duplicates, builds a [`RoomState`], and
+/// inserts it into the room map. Pass `config: None` to create a configless
+/// room (no invite list, no visibility constraint).
+pub(crate) async fn create_room_entry(
+    room_id: &str,
+    config: Option<room_protocol::RoomConfig>,
+    rooms: &RoomMap,
+    daemon_config: &DaemonConfig,
+    system_token_map: &TokenMap,
+) -> Result<(), String> {
+    validate_room_id(room_id)?;
+    {
+        let map = rooms.lock().await;
+        if map.contains_key(room_id) {
+            return Err(format!("room already exists: {room_id}"));
+        }
+    }
+
+    let chat_path = daemon_config.chat_path(room_id);
+    let subscription_map_path = daemon_config.subscription_map_path(room_id);
+    let (shutdown_tx, _) = watch::channel(false);
+
+    let mut registry = PluginRegistry::new();
+    registry
+        .register(Box::new(plugin::help::HelpPlugin))
+        .map_err(|e| format!("plugin error: {e}"))?;
+    registry
+        .register(Box::new(plugin::stats::StatsPlugin))
+        .map_err(|e| format!("plugin error: {e}"))?;
+
+    let persisted_subs = super::commands::load_subscription_map(&subscription_map_path);
+    let merged_subs = if let Some(ref cfg) = config {
+        let mut initial = build_initial_subscriptions(cfg);
+        initial.extend(persisted_subs);
+        initial
+    } else {
+        persisted_subs
+    };
+
+    let state = Arc::new(RoomState {
+        clients: Arc::new(Mutex::new(HashMap::new())),
+        status_map: Arc::new(Mutex::new(HashMap::new())),
+        host_user: Arc::new(Mutex::new(None)),
+        // All rooms in this daemon share the same token map so a token
+        // issued in any room is valid in all rooms.
+        token_map: Arc::clone(system_token_map),
+        claim_map: Arc::new(Mutex::new(HashMap::new())),
+        subscription_map: Arc::new(Mutex::new(merged_subs)),
+        chat_path: Arc::new(chat_path),
+        token_map_path: Arc::new(daemon_config.system_tokens_path()),
+        subscription_map_path: Arc::new(subscription_map_path),
+        room_id: Arc::new(room_id.to_owned()),
+        shutdown: Arc::new(shutdown_tx),
+        seq_counter: Arc::new(AtomicU64::new(0)),
+        plugin_registry: Arc::new(registry),
+        config,
+    });
+
+    rooms.lock().await.insert(room_id.to_owned(), state);
+    Ok(())
+}
+
 /// Parse the `ROOM:<room_id>:` prefix from a handshake line.
 ///
 /// Returns `(room_id, rest)` on success. `rest` is the remainder after the
@@ -810,55 +804,24 @@ async fn handle_create(
         }
     };
 
-    // Build RoomState (mirrors DaemonState::create_room_with_config).
-    let chat_path = daemon_config.chat_path(room_id);
-    let subscription_map_path = daemon_config.subscription_map_path(room_id);
-    let (shutdown_tx, _) = watch::channel(false);
-
-    let mut registry = PluginRegistry::new();
-    if let Err(e) = registry.register(Box::new(plugin::help::HelpPlugin)) {
+    // Delegate to the shared room-creation helper.
+    if let Err(e) = create_room_entry(
+        room_id,
+        Some(room_config),
+        rooms,
+        daemon_config,
+        system_token_map,
+    )
+    .await
+    {
         let err = serde_json::json!({
             "type": "error",
             "code": "internal",
-            "message": format!("plugin error: {e}")
+            "message": e
         });
         write_half.write_all(format!("{err}\n").as_bytes()).await?;
         return Ok(());
     }
-    if let Err(e) = registry.register(Box::new(plugin::stats::StatsPlugin)) {
-        let err = serde_json::json!({
-            "type": "error",
-            "code": "internal",
-            "message": format!("plugin error: {e}")
-        });
-        write_half.write_all(format!("{err}\n").as_bytes()).await?;
-        return Ok(());
-    }
-
-    // Merge persisted subscriptions with config defaults (DM auto-subscribe).
-    let mut merged_subs = build_initial_subscriptions(&room_config);
-    let persisted_subs = super::commands::load_subscription_map(&subscription_map_path);
-    merged_subs.extend(persisted_subs);
-
-    let state = Arc::new(RoomState {
-        clients: Arc::new(Mutex::new(HashMap::new())),
-        status_map: Arc::new(Mutex::new(HashMap::new())),
-        host_user: Arc::new(Mutex::new(None)),
-        // Share the daemon's system-level token map so tokens work across rooms.
-        token_map: Arc::clone(system_token_map),
-        claim_map: Arc::new(Mutex::new(HashMap::new())),
-        subscription_map: Arc::new(Mutex::new(merged_subs)),
-        chat_path: Arc::new(chat_path),
-        token_map_path: Arc::new(daemon_config.system_tokens_path()),
-        subscription_map_path: Arc::new(subscription_map_path),
-        room_id: Arc::new(room_id.to_owned()),
-        shutdown: Arc::new(shutdown_tx),
-        seq_counter: Arc::new(AtomicU64::new(0)),
-        plugin_registry: Arc::new(registry),
-        config: Some(room_config),
-    });
-
-    rooms.lock().await.insert(room_id.to_owned(), state);
 
     let ok = serde_json::json!({
         "type": "room_created",

--- a/crates/room-cli/src/broker/ws.rs
+++ b/crates/room-cli/src/broker/ws.rs
@@ -839,6 +839,8 @@ async fn api_health(State(state): State<WsAppState>) -> impl IntoResponse {
 pub(crate) struct DaemonWsState {
     pub(crate) rooms: super::daemon::RoomMap,
     pub(crate) next_client_id: Arc<AtomicU64>,
+    pub(crate) config: super::daemon::DaemonConfig,
+    pub(crate) system_token_map: super::state::TokenMap,
 }
 
 impl DaemonWsState {
@@ -858,6 +860,7 @@ pub(crate) fn create_daemon_router(state: DaemonWsState) -> Router {
         .route("/api/{room_id}/query", get(daemon_api_query))
         .route("/api/health", get(daemon_api_health))
         .route("/api/rooms", get(daemon_api_rooms))
+        .route("/api/rooms", post(daemon_api_create_room))
         .with_state(state)
 }
 
@@ -1125,6 +1128,115 @@ async fn daemon_api_rooms(State(state): State<DaemonWsState>) -> impl IntoRespon
     Json(serde_json::json!({
         "rooms": ids,
     }))
+}
+
+#[derive(Deserialize)]
+struct CreateRoomRequest {
+    room_id: String,
+    #[serde(default)]
+    visibility: Option<String>,
+    #[serde(default)]
+    invite: Option<Vec<String>>,
+}
+
+async fn daemon_api_create_room(
+    State(state): State<DaemonWsState>,
+    headers: HeaderMap,
+    Json(body): Json<CreateRoomRequest>,
+) -> impl IntoResponse {
+    let token = match extract_bearer_token(&headers) {
+        Some(t) => t,
+        None => {
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({"type":"error","code":"missing_token"})),
+            )
+                .into_response()
+        }
+    };
+
+    // Validate token against the shared token map.
+    if validate_token(token, &state.system_token_map)
+        .await
+        .is_none()
+    {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({"type":"error","code":"invalid_token"})),
+        )
+            .into_response();
+    }
+
+    let visibility_str = body.visibility.as_deref().unwrap_or("public");
+    let invite = body.invite.unwrap_or_default();
+
+    let room_config = match visibility_str {
+        "public" => room_protocol::RoomConfig {
+            visibility: room_protocol::RoomVisibility::Public,
+            max_members: None,
+            invite_list: invite.into_iter().collect(),
+            created_by: "system".to_owned(),
+            created_at: chrono::Utc::now().to_rfc3339(),
+        },
+        "private" => room_protocol::RoomConfig {
+            visibility: room_protocol::RoomVisibility::Private,
+            max_members: None,
+            invite_list: invite.into_iter().collect(),
+            created_by: "system".to_owned(),
+            created_at: chrono::Utc::now().to_rfc3339(),
+        },
+        "dm" => {
+            if invite.len() != 2 {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({
+                        "type": "error",
+                        "code": "invalid_config",
+                        "message": "dm visibility requires exactly 2 users in invite list"
+                    })),
+                )
+                    .into_response();
+            }
+            room_protocol::RoomConfig::dm(&invite[0], &invite[1])
+        }
+        other => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "type": "error",
+                    "code": "invalid_config",
+                    "message": format!("unknown visibility: {other}")
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    match super::daemon::create_room_entry(
+        &body.room_id,
+        Some(room_config),
+        &state.rooms,
+        &state.config,
+        &state.system_token_map,
+    )
+    .await
+    {
+        Ok(()) => (
+            StatusCode::CREATED,
+            Json(serde_json::json!({"type":"room_created","room": body.room_id})),
+        )
+            .into_response(),
+        Err(e) if e.contains("room already exists") => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({"type":"error","code":"room_exists","message": e})),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"type":"error","code":"invalid_room_id","message": e})),
+        )
+            .into_response(),
+    }
 }
 
 async fn daemon_api_query(

--- a/crates/room-cli/tests/integration.rs
+++ b/crates/room-cli/tests/integration.rs
@@ -4385,3 +4385,182 @@ async fn create_then_destroy_then_recreate() {
     let token2 = daemon_join(&td.socket_path, "ephemeral", "bob").await;
     assert!(!token2.is_empty());
 }
+
+// ── REST POST /api/rooms tests ───────────────────────────────────────────────
+
+#[tokio::test]
+async fn rest_create_room_without_token_returns_401() {
+    let (_td, port) = TestDaemon::start_with_ws_configs(vec![]).await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(format!("http://127.0.0.1:{port}/api/rooms"))
+        .json(&serde_json::json!({"room_id": "newroom"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 401);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["code"], "missing_token");
+}
+
+#[tokio::test]
+async fn rest_create_room_with_invalid_token_returns_401() {
+    let (_td, port) = TestDaemon::start_with_ws_configs(vec![]).await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(format!("http://127.0.0.1:{port}/api/rooms"))
+        .header("Authorization", "Bearer not-a-real-token")
+        .json(&serde_json::json!({"room_id": "newroom"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 401);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["code"], "invalid_token");
+}
+
+#[tokio::test]
+async fn rest_create_room_returns_201() {
+    let (td, port) = TestDaemon::start_with_ws_configs(vec![("seed-room", None)]).await;
+    let base = format!("http://127.0.0.1:{port}");
+    let client = reqwest::Client::new();
+
+    // Get a valid token by joining an existing room.
+    let token = rest_join(&client, &base, "seed-room", "alice_cr").await;
+
+    let resp = client
+        .post(format!("{base}/api/rooms"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!({"room_id": "brand-new-room"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["type"], "room_created");
+    assert_eq!(body["room"], "brand-new-room");
+
+    // Room should now be accessible — join it.
+    let token2 = rest_join(&client, &base, "brand-new-room", "bob_cr").await;
+    assert!(!token2.is_empty());
+    drop(td);
+}
+
+#[tokio::test]
+async fn rest_create_room_duplicate_returns_409() {
+    let (td, port) = TestDaemon::start_with_ws_configs(vec![("existing-room-409", None)]).await;
+    let base = format!("http://127.0.0.1:{port}");
+    let client = reqwest::Client::new();
+
+    let token = rest_join(&client, &base, "existing-room-409", "alice_dup").await;
+
+    let resp = client
+        .post(format!("{base}/api/rooms"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!({"room_id": "existing-room-409"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 409);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["code"], "room_exists");
+    drop(td);
+}
+
+#[tokio::test]
+async fn rest_create_room_invalid_id_returns_400() {
+    let (td, port) = TestDaemon::start_with_ws_configs(vec![("seed400", None)]).await;
+    let base = format!("http://127.0.0.1:{port}");
+    let client = reqwest::Client::new();
+
+    let token = rest_join(&client, &base, "seed400", "alice_inv").await;
+
+    let resp = client
+        .post(format!("{base}/api/rooms"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!({"room_id": "../escape"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["code"], "invalid_room_id");
+    drop(td);
+}
+
+#[tokio::test]
+async fn rest_create_room_with_private_visibility() {
+    let (td, port) = TestDaemon::start_with_ws_configs(vec![("seed-priv", None)]).await;
+    let base = format!("http://127.0.0.1:{port}");
+    let client = reqwest::Client::new();
+
+    // alice_priv_creator gets a token from the seed room for auth.
+    let token = rest_join(&client, &base, "seed-priv", "alice_priv_creator").await;
+
+    let resp = client
+        .post(format!("{base}/api/rooms"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!({"room_id": "private-room", "visibility": "private", "invite": ["bob_priv_invited"]}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["type"], "room_created");
+
+    // bob_priv_invited (in invite list) can join the private room.
+    let tok2 = rest_join(&client, &base, "private-room", "bob_priv_invited").await;
+    assert!(!tok2.is_empty());
+    drop(td);
+}
+
+#[tokio::test]
+async fn rest_create_dm_room_returns_201() {
+    let (td, port) = TestDaemon::start_with_ws_configs(vec![("seed-dm", None)]).await;
+    let base = format!("http://127.0.0.1:{port}");
+    let client = reqwest::Client::new();
+
+    // Use a separate creator user to get the auth token from the seed room.
+    let token = rest_join(&client, &base, "seed-dm", "dm_creator").await;
+
+    let resp = client
+        .post(format!("{base}/api/rooms"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!({"room_id": "dm-alice-bob-rest", "visibility": "dm", "invite": ["alice_dm_u", "bob_dm_u"]}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["type"], "room_created");
+
+    // bob_dm_u (in invite list) can join the DM room.
+    let tok2 = rest_join(&client, &base, "dm-alice-bob-rest", "bob_dm_u").await;
+    assert!(!tok2.is_empty());
+    drop(td);
+}
+
+#[tokio::test]
+async fn rest_create_dm_room_wrong_invite_count_returns_400() {
+    let (td, port) = TestDaemon::start_with_ws_configs(vec![("seed-dm2", None)]).await;
+    let base = format!("http://127.0.0.1:{port}");
+    let client = reqwest::Client::new();
+
+    let token = rest_join(&client, &base, "seed-dm2", "alice_dm2").await;
+
+    let resp = client
+        .post(format!("{base}/api/rooms"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(
+            &serde_json::json!({"room_id": "dm-bad", "visibility": "dm", "invite": ["alice_dm2"]}),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["code"], "invalid_config");
+    drop(td);
+}


### PR DESCRIPTION
## Summary

- Adds `POST /api/rooms` endpoint to the daemon REST API for dynamic room creation
- Extracts shared `create_room_entry()` function, eliminating duplicated `RoomState` construction across `create_room()`, `create_room_with_config()`, and `handle_create()` (UDS path)
- Adds `config: DaemonConfig` and `system_token_map: TokenMap` to `DaemonWsState` so the handler can create rooms using the same path configuration as the UDS handler

## Endpoint

```
POST /api/rooms
Authorization: Bearer <token>
Content-Type: application/json

{"room_id": "myroom", "visibility": "public", "invite": []}
```

- `visibility`: `"public"` (default) | `"private"` | `"dm"` (requires exactly 2 users in `invite`)
- `invite`: optional list of usernames
- Requires a valid Bearer token (any authenticated user can create rooms)
- Returns `201` on success, `409` if room already exists, `400` for invalid ID or bad config

## Files changed

- `crates/room-cli/src/broker/daemon.rs` — new `create_room_entry()` shared fn; `create_room()`, `create_room_with_config()`, `handle_create()` delegate to it; `DaemonWsState` construction includes config + system_token_map
- `crates/room-cli/src/broker/ws.rs` — `DaemonWsState` gains `config` + `system_token_map` fields; `POST /api/rooms` route + `daemon_api_create_room` handler + `CreateRoomRequest` struct
- `crates/room-cli/tests/integration.rs` — 8 new integration tests

## Test plan

- [x] `rest_create_room_without_token_returns_401`
- [x] `rest_create_room_with_invalid_token_returns_401`
- [x] `rest_create_room_returns_201` — room created and accessible via join
- [x] `rest_create_room_duplicate_returns_409`
- [x] `rest_create_room_invalid_id_returns_400`
- [x] `rest_create_room_with_private_visibility` — private room, invited user can join
- [x] `rest_create_dm_room_returns_201` — DM room created, participant can join
- [x] `rest_create_dm_room_wrong_invite_count_returns_400`

Closes #291
