### PR TITLE
refactor(state): RoomState::new() factory and accessor methods (#353, #360)

### DIFF
--- a/crates/room-cli/src/broker/commands.rs
+++ b/crates/room-cli/src/broker/commands.rs
@@ -46,7 +46,7 @@ pub(crate) fn load_subscription_map(path: &Path) -> HashMap<String, Subscription
 /// because the file is tiny (a few KB at most) and consistency matters more
 /// than shaving microseconds.
 pub(crate) async fn persist_subscriptions(state: &RoomState) {
-    let snapshot = state.subscription_map.lock().await.clone();
+    let snapshot = state.subscription_snapshot().await;
     if let Err(e) = save_subscription_map(&snapshot, &state.subscription_map_path) {
         eprintln!("[broker] subscription persist failed: {e}");
     }
@@ -106,11 +106,7 @@ pub(crate) async fn route_command(
 
         if cmd == "set_status" {
             let status = params.first().cloned().unwrap_or_default();
-            state
-                .status_map
-                .lock()
-                .await
-                .insert(username.to_owned(), status.clone());
+            state.set_status(username, status.clone()).await;
             let display = if status.is_empty() {
                 format!("{username} cleared their status")
             } else {
@@ -127,19 +123,12 @@ pub(crate) async fn route_command(
         }
 
         if cmd == "who" {
-            let map = state.status_map.lock().await;
-            let mut entries: Vec<String> = map
-                .iter()
-                .map(|(u, s)| {
-                    if s.is_empty() {
-                        u.clone()
-                    } else {
-                        format!("{u}: {s}")
-                    }
-                })
+            let entries: Vec<String> = state
+                .status_entries()
+                .await
+                .into_iter()
+                .map(|(u, s)| if s.is_empty() { u } else { format!("{u}: {s}") })
                 .collect();
-            entries.sort();
-            drop(map);
             let content = if entries.is_empty() {
                 "no users online".to_owned()
             } else {
@@ -153,11 +142,7 @@ pub(crate) async fn route_command(
         // Task claim commands.
         if cmd == "claim" {
             let task = params.join(" ");
-            state
-                .claim_map
-                .lock()
-                .await
-                .insert(username.to_owned(), task.clone());
+            state.set_claim(username, task.clone()).await;
             let display = format!("{username} claimed: {task}");
             let sys = make_system(&state.room_id, "broker", display);
             broadcast_and_persist(&sys, &state.clients, &state.chat_path, &state.seq_counter)
@@ -167,7 +152,7 @@ pub(crate) async fn route_command(
         }
 
         if cmd == "unclaim" {
-            let removed = state.claim_map.lock().await.remove(username);
+            let removed = state.remove_claim(username).await;
             let display = match removed {
                 Some(task) => format!("{username} released claim: {task}"),
                 None => format!("{username} has no active claim"),
@@ -180,18 +165,14 @@ pub(crate) async fn route_command(
         }
 
         if cmd == "claimed" {
-            let map = state.claim_map.lock().await;
-            let content = if map.is_empty() {
+            let raw = state.claim_entries().await;
+            let content = if raw.is_empty() {
                 "no active claims".to_owned()
             } else {
-                let mut entries: Vec<String> = map
-                    .iter()
-                    .map(|(user, task)| format!("{user}: {task}"))
-                    .collect();
-                entries.sort();
+                let entries: Vec<String> =
+                    raw.into_iter().map(|(u, t)| format!("{u}: {t}")).collect();
                 format!("claimed — {}", entries.join(", "))
             };
-            drop(map);
             let sys = make_system(&state.room_id, "broker", content);
             let json = serde_json::to_string(&sys)?;
             return Ok(CommandResult::Reply(json));
@@ -208,11 +189,7 @@ pub(crate) async fn route_command(
                     return Ok(CommandResult::Reply(json));
                 }
             };
-            state
-                .subscription_map
-                .lock()
-                .await
-                .insert(username.to_owned(), tier);
+            state.set_subscription(username, tier).await;
             persist_subscriptions(state).await;
             let display = format!("{username} subscribed to {} (tier: {tier})", state.room_id);
             let sys = make_system(&state.room_id, "broker", display);
@@ -224,10 +201,8 @@ pub(crate) async fn route_command(
 
         if cmd == "unsubscribe" {
             state
-                .subscription_map
-                .lock()
-                .await
-                .insert(username.to_owned(), SubscriptionTier::Unsubscribed);
+                .set_subscription(username, SubscriptionTier::Unsubscribed)
+                .await;
             persist_subscriptions(state).await;
             let display = format!("{username} unsubscribed from {}", state.room_id);
             let sys = make_system(&state.room_id, "broker", display);
@@ -238,18 +213,14 @@ pub(crate) async fn route_command(
         }
 
         if cmd == "subscriptions" {
-            let map = state.subscription_map.lock().await;
-            let content = if map.is_empty() {
+            let raw = state.subscription_entries().await;
+            let content = if raw.is_empty() {
                 "no subscriptions".to_owned()
             } else {
-                let mut entries: Vec<String> = map
-                    .iter()
-                    .map(|(user, tier)| format!("{user}: {tier}"))
-                    .collect();
-                entries.sort();
+                let entries: Vec<String> =
+                    raw.into_iter().map(|(u, t)| format!("{u}: {t}")).collect();
                 format!("subscriptions — {}", entries.join(", "))
             };
-            drop(map);
             let sys = make_system(&state.room_id, "broker", content);
             let json = serde_json::to_string(&sys)?;
             return Ok(CommandResult::Reply(json));
@@ -465,7 +436,6 @@ pub(crate) async fn handle_admin_cmd(
     let room_id = state.room_id.as_str();
     let clients = &state.clients;
     let token_map = &state.token_map;
-    let status_map = &state.status_map;
     let chat_path = &state.chat_path;
     let shutdown = &state.shutdown;
     let seq_counter = &state.seq_counter;
@@ -487,7 +457,7 @@ pub(crate) async fn handle_admin_cmd(
             map.insert(format!("KICKED:{target}"), target.clone());
             drop(map);
             // Remove from status map immediately so /who no longer shows the kicked user.
-            status_map.lock().await.remove(&target);
+            state.remove_status(&target).await;
             let content = format!("{issuer} kicked {target} (token invalidated)");
             let msg = make_system(room_id, "broker", content);
             let _ = broadcast_and_persist(&msg, clients, chat_path, seq_counter).await;
@@ -562,8 +532,8 @@ pub(crate) async fn handle_admin_cmd(
 
 /// Handle `/room-info` — display room visibility, config, and member count.
 async fn handle_room_info(state: &RoomState) -> String {
-    let member_count = state.status_map.lock().await.len();
-    let sub_count = state.subscription_map.lock().await.len();
+    let member_count = state.status_count().await;
+    let sub_count = state.subscription_count().await;
     match &state.config {
         Some(config) => {
             let vis = serde_json::to_string(&config.visibility).unwrap_or_default();
@@ -596,33 +566,23 @@ mod tests {
         message::{make_command, make_dm, make_message},
     };
     use room_protocol::SubscriptionTier;
-    use std::{
-        collections::HashMap,
-        sync::{atomic::AtomicU64, Arc},
-    };
+    use std::{collections::HashMap, sync::Arc};
     use tempfile::NamedTempFile;
-    use tokio::sync::{watch, Mutex};
+    use tokio::sync::Mutex;
 
     fn make_state(chat_path: std::path::PathBuf) -> Arc<RoomState> {
-        let (shutdown_tx, _) = watch::channel(false);
         let token_map_path = chat_path.with_extension("tokens");
         let subscription_map_path = chat_path.with_extension("subscriptions");
-        Arc::new(RoomState {
-            clients: Arc::new(Mutex::new(HashMap::new())),
-            status_map: Arc::new(Mutex::new(HashMap::new())),
-            host_user: Arc::new(Mutex::new(None)),
-            token_map: Arc::new(Mutex::new(HashMap::new())),
-            claim_map: Arc::new(Mutex::new(HashMap::new())),
-            subscription_map: Arc::new(Mutex::new(HashMap::new())),
-            chat_path: Arc::new(chat_path),
-            token_map_path: Arc::new(token_map_path),
-            subscription_map_path: Arc::new(subscription_map_path),
-            room_id: Arc::new("test-room".to_owned()),
-            shutdown: Arc::new(shutdown_tx),
-            seq_counter: Arc::new(AtomicU64::new(0)),
-            plugin_registry: Arc::new(crate::plugin::PluginRegistry::new()),
-            config: None,
-        })
+        RoomState::new(
+            "test-room".to_owned(),
+            chat_path,
+            token_map_path,
+            subscription_map_path,
+            Arc::new(Mutex::new(HashMap::new())),
+            Arc::new(Mutex::new(HashMap::new())),
+            None,
+        )
+        .unwrap()
     }
 
     // ── route_command: passthrough ─────────────────────────────────────────
@@ -1182,25 +1142,18 @@ mod tests {
         chat_path: std::path::PathBuf,
         config: room_protocol::RoomConfig,
     ) -> Arc<RoomState> {
-        let (shutdown_tx, _) = watch::channel(false);
         let token_map_path = chat_path.with_extension("tokens");
         let subscription_map_path = chat_path.with_extension("subscriptions");
-        Arc::new(RoomState {
-            clients: Arc::new(Mutex::new(HashMap::new())),
-            status_map: Arc::new(Mutex::new(HashMap::new())),
-            host_user: Arc::new(Mutex::new(None)),
-            token_map: Arc::new(Mutex::new(HashMap::new())),
-            claim_map: Arc::new(Mutex::new(HashMap::new())),
-            subscription_map: Arc::new(Mutex::new(HashMap::new())),
-            chat_path: Arc::new(chat_path),
-            token_map_path: Arc::new(token_map_path),
-            subscription_map_path: Arc::new(subscription_map_path),
-            room_id: Arc::new("test-room".to_owned()),
-            shutdown: Arc::new(shutdown_tx),
-            seq_counter: Arc::new(AtomicU64::new(0)),
-            plugin_registry: Arc::new(crate::plugin::PluginRegistry::new()),
-            config: Some(config),
-        })
+        RoomState::new(
+            "test-room".to_owned(),
+            chat_path,
+            token_map_path,
+            subscription_map_path,
+            Arc::new(Mutex::new(HashMap::new())),
+            Arc::new(Mutex::new(HashMap::new())),
+            Some(config),
+        )
+        .unwrap()
     }
 
     #[tokio::test]
@@ -1620,25 +1573,16 @@ mod tests {
         assert_eq!(loaded.get("alice"), Some(&SubscriptionTier::Full));
 
         // Verify it can be populated into a new RoomState.
-        let state2 = {
-            let (shutdown_tx, _) = watch::channel(false);
-            Arc::new(RoomState {
-                clients: Arc::new(Mutex::new(HashMap::new())),
-                status_map: Arc::new(Mutex::new(HashMap::new())),
-                host_user: Arc::new(Mutex::new(None)),
-                token_map: Arc::new(Mutex::new(HashMap::new())),
-                claim_map: Arc::new(Mutex::new(HashMap::new())),
-                subscription_map: Arc::new(Mutex::new(loaded)),
-                chat_path: state.chat_path.clone(),
-                token_map_path: state.token_map_path.clone(),
-                subscription_map_path: state.subscription_map_path.clone(),
-                room_id: state.room_id.clone(),
-                shutdown: Arc::new(shutdown_tx),
-                seq_counter: Arc::new(AtomicU64::new(0)),
-                plugin_registry: Arc::new(crate::plugin::PluginRegistry::new()),
-                config: None,
-            })
-        };
+        let state2 = RoomState::new(
+            state.room_id.as_ref().clone(),
+            state.chat_path.as_ref().clone(),
+            state.token_map_path.as_ref().clone(),
+            state.subscription_map_path.as_ref().clone(),
+            Arc::new(Mutex::new(HashMap::new())),
+            Arc::new(Mutex::new(loaded)),
+            None,
+        )
+        .unwrap();
         assert_eq!(
             *state2.subscription_map.lock().await.get("alice").unwrap(),
             SubscriptionTier::Full

--- a/crates/room-cli/src/broker/daemon.rs
+++ b/crates/room-cli/src/broker/daemon.rs
@@ -44,10 +44,7 @@ use tokio::{
     sync::{broadcast, watch, Mutex},
 };
 
-use crate::{
-    plugin::{self, PluginRegistry},
-    registry::UserRegistry,
-};
+use crate::registry::UserRegistry;
 
 use super::{
     handle_oneshot_send,
@@ -652,15 +649,6 @@ pub(crate) async fn create_room_entry(
 
     let chat_path = daemon_config.chat_path(room_id);
     let subscription_map_path = daemon_config.subscription_map_path(room_id);
-    let (shutdown_tx, _) = watch::channel(false);
-
-    let mut registry = PluginRegistry::new();
-    registry
-        .register(Box::new(plugin::help::HelpPlugin))
-        .map_err(|e| format!("plugin error: {e}"))?;
-    registry
-        .register(Box::new(plugin::stats::StatsPlugin))
-        .map_err(|e| format!("plugin error: {e}"))?;
 
     let persisted_subs = super::commands::load_subscription_map(&subscription_map_path);
     let merged_subs = if let Some(ref cfg) = config {
@@ -671,24 +659,17 @@ pub(crate) async fn create_room_entry(
         persisted_subs
     };
 
-    let state = Arc::new(RoomState {
-        clients: Arc::new(Mutex::new(HashMap::new())),
-        status_map: Arc::new(Mutex::new(HashMap::new())),
-        host_user: Arc::new(Mutex::new(None)),
-        // All rooms in this daemon share the same token map so a token
-        // issued in any room is valid in all rooms.
-        token_map: Arc::clone(system_token_map),
-        claim_map: Arc::new(Mutex::new(HashMap::new())),
-        subscription_map: Arc::new(Mutex::new(merged_subs)),
-        chat_path: Arc::new(chat_path),
-        token_map_path: Arc::new(daemon_config.system_tokens_path()),
-        subscription_map_path: Arc::new(subscription_map_path),
-        room_id: Arc::new(room_id.to_owned()),
-        shutdown: Arc::new(shutdown_tx),
-        seq_counter: Arc::new(AtomicU64::new(0)),
-        plugin_registry: Arc::new(registry),
+    // All rooms in this daemon share the same token map so a token
+    // issued in any room is valid in all rooms.
+    let state = RoomState::new(
+        room_id.to_owned(),
+        chat_path,
+        daemon_config.system_tokens_path(),
+        subscription_map_path,
+        Arc::clone(system_token_map),
+        Arc::new(Mutex::new(merged_subs)),
         config,
-    });
+    )?;
 
     rooms.lock().await.insert(room_id.to_owned(), state);
     Ok(())

--- a/crates/room-cli/src/broker/state.rs
+++ b/crates/room-cli/src/broker/state.rs
@@ -62,3 +62,352 @@ pub(crate) struct RoomState {
     /// `None` for rooms created without explicit config (backward compat).
     pub(crate) config: Option<RoomConfig>,
 }
+
+impl RoomState {
+    // ── Factory ───────────────────────────────────────────────────────────────
+
+    /// Construct a fully wired `Arc<RoomState>` with default empty collections.
+    ///
+    /// Creates fresh empty maps for `clients`, `status_map`, `host_user`, `claim_map`,
+    /// a fresh `seq_counter`, and a new `watch::channel` for `shutdown`. Callers that
+    /// need a `watch::Receiver` should call `state.shutdown.subscribe()` after construction.
+    ///
+    /// The built-in `/help` and `/stats` plugins are registered automatically.
+    ///
+    /// # Parameters
+    ///
+    /// - `token_map` — pre-populated token map; pass `Arc::new(Mutex::new(HashMap::new()))`
+    ///   for a fresh map or supply an existing shared map (daemon mode uses one map per daemon).
+    /// - `subscription_map` — pre-populated subscription map loaded from disk (or empty).
+    /// - `config` — room visibility/ACL config; `None` for legacy configless rooms.
+    pub(crate) fn new(
+        room_id: String,
+        chat_path: PathBuf,
+        token_map_path: PathBuf,
+        subscription_map_path: PathBuf,
+        token_map: TokenMap,
+        subscription_map: SubscriptionMap,
+        config: Option<RoomConfig>,
+    ) -> Result<Arc<Self>, String> {
+        let mut registry = crate::plugin::PluginRegistry::new();
+        registry
+            .register(Box::new(crate::plugin::help::HelpPlugin))
+            .map_err(|e| format!("plugin error: {e}"))?;
+        registry
+            .register(Box::new(crate::plugin::stats::StatsPlugin))
+            .map_err(|e| format!("plugin error: {e}"))?;
+
+        let (shutdown_tx, _) = watch::channel(false);
+
+        Ok(Arc::new(Self {
+            clients: Arc::new(Mutex::new(HashMap::new())),
+            status_map: Arc::new(Mutex::new(HashMap::new())),
+            host_user: Arc::new(Mutex::new(None)),
+            token_map,
+            claim_map: Arc::new(Mutex::new(HashMap::new())),
+            subscription_map,
+            chat_path: Arc::new(chat_path),
+            token_map_path: Arc::new(token_map_path),
+            subscription_map_path: Arc::new(subscription_map_path),
+            room_id: Arc::new(room_id),
+            shutdown: Arc::new(shutdown_tx),
+            seq_counter: Arc::new(AtomicU64::new(0)),
+            plugin_registry: Arc::new(registry),
+            config,
+        }))
+    }
+
+    // ── status_map accessors ──────────────────────────────────────────────────
+
+    /// Set (or clear) a user's status string.
+    pub(crate) async fn set_status(&self, user: &str, status: String) {
+        self.status_map.lock().await.insert(user.to_owned(), status);
+    }
+
+    /// Remove a user's status entry (e.g. on kick or disconnect).
+    pub(crate) async fn remove_status(&self, user: &str) {
+        self.status_map.lock().await.remove(user);
+    }
+
+    /// Return all (username, status) pairs, sorted by username.
+    pub(crate) async fn status_entries(&self) -> Vec<(String, String)> {
+        let mut entries: Vec<(String, String)> = self
+            .status_map
+            .lock()
+            .await
+            .iter()
+            .map(|(u, s)| (u.clone(), s.clone()))
+            .collect();
+        entries.sort_by(|a, b| a.0.cmp(&b.0));
+        entries
+    }
+
+    /// Number of users currently in the status map (i.e. online).
+    pub(crate) async fn status_count(&self) -> usize {
+        self.status_map.lock().await.len()
+    }
+
+    // ── claim_map accessors ───────────────────────────────────────────────────
+
+    /// Record a task claim for `user`. Replaces any existing claim.
+    pub(crate) async fn set_claim(&self, user: &str, task: String) {
+        self.claim_map.lock().await.insert(user.to_owned(), task);
+    }
+
+    /// Remove and return a user's active claim, if any.
+    pub(crate) async fn remove_claim(&self, user: &str) -> Option<String> {
+        self.claim_map.lock().await.remove(user)
+    }
+
+    /// Return all (username, task) claim pairs, sorted by username.
+    pub(crate) async fn claim_entries(&self) -> Vec<(String, String)> {
+        let mut entries: Vec<(String, String)> = self
+            .claim_map
+            .lock()
+            .await
+            .iter()
+            .map(|(u, t)| (u.clone(), t.clone()))
+            .collect();
+        entries.sort_by(|a, b| a.0.cmp(&b.0));
+        entries
+    }
+
+    // ── subscription_map accessors ────────────────────────────────────────────
+
+    /// Set a user's subscription tier.
+    pub(crate) async fn set_subscription(&self, user: &str, tier: SubscriptionTier) {
+        self.subscription_map
+            .lock()
+            .await
+            .insert(user.to_owned(), tier);
+    }
+
+    /// Return all (username, tier) subscription pairs, sorted by username.
+    pub(crate) async fn subscription_entries(&self) -> Vec<(String, SubscriptionTier)> {
+        let mut entries: Vec<(String, SubscriptionTier)> = self
+            .subscription_map
+            .lock()
+            .await
+            .iter()
+            .map(|(u, t)| (u.clone(), *t))
+            .collect();
+        entries.sort_by(|a, b| a.0.cmp(&b.0));
+        entries
+    }
+
+    /// Return a cloned snapshot of the full subscription map (for persistence).
+    pub(crate) async fn subscription_snapshot(&self) -> HashMap<String, SubscriptionTier> {
+        self.subscription_map.lock().await.clone()
+    }
+
+    /// Number of subscribed users.
+    pub(crate) async fn subscription_count(&self) -> usize {
+        self.subscription_map.lock().await.len()
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use room_protocol::SubscriptionTier;
+    use std::{collections::HashMap, sync::Arc};
+    use tempfile::TempDir;
+    use tokio::sync::Mutex;
+
+    fn make_state(dir: &TempDir) -> Arc<RoomState> {
+        let chat = dir.path().join("chat.ndjson");
+        let token_map_path = dir.path().join("room.tokens");
+        let sub_map_path = dir.path().join("room.subscriptions");
+        RoomState::new(
+            "test-room".to_owned(),
+            chat,
+            token_map_path,
+            sub_map_path,
+            Arc::new(Mutex::new(HashMap::new())),
+            Arc::new(Mutex::new(HashMap::new())),
+            None,
+        )
+        .unwrap()
+    }
+
+    // ── factory ───────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn new_creates_state_with_correct_room_id() {
+        let dir = TempDir::new().unwrap();
+        let state = make_state(&dir);
+        assert_eq!(state.room_id.as_str(), "test-room");
+    }
+
+    #[tokio::test]
+    async fn new_registers_builtin_plugins() {
+        let dir = TempDir::new().unwrap();
+        let state = make_state(&dir);
+        assert!(
+            state.plugin_registry.resolve("help").is_some(),
+            "help plugin should be registered"
+        );
+        assert!(
+            state.plugin_registry.resolve("stats").is_some(),
+            "stats plugin should be registered"
+        );
+    }
+
+    #[tokio::test]
+    async fn new_starts_with_empty_collections() {
+        let dir = TempDir::new().unwrap();
+        let state = make_state(&dir);
+        assert_eq!(state.status_count().await, 0);
+        assert!(state.claim_entries().await.is_empty());
+        assert_eq!(state.subscription_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn new_uses_provided_token_map() {
+        let dir = TempDir::new().unwrap();
+        let chat = dir.path().join("chat.ndjson");
+        let token_map = Arc::new(Mutex::new({
+            let mut m = HashMap::new();
+            m.insert("tok-1".to_owned(), "alice".to_owned());
+            m
+        }));
+        let state = RoomState::new(
+            "r".to_owned(),
+            chat,
+            dir.path().join("r.tokens"),
+            dir.path().join("r.subscriptions"),
+            token_map,
+            Arc::new(Mutex::new(HashMap::new())),
+            None,
+        )
+        .unwrap();
+        assert!(state.token_map.lock().await.contains_key("tok-1"));
+    }
+
+    // ── status_map accessors ──────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn set_status_inserts_entry() {
+        let dir = TempDir::new().unwrap();
+        let state = make_state(&dir);
+        state.set_status("alice", "busy".to_owned()).await;
+        assert_eq!(state.status_count().await, 1);
+    }
+
+    #[tokio::test]
+    async fn set_status_empty_string_clears_display() {
+        let dir = TempDir::new().unwrap();
+        let state = make_state(&dir);
+        state.set_status("alice", "busy".to_owned()).await;
+        state.set_status("alice", String::new()).await;
+        // Entry still present but empty
+        let entries = state.status_entries().await;
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].1, "");
+    }
+
+    #[tokio::test]
+    async fn remove_status_deletes_entry() {
+        let dir = TempDir::new().unwrap();
+        let state = make_state(&dir);
+        state.set_status("alice", "busy".to_owned()).await;
+        state.remove_status("alice").await;
+        assert_eq!(state.status_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn status_entries_returns_sorted() {
+        let dir = TempDir::new().unwrap();
+        let state = make_state(&dir);
+        state.set_status("carol", "c".to_owned()).await;
+        state.set_status("alice", "a".to_owned()).await;
+        state.set_status("bob", "b".to_owned()).await;
+        let entries = state.status_entries().await;
+        assert_eq!(entries[0].0, "alice");
+        assert_eq!(entries[1].0, "bob");
+        assert_eq!(entries[2].0, "carol");
+    }
+
+    // ── claim_map accessors ───────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn set_claim_and_claim_entries() {
+        let dir = TempDir::new().unwrap();
+        let state = make_state(&dir);
+        state.set_claim("alice", "fix #42".to_owned()).await;
+        let entries = state.claim_entries().await;
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0], ("alice".to_owned(), "fix #42".to_owned()));
+    }
+
+    #[tokio::test]
+    async fn remove_claim_returns_task_and_deletes() {
+        let dir = TempDir::new().unwrap();
+        let state = make_state(&dir);
+        state.set_claim("alice", "task".to_owned()).await;
+        let removed = state.remove_claim("alice").await;
+        assert_eq!(removed, Some("task".to_owned()));
+        assert!(state.claim_entries().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn remove_claim_missing_returns_none() {
+        let dir = TempDir::new().unwrap();
+        let state = make_state(&dir);
+        assert_eq!(state.remove_claim("nobody").await, None);
+    }
+
+    #[tokio::test]
+    async fn claim_entries_sorted_by_username() {
+        let dir = TempDir::new().unwrap();
+        let state = make_state(&dir);
+        state.set_claim("bob", "b".to_owned()).await;
+        state.set_claim("alice", "a".to_owned()).await;
+        let entries = state.claim_entries().await;
+        assert_eq!(entries[0].0, "alice");
+        assert_eq!(entries[1].0, "bob");
+    }
+
+    // ── subscription_map accessors ────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn set_subscription_and_count() {
+        let dir = TempDir::new().unwrap();
+        let state = make_state(&dir);
+        state
+            .set_subscription("alice", SubscriptionTier::Full)
+            .await;
+        assert_eq!(state.subscription_count().await, 1);
+    }
+
+    #[tokio::test]
+    async fn subscription_entries_sorted() {
+        let dir = TempDir::new().unwrap();
+        let state = make_state(&dir);
+        state
+            .set_subscription("bob", SubscriptionTier::MentionsOnly)
+            .await;
+        state
+            .set_subscription("alice", SubscriptionTier::Full)
+            .await;
+        let entries = state.subscription_entries().await;
+        assert_eq!(entries[0].0, "alice");
+        assert_eq!(entries[1].0, "bob");
+    }
+
+    #[tokio::test]
+    async fn subscription_snapshot_clones_map() {
+        let dir = TempDir::new().unwrap();
+        let state = make_state(&dir);
+        state
+            .set_subscription("alice", SubscriptionTier::Full)
+            .await;
+        let snap = state.subscription_snapshot().await;
+        assert_eq!(snap.get("alice"), Some(&SubscriptionTier::Full));
+        // Snapshot is a clone — mutations don't affect the original.
+        drop(snap);
+        assert_eq!(state.subscription_count().await, 1);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `RoomState::new()` factory that wires all 11 `Arc<Mutex<>>` fields and registers built-in plugins automatically, eliminating the struct-literal boilerplate in `create_room_entry` (daemon.rs)
- Add 10 accessor methods on `RoomState` that eliminate ~30 scattered `.lock().await` calls in commands.rs: `set_status`, `remove_status`, `status_entries`, `status_count`, `set_claim`, `remove_claim`, `claim_entries`, `set_subscription`, `subscription_entries`, `subscription_snapshot`, `subscription_count`
- Update `create_room_entry` (daemon.rs) to use `RoomState::new()` — removes 17 lines of boilerplate
- Update `commands.rs` throughout: `route_command`, `handle_admin_cmd`, `persist_subscriptions`, `handle_room_info` — all explicit `.lock().await` on `status_map`, `claim_map`, and `subscription_map` replaced with accessors
- The `mod.rs` construction site is intentionally deferred — will be updated once PR #351 (handshake extraction, which also touches `mod.rs`) merges to avoid a conflict

## Test plan

- [x] 15 new unit tests in `state.rs` covering `RoomState::new()` and every accessor
- [x] Existing `commands.rs` test helpers updated to use `RoomState::new()`, validating the factory in the existing test suite
- [x] `cargo test`: 604 unit tests pass (up from 589, +15 new)
- [x] `cargo clippy -- -D warnings`: clean
- [x] `cargo fmt`: clean

Closes #353
Closes #360
