### PR TITLE
fix(paths): expose room_runtime_dir, fix cmd_list /tmp hardcode (#361)

### DIFF
--- a/crates/room-cli/src/oneshot/list.rs
+++ b/crates/room-cli/src/oneshot/list.rs
@@ -12,10 +12,11 @@ struct RoomInfo {
     chat_path: Option<String>,
 }
 
-/// Scan `/tmp` for `room-*.sock` files, verify each broker is alive via a
-/// short connect attempt, and print one NDJSON line per active room.
+/// Scan the platform runtime directory for `room-*.sock` files, verify each
+/// broker is alive via a short connect attempt, and print one NDJSON line per
+/// active room.
 pub async fn cmd_list() -> anyhow::Result<()> {
-    let rooms = discover_rooms(Path::new("/tmp")).await?;
+    let rooms = discover_rooms(&crate::paths::room_runtime_dir()).await?;
 
     for info in &rooms {
         println!("{}", serde_json::to_string(info)?);

--- a/crates/room-cli/src/paths.rs
+++ b/crates/room-cli/src/paths.rs
@@ -35,6 +35,15 @@ pub fn room_data_dir() -> PathBuf {
     room_home().join("data")
 }
 
+/// Platform-native runtime directory for ephemeral room files (sockets,
+/// PID, meta).
+///
+/// - macOS: `$TMPDIR` (per-user, e.g. `/var/folders/...`)
+/// - Linux: `$XDG_RUNTIME_DIR/room/` or `/tmp/` fallback
+pub fn room_runtime_dir() -> PathBuf {
+    runtime_dir()
+}
+
 /// Platform-native socket path for the multi-room daemon.
 ///
 /// - macOS: `$TMPDIR/roomd.sock`
@@ -304,6 +313,12 @@ mod tests {
             let result = effective_socket_path(None);
             assert_eq!(result, room_socket_path());
         }
+    }
+
+    #[test]
+    fn room_runtime_dir_returns_absolute_path() {
+        let p = room_runtime_dir();
+        assert!(p.is_absolute(), "expected absolute path, got: {p:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Added `pub room_runtime_dir()` to paths.rs, exposing the platform-native runtime directory
- Fixed `cmd_list()` in list.rs which hardcoded `Path::new("/tmp")` — on macOS `$TMPDIR` points to `/var/folders/...`, so rooms started by the daemon were invisible to `room list`
- Most cursor/meta path centralization was already done in sprint 8; this closes the remaining gap

## Files modified
- `crates/room-cli/src/paths.rs` — added `room_runtime_dir()` + test
- `crates/room-cli/src/oneshot/list.rs` — replaced hardcoded `/tmp` with `paths::room_runtime_dir()`

## Test plan
- [x] All Rust tests pass
- [x] cargo check, fmt, clippy clean
- [x] New test: `room_runtime_dir_returns_absolute_path`
- [x] Existing list.rs tests still pass (they use tempdir, unaffected)

Closes #361