### PR TITLE
add clippy.toml complexity thresholds and fix loop_runner.rs (#364)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,8 @@
 [workspace]
 members = ["crates/*"]
 resolver = "2"
+
+[workspace.lints.clippy]
+cognitive_complexity = "warn"
+too_many_lines = "warn"
+too_many_arguments = "warn"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,23 @@
+# Clippy configuration for the room workspace.
+#
+# Thresholds are currently set conservatively above the existing maximums
+# in the codebase while the sprint-9 refactor sprint resolves known violations.
+# Tighten these progressively as wave-1 and wave-2 refactor PRs (#351–#363) land:
+#
+#   cognitive-complexity: target ≤ 25 after handle_key (#354) and loop_runner land
+#   too-many-lines:       target ≤ 200 after run() / main() / dispatch() refactors
+#   too-many-arguments:   keep at 7 (no current violations)
+
+# Flag functions whose cognitive complexity exceeds this threshold.
+# Set to 40 so that tui/input.rs::handle_key (complexity 38, assigned to #354)
+# does not break CI until bumblebee's wave-1 refactor lands.
+# Target: tighten to 25 after #354 and #363 (tui/mod.rs::run at 33) are resolved.
+cognitive-complexity-threshold = 40
+
+# Flag functions with more lines than this threshold.
+# Current maximum: tui/mod.rs::run (559 lines — wave-2 refactor target).
+too-many-lines-threshold = 600
+
+# Flag functions with more arguments than this threshold.
+# No current violations; enforces reasonable API surface.
+too-many-arguments-threshold = 7

--- a/crates/agentroom/Cargo.toml
+++ b/crates/agentroom/Cargo.toml
@@ -11,3 +11,6 @@ categories = ["command-line-utilities"]
 [[bin]]
 name = "agentroom"
 path = "src/main.rs"
+
+[lints]
+workspace = true

--- a/crates/room-cli/Cargo.toml
+++ b/crates/room-cli/Cargo.toml
@@ -38,3 +38,6 @@ futures-util = { version = "=0.3.31", features = ["sink"] }
 reqwest = { version = "0.13.2", features = ["json"] }
 tempfile = "3"
 tokio-tungstenite = "0.28"
+
+[lints]
+workspace = true

--- a/crates/room-protocol/Cargo.toml
+++ b/crates/room-protocol/Cargo.toml
@@ -11,3 +11,6 @@ chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
+
+[lints]
+workspace = true

--- a/crates/room-ralph/Cargo.toml
+++ b/crates/room-ralph/Cargo.toml
@@ -26,3 +26,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 tempfile = "3"
+
+[lints]
+workspace = true

--- a/crates/room-ralph/src/loop_runner.rs
+++ b/crates/room-ralph/src/loop_runner.rs
@@ -1,7 +1,8 @@
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-use crate::claude;
+use crate::claude::{self, ClaudeOutput};
 use crate::monitor;
 use crate::progress;
 use crate::prompt::{self, PromptConfig};
@@ -22,182 +23,271 @@ pub async fn run_loop(cli: &Cli, token: String, running: &Arc<AtomicBool>) -> Re
     while running.load(Ordering::SeqCst) {
         iteration += 1;
 
-        if cli.max_iter > 0 && iteration > cli.max_iter {
-            tracing::info!("max iterations ({}) reached, stopping", cli.max_iter);
-            room::send_message(
-                &cli.room_id,
-                &token,
-                &format!("max iterations reached ({}), shutting down", cli.max_iter),
-                socket_ref,
-            )
-            .ok();
+        if at_max_iter(cli, iteration, &token, socket_ref) {
             break;
         }
 
         tracing::info!("--- iteration {} ---", iteration);
 
-        // Poll room for recent messages — re-join if token is stale (broker restart)
-        let messages = match room::poll_messages(&cli.room_id, &token, socket_ref) {
-            Ok(msgs) => msgs,
-            Err(e) if room::detect_token_expiry(&e) => {
-                tracing::warn!("token expired during poll, re-joining: {}", e);
-                match room::join_room(&cli.room_id, &cli.username, socket_ref) {
-                    Ok(new_token) => {
-                        tracing::info!("re-joined with new token");
-                        token = new_token;
-                        room::poll_messages(&cli.room_id, &token, socket_ref).unwrap_or_default()
-                    }
-                    Err(join_err) => {
-                        tracing::error!("re-join failed: {}", join_err);
-                        Vec::new()
-                    }
-                }
-            }
-            Err(_) => Vec::new(),
-        };
+        let messages = poll_with_token_refresh(cli, &mut token, socket_ref);
+        let prompt_text = build_iteration_prompt(cli, &messages, &progress_file, &token);
 
-        // Build prompt
-        let config = PromptConfig {
-            room_id: &cli.room_id,
-            username: &cli.username,
-            token: &token,
-            custom_prompt_file: cli.prompt.as_deref(),
-            personality_file: cli.personality.as_deref(),
-            progress_file: &progress_file,
-            issue: cli.issue.as_deref(),
-        };
-        let prompt_text = prompt::build_prompt(&config, &messages);
-
-        // Dry run — print and exit
         if cli.dry_run {
-            println!("=== DRY RUN: prompt ===");
-            println!("{prompt_text}");
+            println!("=== DRY RUN: prompt ===\n{prompt_text}");
             return Ok(());
         }
 
-        // Write prompt to temp file
-        let prompt_file =
-            std::path::PathBuf::from(format!("/tmp/ralph-room-prompt-{}.txt", cli.username));
-        std::fs::write(&prompt_file, &prompt_text)
-            .map_err(|e| format!("failed to write prompt file: {e}"))?;
+        let prompt_file = write_prompt_file(&cli.username, &prompt_text)?;
 
-        // Update status before spawning claude.
-        let status_text = match cli.issue.as_deref() {
-            Some(issue) => format!("running claude — iteration {iteration} for #{issue}"),
-            None => format!("running claude — iteration {iteration}"),
-        };
-        room::set_status(&cli.room_id, &token, &status_text, socket_ref).ok();
-
-        // Run claude
-        tracing::info!(
-            "running claude -p (model={}, iteration={})",
-            cli.model,
-            iteration
-        );
-        let (profile_allow, profile_disallow) = claude::merge_profile_with_overrides(
-            cli.profile,
-            &cli.allow_tools,
-            &cli.disallow_tools,
-        );
-        let effective_tools = claude::resolve_allowed_tools(&profile_allow);
-        let effective_disallowed = claude::resolve_disallowed_tools(&profile_disallow);
-        let claude_output = match claude::spawn_claude(
-            &cli.model,
-            &prompt_file,
-            &cli.add_dirs,
-            &effective_tools,
-            &effective_disallowed,
-        ) {
-            Ok(o) => o,
-            Err(e) => {
-                tracing::error!("failed to spawn claude: {}", e);
-                cooldown(cli.cooldown, running).await;
-                continue;
-            }
+        let Some(output) = try_invoke_claude(cli, &token, socket_ref, iteration, &prompt_file)
+        else {
+            cooldown(cli.cooldown, running).await;
+            continue;
         };
 
-        tracing::info!("claude exited with code {}", claude_output.exit_code);
-
-        // Extract response text
-        let response = claude::extract_response(&claude_output.raw_json);
-
-        // Context monitoring — parse token usage
-        let input_tokens = monitor::parse_usage(&claude_output.raw_json);
-        let output_tokens = monitor::parse_output_tokens(&claude_output.raw_json);
-        tracing::info!(
-            "{}",
-            monitor::format_usage_summary(input_tokens, output_tokens)
-        );
-        monitor::log_usage(&progress_file, input_tokens, output_tokens, iteration).ok();
-
-        // Detect context exhaustion — two paths:
-        // 1. Proactive: token usage exceeds threshold
-        // 2. Reactive: claude crashed with context-related error message
-        let should_cycle = if monitor::should_restart(input_tokens) {
-            tracing::info!(
-                "proactive restart: token usage ({}) exceeds threshold",
-                input_tokens
-            );
-            true
-        } else if claude::detect_context_exhaustion(claude_output.exit_code, &response) {
-            tracing::info!("reactive restart: context exhaustion detected in output");
-            true
-        } else {
-            false
-        };
-
-        if should_cycle {
-            progress::write_progress(&progress_file, iteration, cli.issue.as_deref(), &response)
-                .map_err(|e| format!("failed to write progress: {e}"))?;
-
-            room::set_status(
-                &cli.room_id,
-                &token,
-                &format!("restarting — context limit at iteration {iteration}"),
-                socket_ref,
-            )
-            .ok();
-            let msg = format!(
-                "context limit at iteration {} (tokens: {}), restarting with fresh context",
-                iteration, input_tokens
-            );
-            room::send_message(&cli.room_id, &token, &msg, socket_ref).ok();
-        } else if claude_output.exit_code != 0 {
-            tracing::warn!(
-                "claude failed (exit {}), will retry after cooldown",
-                claude_output.exit_code
-            );
-            room::set_status(
-                &cli.room_id,
-                &token,
-                &format!(
-                    "retrying — claude error (code {}) at iteration {iteration}",
-                    claude_output.exit_code
-                ),
-                socket_ref,
-            )
-            .ok();
-            let msg = format!(
-                "claude exited with error (code {}), retrying in {}s",
-                claude_output.exit_code, cli.cooldown
-            );
-            room::send_message(&cli.room_id, &token, &msg, socket_ref).ok();
-        }
-
-        // Cooldown
+        process_output(cli, &token, socket_ref, iteration, &output, &progress_file)?;
         cooldown(cli.cooldown, running).await;
     }
 
-    tracing::info!("room-ralph stopped after {} iterations", iteration);
-    room::set_status(&cli.room_id, &token, "offline", socket_ref).ok();
+    shutdown(cli, &token, socket_ref, iteration);
+    Ok(())
+}
+
+/// Returns `true` and sends a shutdown message if `iteration` has exceeded
+/// `cli.max_iter` (when max_iter > 0).
+fn at_max_iter(cli: &Cli, iteration: u32, token: &str, socket_ref: Option<&str>) -> bool {
+    if cli.max_iter > 0 && iteration > cli.max_iter {
+        tracing::info!("max iterations ({}) reached, stopping", cli.max_iter);
+        room::send_message(
+            &cli.room_id,
+            token,
+            &format!("max iterations reached ({}), shutting down", cli.max_iter),
+            socket_ref,
+        )
+        .ok();
+        return true;
+    }
+    false
+}
+
+/// Poll room for recent messages, transparently re-joining if the token has
+/// expired due to a broker restart.
+fn poll_with_token_refresh(
+    cli: &Cli,
+    token: &mut String,
+    socket_ref: Option<&str>,
+) -> Vec<room_protocol::Message> {
+    match room::poll_messages(&cli.room_id, token, socket_ref) {
+        Ok(msgs) => msgs,
+        Err(e) if room::detect_token_expiry(&e) => {
+            tracing::warn!("token expired during poll, re-joining: {}", e);
+            rejoin_and_poll(cli, token, socket_ref)
+        }
+        Err(_) => Vec::new(),
+    }
+}
+
+/// Re-join the room to obtain a fresh token, then poll for messages.
+fn rejoin_and_poll(
+    cli: &Cli,
+    token: &mut String,
+    socket_ref: Option<&str>,
+) -> Vec<room_protocol::Message> {
+    match room::join_room(&cli.room_id, &cli.username, socket_ref) {
+        Ok(new_token) => {
+            tracing::info!("re-joined with new token");
+            *token = new_token;
+            room::poll_messages(&cli.room_id, token, socket_ref).unwrap_or_default()
+        }
+        Err(join_err) => {
+            tracing::error!("re-join failed: {}", join_err);
+            Vec::new()
+        }
+    }
+}
+
+/// Build the prompt text for this iteration.
+fn build_iteration_prompt(
+    cli: &Cli,
+    messages: &[room_protocol::Message],
+    progress_file: &Path,
+    token: &str,
+) -> String {
+    let config = PromptConfig {
+        room_id: &cli.room_id,
+        username: &cli.username,
+        token,
+        custom_prompt_file: cli.prompt.as_deref(),
+        personality_file: cli.personality.as_deref(),
+        progress_file,
+        issue: cli.issue.as_deref(),
+    };
+    prompt::build_prompt(&config, messages)
+}
+
+/// Write the prompt to a temp file and return its path.
+fn write_prompt_file(username: &str, prompt_text: &str) -> Result<PathBuf, String> {
+    let path = PathBuf::from(format!("/tmp/ralph-room-prompt-{username}.txt"));
+    std::fs::write(&path, prompt_text).map_err(|e| format!("failed to write prompt file: {e}"))?;
+    Ok(path)
+}
+
+/// Set running-status, invoke claude, and return its output. Returns `None`
+/// if spawning fails (the caller should continue to the next iteration).
+fn try_invoke_claude(
+    cli: &Cli,
+    token: &str,
+    socket_ref: Option<&str>,
+    iteration: u32,
+    prompt_file: &Path,
+) -> Option<ClaudeOutput> {
+    let status_text = match cli.issue.as_deref() {
+        Some(issue) => format!("running claude — iteration {iteration} for #{issue}"),
+        None => format!("running claude — iteration {iteration}"),
+    };
+    room::set_status(&cli.room_id, token, &status_text, socket_ref).ok();
+
+    tracing::info!(
+        "running claude -p (model={}, iteration={})",
+        cli.model,
+        iteration
+    );
+    let (profile_allow, profile_disallow) =
+        claude::merge_profile_with_overrides(cli.profile, &cli.allow_tools, &cli.disallow_tools);
+    let effective_tools = claude::resolve_allowed_tools(&profile_allow);
+    let effective_disallowed = claude::resolve_disallowed_tools(&profile_disallow);
+
+    match claude::spawn_claude(
+        &cli.model,
+        prompt_file,
+        &cli.add_dirs,
+        &effective_tools,
+        &effective_disallowed,
+    ) {
+        Ok(output) => Some(output),
+        Err(e) => {
+            tracing::error!("failed to spawn claude: {}", e);
+            None
+        }
+    }
+}
+
+/// Process claude's output: log usage, detect context exhaustion, send status
+/// updates to the room.
+fn process_output(
+    cli: &Cli,
+    token: &str,
+    socket_ref: Option<&str>,
+    iteration: u32,
+    output: &ClaudeOutput,
+    progress_file: &Path,
+) -> Result<(), String> {
+    tracing::info!("claude exited with code {}", output.exit_code);
+
+    let response = claude::extract_response(&output.raw_json);
+    let input_tokens = monitor::parse_usage(&output.raw_json);
+    let output_tokens = monitor::parse_output_tokens(&output.raw_json);
+    tracing::info!(
+        "{}",
+        monitor::format_usage_summary(input_tokens, output_tokens)
+    );
+    monitor::log_usage(progress_file, input_tokens, output_tokens, iteration).ok();
+
+    let should_cycle = monitor::should_restart(input_tokens)
+        || claude::detect_context_exhaustion(output.exit_code, &response);
+
+    if should_cycle {
+        on_context_cycle(
+            cli,
+            token,
+            socket_ref,
+            iteration,
+            input_tokens,
+            &response,
+            progress_file,
+        )
+    } else if output.exit_code != 0 {
+        on_claude_error(cli, token, socket_ref, iteration, output.exit_code);
+        Ok(())
+    } else {
+        Ok(())
+    }
+}
+
+/// Write progress and broadcast a context-cycle notification.
+fn on_context_cycle(
+    cli: &Cli,
+    token: &str,
+    socket_ref: Option<&str>,
+    iteration: u32,
+    input_tokens: u64,
+    response: &str,
+    progress_file: &Path,
+) -> Result<(), String> {
+    progress::write_progress(progress_file, iteration, cli.issue.as_deref(), response)
+        .map_err(|e| format!("failed to write progress: {e}"))?;
+    room::set_status(
+        &cli.room_id,
+        token,
+        &format!("restarting — context limit at iteration {iteration}"),
+        socket_ref,
+    )
+    .ok();
     room::send_message(
         &cli.room_id,
-        &token,
-        &format!("offline (room-ralph stopped after {iteration} iterations)"),
+        token,
+        &format!(
+            "context limit at iteration {} (tokens: {}), restarting with fresh context",
+            iteration, input_tokens
+        ),
         socket_ref,
     )
     .ok();
     Ok(())
+}
+
+/// Broadcast a claude error notification when exit_code != 0.
+fn on_claude_error(
+    cli: &Cli,
+    token: &str,
+    socket_ref: Option<&str>,
+    iteration: u32,
+    exit_code: i32,
+) {
+    tracing::warn!(
+        "claude failed (exit {}), will retry after cooldown",
+        exit_code
+    );
+    room::set_status(
+        &cli.room_id,
+        token,
+        &format!("retrying — claude error (code {exit_code}) at iteration {iteration}"),
+        socket_ref,
+    )
+    .ok();
+    room::send_message(
+        &cli.room_id,
+        token,
+        &format!(
+            "claude exited with error (code {exit_code}), retrying in {}s",
+            cli.cooldown
+        ),
+        socket_ref,
+    )
+    .ok();
+}
+
+/// Broadcast offline status and final message after the loop exits.
+fn shutdown(cli: &Cli, token: &str, socket_ref: Option<&str>, iteration: u32) {
+    tracing::info!("room-ralph stopped after {} iterations", iteration);
+    room::set_status(&cli.room_id, token, "offline", socket_ref).ok();
+    room::send_message(
+        &cli.room_id,
+        token,
+        &format!("offline (room-ralph stopped after {iteration} iterations)"),
+        socket_ref,
+    )
+    .ok();
 }
 
 /// Sleep for the cooldown period, but wake early if running is set to false.


### PR DESCRIPTION
## Summary

- Adds `clippy.toml` at workspace root with three complexity lint thresholds
- Enables lints across all crates via `[workspace.lints.clippy]` in `Cargo.toml`
- Refactors `room-ralph/src/loop_runner.rs` to resolve the one triggered violation

## Lints enabled

| Lint | Threshold | Rationale |
|------|-----------|-----------|
| `clippy::cognitive_complexity` | 40 | Flags functions harder to reason about than `handle_key()` |
| `clippy::too_many_lines` | 600 | Above current worst-case; prevents new runaway functions |
| `clippy::too_many_arguments` | 7 | Default; no current violations |

## Violations fixed

**`crates/room-ralph/src/loop_runner.rs::run_loop()`** — cognitive complexity 105 → resolved by extracting seven single-responsibility helpers:
- `at_max_iter()` — max-iteration guard + shutdown
- `poll_with_token_refresh()` / `rejoin_and_poll()` — poll with token expiry handling
- `build_iteration_prompt()` — prompt construction
- `write_prompt_file()` — temp file write
- `try_invoke_claude()` — claude spawn + error handling
- `process_output()` / `on_context_cycle()` / `on_claude_error()` — output dispatch
- `shutdown()` — final status broadcast

## Violations NOT fixed (other agents' territory)

- `tui/input.rs::handle_key()` — complexity 38 — assigned to bumblebee, **#354**. Threshold set to 40 so CI passes until that PR lands. After #354 merges, threshold can be lowered to 25.
- `tui/mod.rs::run()` — 559 lines — unassigned wave-2 target. Threshold set to 600 so CI passes. After wave-2 refactors, lower to 200.

## Threshold tightening path

1. After **#354** (bumblebee, handle_key decomposition): lower cognitive-complexity to 25
2. After wave-2 refactors (**#357–#363**): lower too-many-lines to 200

## Tests

All 8 room-ralph tests pass. `cargo clippy -- -D warnings` clean. `cargo fmt --check` clean.

Closes #364.