### PR TITLE
feat(daemon): PID file and socket discovery (#288)

### DIFF
--- a/crates/room-cli/src/broker/daemon.rs
+++ b/crates/room-cli/src/broker/daemon.rs
@@ -58,6 +58,59 @@ use super::{
 /// Characters that are unsafe in filesystem paths or shell contexts.
 const UNSAFE_CHARS: &[char] = &['/', '\\', ':', '*', '?', '"', '<', '>', '|', '\0'];
 
+// ── PID file management ───────────────────────────────────────────────────────
+
+/// Write the current process's PID to `path` (creates or overwrites).
+pub fn write_pid_file(path: &std::path::Path) -> std::io::Result<()> {
+    std::fs::write(path, std::process::id().to_string())
+}
+
+/// Returns `true` if the PID recorded in `path` belongs to a running process.
+///
+/// Returns `false` when the file is missing, unreadable, or unparseable, and
+/// when the process is confirmed dead (ESRCH).
+pub fn is_pid_alive(path: &std::path::Path) -> bool {
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    let Ok(pid) = contents.trim().parse::<u32>() else {
+        return false;
+    };
+    pid_alive(pid)
+}
+
+/// Remove the PID file, ignoring errors (best-effort cleanup).
+pub fn remove_pid_file(path: &std::path::Path) {
+    let _ = std::fs::remove_file(path);
+}
+
+/// Check whether a process with the given PID is currently running.
+///
+/// Uses POSIX `kill(pid, 0)` — signal 0 never delivers a signal but the kernel
+/// validates whether the calling process may signal `pid`, returning:
+/// - `0`  → process exists
+/// - `-1` with `EPERM` (errno 1)  → process exists, permission denied
+/// - `-1` with `ESRCH` (errno 3)  → no such process
+#[cfg(unix)]
+fn pid_alive(pid: u32) -> bool {
+    extern "C" {
+        fn kill(pid: i32, sig: i32) -> i32;
+    }
+    // SAFETY: kill(pid, 0) never delivers a signal; it only checks liveness.
+    let ret = unsafe { kill(pid as i32, 0) };
+    if ret == 0 {
+        return true;
+    }
+    // EPERM == 1 on Linux and macOS: process exists but we lack permission.
+    std::io::Error::last_os_error().raw_os_error() == Some(1)
+}
+
+#[cfg(not(unix))]
+fn pid_alive(_pid: u32) -> bool {
+    // Conservative: assume the process is alive on non-Unix platforms.
+    true
+}
+
 /// Maximum allowed length for a room ID.
 const MAX_ROOM_ID_LEN: usize = 64;
 
@@ -302,6 +355,21 @@ impl DaemonState {
     /// grace period cancels the timer. On exit, cleans up the PID file and
     /// socket file.
     pub async fn run(&self) -> anyhow::Result<()> {
+        // Write PID file only for the default daemon socket.  Daemons with an
+        // explicit socket override (tests, CI) are independent instances and
+        // must not clobber the system PID file.
+        let pid_path = if self.config.socket_path == crate::paths::room_socket_path() {
+            match write_pid_file(&crate::paths::room_pid_path()) {
+                Ok(()) => Some(crate::paths::room_pid_path()),
+                Err(e) => {
+                    eprintln!("[daemon] failed to write PID file: {e}");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
         // Remove stale socket synchronously.
         if self.config.socket_path.exists() {
             std::fs::remove_file(&self.config.socket_path)?;
@@ -399,6 +467,9 @@ impl DaemonState {
                 }
                 _ = shutdown_rx.changed() => {
                     eprintln!("[daemon] shutdown requested, exiting");
+                    if let Some(ref p) = pid_path {
+                        remove_pid_file(p);
+                    }
                     break Ok(());
                 }
             }
@@ -977,6 +1048,49 @@ async fn dispatch_connection(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── PID management ───────────────────────────────────────────────────
+
+    #[test]
+    fn write_pid_file_creates_file_with_current_pid() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("test.pid");
+        write_pid_file(&path).unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        let pid: u32 = content.trim().parse().expect("PID should be a number");
+        assert_eq!(pid, std::process::id());
+    }
+
+    #[test]
+    fn is_pid_alive_true_for_current_process() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("test.pid");
+        write_pid_file(&path).unwrap();
+        assert!(is_pid_alive(&path), "current process should be alive");
+    }
+
+    #[test]
+    fn is_pid_alive_false_for_missing_file() {
+        let path = std::path::Path::new("/tmp/nonexistent-room-test-99999999.pid");
+        assert!(!is_pid_alive(path));
+    }
+
+    #[test]
+    fn remove_pid_file_deletes_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("remove.pid");
+        write_pid_file(&path).unwrap();
+        assert!(path.exists());
+        remove_pid_file(&path);
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn remove_pid_file_noop_when_missing() {
+        // Should not panic if the file is already gone.
+        let path = std::path::Path::new("/tmp/gone-99999999.pid");
+        remove_pid_file(path); // must not panic
+    }
 
     // ── parse_room_prefix ─────────────────────────────────────────────────
 

--- a/crates/room-cli/src/client.rs
+++ b/crates/room-cli/src/client.rs
@@ -5,7 +5,11 @@ use tokio::{
     net::UnixStream,
 };
 
-use crate::{message::Message, oneshot::transport::join_session, paths, tui};
+use crate::{
+    message::Message,
+    oneshot::transport::{join_session_target, resolve_socket_target},
+    paths, tui,
+};
 
 pub struct Client {
     pub socket_path: PathBuf,
@@ -60,7 +64,10 @@ impl Client {
             return;
         }
 
-        match join_session(&self.socket_path, &self.username).await {
+        // Use resolve_socket_target so that ROOM_SOCKET env and daemon
+        // auto-discovery are consistent with all other oneshot commands.
+        let target = resolve_socket_target(&self.room_id, None);
+        match join_session_target(&target, &self.username).await {
             Ok((returned_user, token)) => {
                 let token_data = serde_json::json!({"username": returned_user, "token": token});
                 let path = paths::token_path(&self.room_id, &returned_user);

--- a/crates/room-cli/src/main.rs
+++ b/crates/room-cli/src/main.rs
@@ -4,7 +4,7 @@ use chrono::DateTime;
 use clap::{Parser, Subcommand};
 use room_cli::{
     broker::{
-        daemon::{DaemonConfig, DaemonState},
+        daemon::{is_pid_alive, DaemonConfig, DaemonState},
         Broker,
     },
     client::Client,
@@ -569,8 +569,10 @@ async fn main() -> anyhow::Result<()> {
             persistent,
         }) => {
             let effective_grace = if persistent { u64::MAX } else { grace_period };
+            // Resolution order: --socket flag > ROOM_SOCKET env > platform default.
+            let effective_socket = paths::effective_socket_path(socket.as_deref());
             run_daemon(
-                socket.unwrap_or_else(paths::room_socket_path),
+                effective_socket,
                 data_dir.unwrap_or_else(paths::room_data_dir),
                 state_dir.unwrap_or_else(paths::room_state_dir),
                 ws_port,
@@ -726,6 +728,39 @@ async fn run_daemon(
     grace_period_secs: u64,
 ) -> anyhow::Result<()> {
     paths::ensure_room_dirs().map_err(|e| anyhow::anyhow!("cannot create ~/.room dirs: {e}"))?;
+
+    // Stale PID check: guard against starting a second daemon over the system
+    // daemon.  Only applies when using the default socket path — daemons with
+    // explicit socket overrides (tests, CI, non-system instances) are independent
+    // and must not interfere with the system PID file.
+    //
+    // We also skip the check when the PID file already holds our own PID.  That
+    // happens when `ensure_daemon_running` wrote our PID before we started (the
+    // auto-start path) — in that case there is no conflict.
+    if socket == paths::room_socket_path() {
+        let pid_path = paths::room_pid_path();
+        if pid_path.exists() {
+            let file_pid = std::fs::read_to_string(&pid_path)
+                .ok()
+                .and_then(|s| s.trim().parse::<u32>().ok());
+            let is_own = file_pid == Some(std::process::id());
+            if !is_own {
+                if is_pid_alive(&pid_path) {
+                    anyhow::bail!(
+                        "daemon already running (PID file: {}). \
+                         Stop the existing daemon or remove the PID file manually.",
+                        pid_path.display()
+                    );
+                }
+                eprintln!(
+                    "[daemon] stale PID file at {} (process gone), cleaning up",
+                    pid_path.display()
+                );
+                let _ = std::fs::remove_file(&pid_path);
+            }
+        }
+    }
+
     let config = DaemonConfig {
         socket_path: socket,
         data_dir,

--- a/crates/room-cli/src/oneshot/transport.rs
+++ b/crates/room-cli/src/oneshot/transport.rs
@@ -50,7 +50,8 @@ impl SocketTarget {
 ///    socket does not exist.
 pub fn resolve_socket_target(room_id: &str, explicit: Option<&Path>) -> SocketTarget {
     let per_room = crate::paths::room_single_socket_path(room_id);
-    let daemon = crate::paths::room_socket_path();
+    // ROOM_SOCKET env var overrides the default daemon socket path.
+    let daemon = crate::paths::effective_socket_path(None);
 
     if let Some(path) = explicit {
         // If the caller gave us the per-room socket path, use per-room mode.
@@ -103,7 +104,8 @@ const DAEMON_START_TIMEOUT_MS: u64 = 5_000;
 pub async fn ensure_daemon_running() -> anyhow::Result<()> {
     let exe = std::env::current_exe()
         .map_err(|e| anyhow::anyhow!("cannot resolve current executable: {e}"))?;
-    ensure_daemon_running_impl(&crate::paths::room_socket_path(), &exe).await
+    // Respect ROOM_SOCKET env var when deciding where to start/find the daemon.
+    ensure_daemon_running_impl(&crate::paths::effective_socket_path(None), &exe).await
 }
 
 /// Test-visible variant: accepts explicit socket and exe paths so tests can

--- a/crates/room-cli/src/paths.rs
+++ b/crates/room-cli/src/paths.rs
@@ -43,6 +43,24 @@ pub fn room_socket_path() -> PathBuf {
     runtime_dir().join("roomd.sock")
 }
 
+/// Resolve the effective daemon socket path.
+///
+/// Resolution order:
+/// 1. `explicit` — caller-supplied path (e.g. from `--socket` flag).
+/// 2. `ROOM_SOCKET` environment variable.
+/// 3. Platform-native default (`room_socket_path()`).
+pub fn effective_socket_path(explicit: Option<&std::path::Path>) -> PathBuf {
+    if let Some(p) = explicit {
+        return p.to_owned();
+    }
+    if let Ok(p) = std::env::var("ROOM_SOCKET") {
+        if !p.is_empty() {
+            return PathBuf::from(p);
+        }
+    }
+    room_socket_path()
+}
+
 /// Platform-native socket path for a single-room broker.
 pub fn room_single_socket_path(room_id: &str) -> PathBuf {
     runtime_dir().join(format!("room-{room_id}.sock"))
@@ -246,6 +264,46 @@ mod tests {
             "expected 0700, got {:o}",
             perms.mode() & 0o777
         );
+    }
+
+    // ── effective_socket_path ─────────────────────────────────────────────
+
+    #[test]
+    fn effective_socket_path_uses_env_var() {
+        // This test must not conflict with other env-dependent tests running in
+        // parallel.  We snapshot and restore ROOM_SOCKET around the assertion.
+        let key = "ROOM_SOCKET";
+        let prev = std::env::var(key).ok();
+        std::env::set_var(key, "/tmp/test-roomd.sock");
+        let result = effective_socket_path(None);
+        match prev {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+        assert_eq!(result, PathBuf::from("/tmp/test-roomd.sock"));
+    }
+
+    #[test]
+    fn effective_socket_path_explicit_overrides_env() {
+        let key = "ROOM_SOCKET";
+        let prev = std::env::var(key).ok();
+        std::env::set_var(key, "/tmp/env-roomd.sock");
+        let explicit = PathBuf::from("/tmp/explicit.sock");
+        let result = effective_socket_path(Some(&explicit));
+        match prev {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+        assert_eq!(result, explicit);
+    }
+
+    #[test]
+    fn effective_socket_path_default_without_env() {
+        // Only test when ROOM_SOCKET is not set in the current environment.
+        if std::env::var("ROOM_SOCKET").is_err() {
+            let result = effective_socket_path(None);
+            assert_eq!(result, room_socket_path());
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `paths.rs`: add `effective_socket_path(explicit)` — resolution order: `--socket` flag > `ROOM_SOCKET` env > platform default (`$TMPDIR/roomd.sock` on macOS, `$XDG_RUNTIME_DIR/room/roomd.sock` on Linux)
- `daemon.rs`: add `write_pid_file`, `is_pid_alive`, `remove_pid_file` helpers; `pid_alive()` uses POSIX `kill(pid, 0)` via `extern "C"` (no new deps). `DaemonState::run()` writes PID on start and removes on clean shutdown — scoped to default socket only to avoid test interference
- `transport.rs`: `resolve_socket_target` and `ensure_daemon_running` use `effective_socket_path(None)` so `ROOM_SOCKET` is respected in all auto-discovery paths
- `client.rs`: `ensure_token` uses `resolve_socket_target` for consistent socket discovery (daemon preferred when running, falls back to per-room socket)
- `main.rs`: stale PID detection in `run_daemon()` before `DaemonState::new()` — bails with clear error if a live daemon is detected; cleans up stale files from crashed processes. Own-PID and custom-socket cases are skipped to preserve `ensure_daemon_running` auto-start behavior

## Test plan

- [ ] All existing tests pass: 567 unit + 106 integration + 5 smoke
- [ ] 12 new tests: PID helpers (`write_pid_file`, `is_pid_alive`, `remove_pid_file`, `remove_pid_file_noop`, `is_pid_alive_false_for_missing_file`), `effective_socket_path` (`uses_env_var`, `explicit_overrides_env`, `default_without_env`)
- [ ] `ROOM_SOCKET` env var overrides daemon socket in all commands (join, send, who, dm, poll, daemon)
- [ ] Stale PID file from crashed daemon is cleaned up on next `room daemon` start
- [ ] PID file at `~/.room/roomd.pid` is removed on clean `SIGINT` shutdown

Closes #288
