### PR TITLE
refactor(broker): extract handshake parser to broker/handshake.rs (#351)

### DIFF
--- a/crates/room-cli/src/broker/daemon.rs
+++ b/crates/room-cli/src/broker/daemon.rs
@@ -694,21 +694,6 @@ pub(crate) async fn create_room_entry(
     Ok(())
 }
 
-/// Parse the `ROOM:<room_id>:` prefix from a handshake line.
-///
-/// Returns `(room_id, rest)` on success. `rest` is the remainder after the
-/// second colon (e.g. `JOIN:alice`, `TOKEN:uuid`, `SEND:bob`, or `username`).
-pub(crate) fn parse_room_prefix(line: &str) -> Option<(&str, &str)> {
-    let stripped = line.strip_prefix("ROOM:")?;
-    let colon = stripped.find(':')?;
-    let room_id = &stripped[..colon];
-    let rest = &stripped[colon + 1..];
-    if room_id.is_empty() {
-        return None;
-    }
-    Some((room_id, rest))
-}
-
 /// Handle a `DESTROY:<room_id>` request: remove the room from the daemon.
 ///
 /// Protocol:
@@ -928,28 +913,26 @@ async fn dispatch_connection(
         return Ok(());
     }
 
-    // Handle DESTROY:<room_id> — daemon-level room destruction.
-    if let Some(room_id) = first_line.strip_prefix("DESTROY:") {
-        return handle_destroy(room_id, &mut write_half, rooms).await;
-    }
-
-    // Handle CREATE:<room_id> — daemon-level room creation.
-    if let Some(room_id) = first_line.strip_prefix("CREATE:") {
-        return handle_create(
-            room_id,
-            &mut reader,
-            &mut write_half,
-            rooms,
-            daemon_config,
-            system_token_map,
-        )
-        .await;
-    }
-
-    // Parse ROOM:<room_id>:<rest>
-    let (room_id, rest) = match parse_room_prefix(first_line) {
-        Some(pair) => pair,
-        None => {
+    use super::handshake::{
+        parse_client_handshake, parse_daemon_prefix, ClientHandshake, DaemonPrefix,
+    };
+    let (room_id, rest) = match parse_daemon_prefix(first_line) {
+        DaemonPrefix::Destroy(room_id) => {
+            return handle_destroy(&room_id, &mut write_half, rooms).await;
+        }
+        DaemonPrefix::Create(room_id) => {
+            return handle_create(
+                &room_id,
+                &mut reader,
+                &mut write_half,
+                rooms,
+                daemon_config,
+                system_token_map,
+            )
+            .await;
+        }
+        DaemonPrefix::Room { room_id, rest } => (room_id, rest),
+        DaemonPrefix::Unknown => {
             let err = serde_json::json!({
                 "type": "error",
                 "code": "missing_room_prefix",
@@ -963,7 +946,7 @@ async fn dispatch_connection(
     // Look up the room.
     let state = {
         let map = rooms.lock().await;
-        map.get(room_id).cloned()
+        map.get(room_id.as_str()).cloned()
     };
 
     let state = match state {
@@ -981,43 +964,43 @@ async fn dispatch_connection(
 
     let cid = next_client_id.fetch_add(1, Ordering::SeqCst) + 1;
 
-    // Dispatch based on the handshake after the ROOM: prefix.
-    if let Some(send_user) = rest.strip_prefix("SEND:") {
-        return handle_oneshot_send(send_user.to_owned(), reader, write_half, &state).await;
-    }
+    // Dispatch based on the per-room handshake after the ROOM: prefix.
+    let username = match parse_client_handshake(&rest) {
+        ClientHandshake::Send(u) => {
+            return handle_oneshot_send(u, reader, write_half, &state).await;
+        }
+        ClientHandshake::Token(token) => {
+            return match super::auth::validate_token(&token, &state.token_map).await {
+                Some(u) => handle_oneshot_send(u, reader, write_half, &state).await,
+                None => {
+                    let err = serde_json::json!({"type":"error","code":"invalid_token"});
+                    write_half
+                        .write_all(format!("{err}\n").as_bytes())
+                        .await
+                        .map_err(Into::into)
+                }
+            };
+        }
+        ClientHandshake::Join(u) => {
+            return super::auth::handle_oneshot_join_with_registry(
+                u,
+                write_half,
+                user_registry,
+                &state.token_map,
+                state.config.as_ref(),
+            )
+            .await;
+        }
+        ClientHandshake::Interactive(u) => u,
+    };
 
-    if let Some(token) = rest.strip_prefix("TOKEN:") {
-        return match super::auth::validate_token(token, &state.token_map).await {
-            Some(u) => handle_oneshot_send(u, reader, write_half, &state).await,
-            None => {
-                let err = serde_json::json!({"type":"error","code":"invalid_token"});
-                write_half
-                    .write_all(format!("{err}\n").as_bytes())
-                    .await
-                    .map_err(Into::into)
-            }
-        };
-    }
-
-    if let Some(join_user) = rest.strip_prefix("JOIN:") {
-        return super::auth::handle_oneshot_join_with_registry(
-            join_user.to_owned(),
-            write_half,
-            user_registry,
-            &state.token_map,
-            state.config.as_ref(),
-        )
-        .await;
-    }
-
-    // Interactive join: rest is the username.
-    let username = rest;
+    // Interactive join.
     if username.is_empty() {
         return Ok(());
     }
 
     // Check join permission before entering interactive session.
-    if let Err(reason) = super::auth::check_join_permission(username, state.config.as_ref()) {
+    if let Err(reason) = super::auth::check_join_permission(&username, state.config.as_ref()) {
         let err = serde_json::json!({
             "type": "error",
             "code": "join_denied",
@@ -1037,7 +1020,7 @@ async fn dispatch_connection(
         .insert(cid, (String::new(), tx.clone()));
 
     let result =
-        super::run_interactive_session(cid, username, reader, write_half, tx, &state).await;
+        super::run_interactive_session(cid, &username, reader, write_half, tx, &state).await;
 
     state.clients.lock().await.remove(&cid);
     result
@@ -1090,63 +1073,6 @@ mod tests {
         // Should not panic if the file is already gone.
         let path = std::path::Path::new("/tmp/gone-99999999.pid");
         remove_pid_file(path); // must not panic
-    }
-
-    // ── parse_room_prefix ─────────────────────────────────────────────────
-
-    #[test]
-    fn parse_room_prefix_join() {
-        let (room, rest) = parse_room_prefix("ROOM:myroom:JOIN:alice").unwrap();
-        assert_eq!(room, "myroom");
-        assert_eq!(rest, "JOIN:alice");
-    }
-
-    #[test]
-    fn parse_room_prefix_token() {
-        let (room, rest) = parse_room_prefix("ROOM:myroom:TOKEN:abc-123").unwrap();
-        assert_eq!(room, "myroom");
-        assert_eq!(rest, "TOKEN:abc-123");
-    }
-
-    #[test]
-    fn parse_room_prefix_send() {
-        let (room, rest) = parse_room_prefix("ROOM:myroom:SEND:bob").unwrap();
-        assert_eq!(room, "myroom");
-        assert_eq!(rest, "SEND:bob");
-    }
-
-    #[test]
-    fn parse_room_prefix_interactive() {
-        let (room, rest) = parse_room_prefix("ROOM:chat:alice").unwrap();
-        assert_eq!(room, "chat");
-        assert_eq!(rest, "alice");
-    }
-
-    #[test]
-    fn parse_room_prefix_room_id_with_hyphens() {
-        let (room, rest) = parse_room_prefix("ROOM:agent-room-2:JOIN:r2d2").unwrap();
-        assert_eq!(room, "agent-room-2");
-        assert_eq!(rest, "JOIN:r2d2");
-    }
-
-    #[test]
-    fn parse_room_prefix_missing_prefix() {
-        assert!(parse_room_prefix("JOIN:alice").is_none());
-        assert!(parse_room_prefix("alice").is_none());
-        assert!(parse_room_prefix("TOKEN:abc").is_none());
-    }
-
-    #[test]
-    fn parse_room_prefix_empty_room_id() {
-        assert!(parse_room_prefix("ROOM::JOIN:alice").is_none());
-    }
-
-    #[test]
-    fn parse_room_prefix_no_rest() {
-        // "ROOM:myroom:" — rest is empty string, valid (treated as empty username)
-        let (room, rest) = parse_room_prefix("ROOM:myroom:").unwrap();
-        assert_eq!(room, "myroom");
-        assert_eq!(rest, "");
     }
 
     // ── DaemonState lifecycle ─────────────────────────────────────────────

--- a/crates/room-cli/src/broker/handshake.rs
+++ b/crates/room-cli/src/broker/handshake.rs
@@ -1,0 +1,262 @@
+//! Handshake protocol parsing for UDS and WebSocket connections.
+//!
+//! The room wire protocol uses a text-based handshake as the first
+//! line (UDS) or first frame (WebSocket) of every connection. This module
+//! provides typed parsers for both protocol layers:
+//!
+//! ## Per-room client handshake
+//!
+//! The first line after a room is established can be:
+//!
+//! | Prefix | Variant | Meaning |
+//! |---|---|---|
+//! | `SEND:<username>` | [`ClientHandshake::Send`] | Legacy unauthenticated one-shot send |
+//! | `TOKEN:<uuid>` | [`ClientHandshake::Token`] | Token-authenticated one-shot send |
+//! | `JOIN:<username>` | [`ClientHandshake::Join`] | Register username, receive session token |
+//! | `<username>` | [`ClientHandshake::Interactive`] | Full interactive join |
+//!
+//! ## Daemon-level prefix
+//!
+//! The first line of a connection to the multi-room daemon is:
+//!
+//! | Prefix | Variant | Meaning |
+//! |---|---|---|
+//! | `CREATE:<room_id>` | [`DaemonPrefix::Create`] | Create a new room |
+//! | `DESTROY:<room_id>` | [`DaemonPrefix::Destroy`] | Destroy an existing room |
+//! | `ROOM:<room_id>:<rest>` | [`DaemonPrefix::Room`] | Route to an existing room |
+//! | anything else | [`DaemonPrefix::Unknown`] | Rejected with an error response |
+
+/// Typed result of parsing the first line of a per-room connection.
+#[derive(Debug, PartialEq)]
+pub(crate) enum ClientHandshake {
+    /// `SEND:<username>` — legacy unauthenticated one-shot send.
+    Send(String),
+    /// `TOKEN:<uuid>` — token-authenticated one-shot send.
+    Token(String),
+    /// `JOIN:<username>` — register username, receive a session token.
+    Join(String),
+    /// `<username>` — full interactive session.
+    Interactive(String),
+}
+
+/// Parse the first line of a per-room connection into a typed handshake.
+///
+/// Recognition order: `SEND:` → `TOKEN:` → `JOIN:` → Interactive.
+/// Whitespace has already been trimmed by the caller.
+pub(crate) fn parse_client_handshake(line: &str) -> ClientHandshake {
+    if let Some(u) = line.strip_prefix("SEND:") {
+        return ClientHandshake::Send(u.to_owned());
+    }
+    if let Some(t) = line.strip_prefix("TOKEN:") {
+        return ClientHandshake::Token(t.to_owned());
+    }
+    if let Some(u) = line.strip_prefix("JOIN:") {
+        return ClientHandshake::Join(u.to_owned());
+    }
+    ClientHandshake::Interactive(line.to_owned())
+}
+
+/// Typed result of parsing the first line of a daemon connection.
+#[derive(Debug, PartialEq)]
+pub(crate) enum DaemonPrefix {
+    /// `CREATE:<room_id>` — create a new room (config follows on the next line).
+    Create(String),
+    /// `DESTROY:<room_id>` — destroy an existing room.
+    Destroy(String),
+    /// `ROOM:<room_id>:<rest>` — route to an existing room.
+    ///
+    /// `rest` is everything after the second colon: `JOIN:alice`, `TOKEN:uuid`,
+    /// `SEND:bob`, or a plain username for an interactive join.
+    Room { room_id: String, rest: String },
+    /// Unrecognised prefix — the connection should be rejected with an error.
+    Unknown,
+}
+
+/// Parse the first line of a daemon connection into a typed prefix.
+///
+/// Recognition order: `DESTROY:` → `CREATE:` → `ROOM:` → Unknown.
+/// Whitespace has already been trimmed by the caller.
+pub(crate) fn parse_daemon_prefix(line: &str) -> DaemonPrefix {
+    if let Some(room_id) = line.strip_prefix("DESTROY:") {
+        return DaemonPrefix::Destroy(room_id.to_owned());
+    }
+    if let Some(room_id) = line.strip_prefix("CREATE:") {
+        return DaemonPrefix::Create(room_id.to_owned());
+    }
+    if let Some(stripped) = line.strip_prefix("ROOM:") {
+        if let Some(colon) = stripped.find(':') {
+            let room_id = &stripped[..colon];
+            if !room_id.is_empty() {
+                let rest = stripped[colon + 1..].to_owned();
+                return DaemonPrefix::Room {
+                    room_id: room_id.to_owned(),
+                    rest,
+                };
+            }
+        }
+    }
+    DaemonPrefix::Unknown
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── parse_client_handshake ────────────────────────────────────────────
+
+    #[test]
+    fn client_send_prefix() {
+        assert_eq!(
+            parse_client_handshake("SEND:alice"),
+            ClientHandshake::Send("alice".into())
+        );
+    }
+
+    #[test]
+    fn client_token_prefix() {
+        assert_eq!(
+            parse_client_handshake("TOKEN:abc-123"),
+            ClientHandshake::Token("abc-123".into())
+        );
+    }
+
+    #[test]
+    fn client_join_prefix() {
+        assert_eq!(
+            parse_client_handshake("JOIN:bob"),
+            ClientHandshake::Join("bob".into())
+        );
+    }
+
+    #[test]
+    fn client_interactive_plain_username() {
+        assert_eq!(
+            parse_client_handshake("alice"),
+            ClientHandshake::Interactive("alice".into())
+        );
+    }
+
+    #[test]
+    fn client_interactive_empty_string() {
+        assert_eq!(
+            parse_client_handshake(""),
+            ClientHandshake::Interactive("".into())
+        );
+    }
+
+    #[test]
+    fn client_send_empty_username() {
+        assert_eq!(
+            parse_client_handshake("SEND:"),
+            ClientHandshake::Send("".into())
+        );
+    }
+
+    // ── parse_daemon_prefix ───────────────────────────────────────────────
+
+    #[test]
+    fn daemon_create_prefix() {
+        assert_eq!(
+            parse_daemon_prefix("CREATE:newroom"),
+            DaemonPrefix::Create("newroom".into())
+        );
+    }
+
+    #[test]
+    fn daemon_destroy_prefix() {
+        assert_eq!(
+            parse_daemon_prefix("DESTROY:myroom"),
+            DaemonPrefix::Destroy("myroom".into())
+        );
+    }
+
+    #[test]
+    fn daemon_room_join() {
+        assert_eq!(
+            parse_daemon_prefix("ROOM:myroom:JOIN:alice"),
+            DaemonPrefix::Room {
+                room_id: "myroom".into(),
+                rest: "JOIN:alice".into()
+            }
+        );
+    }
+
+    #[test]
+    fn daemon_room_token() {
+        assert_eq!(
+            parse_daemon_prefix("ROOM:myroom:TOKEN:abc-123"),
+            DaemonPrefix::Room {
+                room_id: "myroom".into(),
+                rest: "TOKEN:abc-123".into()
+            }
+        );
+    }
+
+    #[test]
+    fn daemon_room_send() {
+        assert_eq!(
+            parse_daemon_prefix("ROOM:myroom:SEND:bob"),
+            DaemonPrefix::Room {
+                room_id: "myroom".into(),
+                rest: "SEND:bob".into()
+            }
+        );
+    }
+
+    #[test]
+    fn daemon_room_interactive() {
+        assert_eq!(
+            parse_daemon_prefix("ROOM:chat:alice"),
+            DaemonPrefix::Room {
+                room_id: "chat".into(),
+                rest: "alice".into()
+            }
+        );
+    }
+
+    #[test]
+    fn daemon_room_id_with_hyphens() {
+        assert_eq!(
+            parse_daemon_prefix("ROOM:agent-room-2:JOIN:r2d2"),
+            DaemonPrefix::Room {
+                room_id: "agent-room-2".into(),
+                rest: "JOIN:r2d2".into()
+            }
+        );
+    }
+
+    #[test]
+    fn daemon_room_empty_rest() {
+        assert_eq!(
+            parse_daemon_prefix("ROOM:myroom:"),
+            DaemonPrefix::Room {
+                room_id: "myroom".into(),
+                rest: "".into()
+            }
+        );
+    }
+
+    #[test]
+    fn daemon_unknown_plain_join() {
+        assert_eq!(parse_daemon_prefix("JOIN:alice"), DaemonPrefix::Unknown);
+    }
+
+    #[test]
+    fn daemon_unknown_plain_username() {
+        assert_eq!(parse_daemon_prefix("alice"), DaemonPrefix::Unknown);
+    }
+
+    #[test]
+    fn daemon_unknown_token_without_room() {
+        assert_eq!(parse_daemon_prefix("TOKEN:abc"), DaemonPrefix::Unknown);
+    }
+
+    #[test]
+    fn daemon_room_empty_room_id_is_unknown() {
+        // "ROOM::JOIN:alice" — room_id is empty string, should be Unknown.
+        assert_eq!(
+            parse_daemon_prefix("ROOM::JOIN:alice"),
+            DaemonPrefix::Unknown
+        );
+    }
+}

--- a/crates/room-cli/src/broker/mod.rs
+++ b/crates/room-cli/src/broker/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod auth;
 pub(crate) mod commands;
 pub mod daemon;
 pub(crate) mod fanout;
+pub(crate) mod handshake;
 pub(crate) mod state;
 pub(crate) mod ws;
 
@@ -173,44 +174,42 @@ async fn handle_client(
     let (read_half, mut write_half) = stream.into_split();
     let mut reader = BufReader::new(read_half);
 
-    // First line: username handshake, or one of the one-shot prefixes:
-    //   SEND:<username>  — legacy one-shot send
-    //   TOKEN:<uuid>     — token-authenticated one-shot send
-    //   JOIN:<username>  — register username, receive a session token
+    // First line: username handshake, or one of the one-shot prefixes.
     let mut first = String::new();
     reader.read_line(&mut first).await?;
     let first_line = first.trim();
 
-    if let Some(send_user) = first_line.strip_prefix("SEND:") {
-        return handle_oneshot_send(send_user.to_owned(), reader, write_half, state).await;
-    }
+    use handshake::{parse_client_handshake, ClientHandshake};
+    let username = match parse_client_handshake(first_line) {
+        ClientHandshake::Send(u) => {
+            return handle_oneshot_send(u, reader, write_half, state).await;
+        }
+        ClientHandshake::Token(token) => {
+            return match validate_token(&token, &token_map).await {
+                Some(u) => handle_oneshot_send(u, reader, write_half, state).await,
+                None => {
+                    let err = serde_json::json!({"type":"error","code":"invalid_token"});
+                    write_half
+                        .write_all(format!("{err}\n").as_bytes())
+                        .await
+                        .map_err(Into::into)
+                }
+            };
+        }
+        ClientHandshake::Join(u) => {
+            return handle_oneshot_join(
+                u,
+                write_half,
+                &token_map,
+                state.config.as_ref(),
+                Some(&state.token_map_path),
+            )
+            .await;
+        }
+        ClientHandshake::Interactive(u) => u,
+    };
 
-    if let Some(token) = first_line.strip_prefix("TOKEN:") {
-        return match validate_token(token, &token_map).await {
-            Some(u) => handle_oneshot_send(u, reader, write_half, state).await,
-            None => {
-                let err = serde_json::json!({"type":"error","code":"invalid_token"});
-                write_half
-                    .write_all(format!("{err}\n").as_bytes())
-                    .await
-                    .map_err(Into::into)
-            }
-        };
-    }
-
-    if let Some(join_user) = first_line.strip_prefix("JOIN:") {
-        return handle_oneshot_join(
-            join_user.to_owned(),
-            write_half,
-            &token_map,
-            state.config.as_ref(),
-            Some(&state.token_map_path),
-        )
-        .await;
-    }
-
-    // Remaining path: full interactive join — first_line is the username.
-    let username = first_line.to_owned();
+    // Remaining path: full interactive join.
     if username.is_empty() {
         return Ok(());
     }

--- a/crates/room-cli/src/broker/ws.rs
+++ b/crates/room-cli/src/broker/ws.rs
@@ -100,30 +100,28 @@ async fn run_ws_session(
         Some(Err(e)) => return Err(e.into()),
     };
 
-    // One-shot: JOIN — register username, return token, close.
-    if let Some(join_user) = first_frame.strip_prefix("JOIN:") {
-        return ws_oneshot_join(join_user, &mut ws_tx, state).await;
-    }
+    use super::handshake::{parse_client_handshake, ClientHandshake};
+    let username = match parse_client_handshake(&first_frame) {
+        ClientHandshake::Join(u) => {
+            return ws_oneshot_join(&u, &mut ws_tx, state).await;
+        }
+        ClientHandshake::Send(u) => {
+            return ws_oneshot_send(u, &mut ws_rx, &mut ws_tx, state).await;
+        }
+        ClientHandshake::Token(token) => {
+            return match validate_token(&token, &state.token_map).await {
+                Some(u) => ws_oneshot_send(u, &mut ws_rx, &mut ws_tx, state).await,
+                None => {
+                    let err = serde_json::json!({"type":"error","code":"invalid_token"});
+                    let _ = ws_tx.send(WsMessage::Text(err.to_string().into())).await;
+                    Ok(())
+                }
+            };
+        }
+        ClientHandshake::Interactive(u) => u,
+    };
 
-    // One-shot: SEND — legacy unauthenticated send.
-    if let Some(send_user) = first_frame.strip_prefix("SEND:") {
-        return ws_oneshot_send(send_user.to_owned(), &mut ws_rx, &mut ws_tx, state).await;
-    }
-
-    // One-shot: TOKEN — authenticated send.
-    if let Some(token) = first_frame.strip_prefix("TOKEN:") {
-        return match validate_token(token, &state.token_map).await {
-            Some(u) => ws_oneshot_send(u, &mut ws_rx, &mut ws_tx, state).await,
-            None => {
-                let err = serde_json::json!({"type":"error","code":"invalid_token"});
-                let _ = ws_tx.send(WsMessage::Text(err.to_string().into())).await;
-                Ok(())
-            }
-        };
-    }
-
-    // Interactive join — first_frame is the username.
-    let username = first_frame;
+    // Interactive join.
     if username.is_empty() {
         return Ok(());
     }


### PR DESCRIPTION
## Summary

Extract handshake protocol parsing from three duplicated sites into a single `broker/handshake.rs` module. No wire format or protocol changes.

## Changes

**New file: `broker/handshake.rs`**
- `ClientHandshake { Send, Token, Join, Interactive }` — typed result of per-room handshake parsing
- `parse_client_handshake(line) -> ClientHandshake` — recognises `SEND:`, `TOKEN:`, `JOIN:`, or Interactive
- `DaemonPrefix { Create, Destroy, Room { room_id, rest }, Unknown }` — typed result of daemon prefix parsing
- `parse_daemon_prefix(line) -> DaemonPrefix` — recognises `DESTROY:`, `CREATE:`, `ROOM:<id>:`, or Unknown
- 18 unit tests covering all variants and edge cases

**Updated: `broker/mod.rs`**
- `handle_client()`: replaced 3 `if let Some(...) = strip_prefix(...)` blocks with `parse_client_handshake()`

**Updated: `broker/ws.rs`**
- `run_ws_session()`: replaced 3 `if let Some(...) = strip_prefix(...)` blocks with `parse_client_handshake()`

**Updated: `broker/daemon.rs`**
- `dispatch_connection()`: replaced 3 `strip_prefix` calls + `parse_room_prefix()` with `parse_daemon_prefix()`, per-room dispatch with `parse_client_handshake()`
- Removed `parse_room_prefix()` function (superseded by `parse_daemon_prefix`)
- Removed 8 `parse_room_prefix` tests (migrated and expanded to 18 tests in `handshake.rs`)

## Test plan

- 18 tests in `handshake.rs` covering `ClientHandshake` and `DaemonPrefix` variants
- All 599 lib tests pass
- All 127 integration tests pass

Closes #351
