### PR TITLE
refactor(protocol): add Message::is_visible_to, replace DM filter patterns

### DIFF
--- a/crates/room-cli/src/broker/fanout.rs
+++ b/crates/room-cli/src/broker/fanout.rs
@@ -39,8 +39,6 @@ pub(crate) async fn broadcast_and_persist(
 /// receives their own echo; no error is returned.
 pub(crate) async fn dm_and_persist(
     msg: &Message,
-    sender: &str,
-    recipient: &str,
     host_user: &HostUser,
     clients: &ClientMap,
     chat_path: &Path,
@@ -57,7 +55,7 @@ pub(crate) async fn dm_and_persist(
     let host_name = host.as_deref();
     let map = clients.lock().await;
     for (username, tx) in map.values() {
-        if username == sender || username == recipient || host_name == Some(username.as_str()) {
+        if msg.is_visible_to(username, host_name) {
             let _ = tx.send(line.clone());
         }
     }

--- a/crates/room-cli/src/broker/mod.rs
+++ b/crates/room-cli/src/broker/mod.rs
@@ -276,16 +276,9 @@ pub(crate) async fn run_interactive_session(
     // client is not party to (sender, recipient, or host).
     // If the client disconnects mid-replay, treat it as a clean exit.
     let host_name = state.host_user.lock().await.clone();
-    let is_host = host_name.as_deref() == Some(username.as_str());
     let history = history::load(&state.chat_path).await.unwrap_or_default();
     for msg in &history {
-        let visible = match msg {
-            Message::DirectMessage { user, to, .. } => {
-                is_host || user == &username || to == &username
-            }
-            _ => true,
-        };
-        if visible {
+        if msg.is_visible_to(&username, host_name.as_deref()) {
             let line = format!("{}\n", serde_json::to_string(msg)?);
             if write_half.write_all(line.as_bytes()).await.is_err() {
                 return Ok(());
@@ -397,11 +390,9 @@ pub(crate) async fn run_interactive_session(
                                 }
                                 let is_broadcast = !matches!(&msg, Message::DirectMessage { .. });
                                 let result = match &msg {
-                                    Message::DirectMessage { to, .. } => {
+                                    Message::DirectMessage { .. } => {
                                         dm_and_persist(
                                             &msg,
-                                            &username_in,
-                                            to,
                                             &state_in.host_user,
                                             &state_in.clients,
                                             &state_in.chat_path,
@@ -492,11 +483,9 @@ pub(crate) async fn handle_oneshot_send(
             }
             let is_broadcast = !matches!(&msg, Message::DirectMessage { .. });
             let seq_msg = match &msg {
-                Message::DirectMessage { to, .. } => {
+                Message::DirectMessage { .. } => {
                     dm_and_persist(
                         &msg,
-                        &username,
-                        to,
                         &state.host_user,
                         &state.clients,
                         &state.chat_path,

--- a/crates/room-cli/src/broker/ws.rs
+++ b/crates/room-cli/src/broker/ws.rs
@@ -167,16 +167,9 @@ async fn run_ws_session(
 
     // Send chat history, filtering DMs the client is not party to.
     let host_name = state.host_user.lock().await.clone();
-    let is_host = host_name.as_deref() == Some(username.as_str());
     let history = history::load(&state.chat_path).await.unwrap_or_default();
     for msg in &history {
-        let visible = match msg {
-            Message::DirectMessage { user, to, .. } => {
-                is_host || user == &username || to == &username
-            }
-            _ => true,
-        };
-        if visible {
+        if msg.is_visible_to(&username, host_name.as_deref()) {
             let line = serde_json::to_string(msg)?;
             if ws_tx.send(WsMessage::Text(line.into())).await.is_err() {
                 return Ok(());
@@ -275,11 +268,9 @@ async fn run_ws_session(
                                     continue;
                                 }
                                 let result = match &msg {
-                                    Message::DirectMessage { to, .. } => {
+                                    Message::DirectMessage { .. } => {
                                         dm_and_persist(
                                             &msg,
-                                            &username_in,
-                                            to,
                                             &state_in.host_user,
                                             &state_in.clients,
                                             &state_in.chat_path,
@@ -404,11 +395,9 @@ async fn ws_oneshot_send(
                 return Ok(());
             }
             let seq_msg = match &msg {
-                Message::DirectMessage { to, .. } => {
+                Message::DirectMessage { .. } => {
                     dm_and_persist(
                         &msg,
-                        &username,
-                        to,
                         &state.host_user,
                         &state.clients,
                         &state.chat_path,
@@ -563,11 +552,9 @@ async fn api_send(
                     .into_response();
             }
             let result = match &msg {
-                Message::DirectMessage { to, .. } => {
+                Message::DirectMessage { .. } => {
                     dm_and_persist(
                         &msg,
-                        &username,
-                        to,
                         &rs.host_user,
                         &rs.clients,
                         &rs.chat_path,
@@ -641,7 +628,6 @@ async fn api_poll(
     let rs = &state.room_state;
     let history = history::load(&rs.chat_path).await.unwrap_or_default();
     let host_name = rs.host_user.lock().await.clone();
-    let is_host = host_name.as_deref() == Some(username.as_str());
 
     // Filter messages after the `since` ID (stateless — no server-side cursor).
     let mut found_since = query.since.is_none();
@@ -654,12 +640,7 @@ async fn api_poll(
                 }
                 return false;
             }
-            match msg {
-                Message::DirectMessage { user, to, .. } => {
-                    is_host || user == &username || to == &username
-                }
-                _ => true,
-            }
+            msg.is_visible_to(&username, host_name.as_deref())
         })
         .filter_map(|msg| serde_json::to_value(&msg).ok())
         .collect();
@@ -730,16 +711,14 @@ fn apply_query_filter(
     filter: &QueryFilter,
     room_id: &str,
     username: &str,
-    is_host: bool,
+    host: Option<&str>,
 ) -> Vec<serde_json::Value> {
     let mut messages: Vec<serde_json::Value> = history
         .into_iter()
         .filter(|msg| {
             // Enforce DM privacy before running QueryFilter.
-            if let Message::DirectMessage { user, to, .. } = msg {
-                if !is_host && user != username && to != username {
-                    return false;
-                }
+            if !msg.is_visible_to(username, host) {
+                return false;
             }
             filter.matches(msg, room_id)
         })
@@ -811,8 +790,7 @@ async fn api_query(
     let rs = &state.room_state;
     let history = history::load(&rs.chat_path).await.unwrap_or_default();
     let host_name = rs.host_user.lock().await.clone();
-    let is_host = host_name.as_deref() == Some(username.as_str());
-    let messages = apply_query_filter(history, &filter, &room_id, &username, is_host);
+    let messages = apply_query_filter(history, &filter, &room_id, &username, host_name.as_deref());
 
     (
         StatusCode::OK,
@@ -997,11 +975,9 @@ async fn daemon_api_send(
                     .into_response();
             }
             let result = match &msg {
-                Message::DirectMessage { to, .. } => {
+                Message::DirectMessage { .. } => {
                     dm_and_persist(
                         &msg,
-                        &username,
-                        to,
                         &room.host_user,
                         &room.clients,
                         &room.chat_path,
@@ -1075,7 +1051,6 @@ async fn daemon_api_poll(
 
     let history = history::load(&room.chat_path).await.unwrap_or_default();
     let host_name = room.host_user.lock().await.clone();
-    let is_host = host_name.as_deref() == Some(username.as_str());
 
     let mut found_since = query.since.is_none();
     let messages: Vec<serde_json::Value> = history
@@ -1087,12 +1062,7 @@ async fn daemon_api_poll(
                 }
                 return false;
             }
-            match msg {
-                Message::DirectMessage { user, to, .. } => {
-                    is_host || user == &username || to == &username
-                }
-                _ => true,
-            }
+            msg.is_visible_to(&username, host_name.as_deref())
         })
         .filter_map(|msg| serde_json::to_value(&msg).ok())
         .collect();
@@ -1293,8 +1263,7 @@ async fn daemon_api_query(
 
     let history = history::load(&room.chat_path).await.unwrap_or_default();
     let host_name = room.host_user.lock().await.clone();
-    let is_host = host_name.as_deref() == Some(username.as_str());
-    let messages = apply_query_filter(history, &filter, &room_id, &username, is_host);
+    let messages = apply_query_filter(history, &filter, &room_id, &username, host_name.as_deref());
 
     (
         StatusCode::OK,

--- a/crates/room-protocol/src/lib.rs
+++ b/crates/room-protocol/src/lib.rs
@@ -320,6 +320,20 @@ impl Message {
         }
     }
 
+    /// Returns `true` if `viewer` is allowed to see this message.
+    ///
+    /// All non-DM variants are visible to everyone. A [`Message::DirectMessage`]
+    /// is visible only to the sender (`user`), the recipient (`to`), and the
+    /// room host (when `host == Some(viewer)`).
+    pub fn is_visible_to(&self, viewer: &str, host: Option<&str>) -> bool {
+        match self {
+            Self::DirectMessage { user, to, .. } => {
+                viewer == user || viewer == to.as_str() || host == Some(viewer)
+            }
+            _ => true,
+        }
+    }
+
     /// Assign a broker-issued sequence number to this message.
     pub fn set_seq(&mut self, seq: u64) {
         let n = Some(seq);
@@ -783,6 +797,63 @@ mod tests {
         assert_eq!(v["type"], "dm");
         assert_eq!(v["to"], "bob");
         assert_eq!(v["content"], "hi");
+    }
+
+    // ── is_visible_to tests ───────────────────────────────────────────────────
+
+    fn make_test_dm(from: &str, to: &str) -> Message {
+        Message::DirectMessage {
+            id: fixed_id(),
+            room: "r".into(),
+            user: from.into(),
+            ts: fixed_ts(),
+            seq: None,
+            to: to.into(),
+            content: "secret".into(),
+        }
+    }
+
+    #[test]
+    fn dm_visible_to_sender() {
+        let msg = make_test_dm("alice", "bob");
+        assert!(msg.is_visible_to("alice", None));
+    }
+
+    #[test]
+    fn dm_visible_to_recipient() {
+        let msg = make_test_dm("alice", "bob");
+        assert!(msg.is_visible_to("bob", None));
+    }
+
+    #[test]
+    fn dm_visible_to_host() {
+        let msg = make_test_dm("alice", "bob");
+        assert!(msg.is_visible_to("carol", Some("carol")));
+    }
+
+    #[test]
+    fn dm_hidden_from_non_participant() {
+        let msg = make_test_dm("alice", "bob");
+        assert!(!msg.is_visible_to("carol", None));
+    }
+
+    #[test]
+    fn dm_non_participant_not_elevated_by_different_host() {
+        let msg = make_test_dm("alice", "bob");
+        assert!(!msg.is_visible_to("carol", Some("dave")));
+    }
+
+    #[test]
+    fn non_dm_always_visible() {
+        let msg = make_message("r", "alice", "hello");
+        assert!(msg.is_visible_to("bob", None));
+        assert!(msg.is_visible_to("carol", Some("dave")));
+    }
+
+    #[test]
+    fn join_always_visible() {
+        let msg = make_join("r", "alice");
+        assert!(msg.is_visible_to("bob", None));
     }
 
     // ── Accessor tests ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Add `Message::is_visible_to(viewer, host)` to room-protocol and replace all 6 duplicated DM filter patterns across the broker.

## Changes

**Updated: `crates/room-protocol/src/lib.rs`**
- `Message::is_visible_to(viewer: &str, host: Option<&str>) -> bool`
  - Non-DM variants: unconditionally `true`
  - `DirectMessage`: `true` iff `viewer == sender || viewer == to || host == Some(viewer)`
- 7 unit tests covering sender, recipient, host elevation, non-participant exclusion, and non-DM pass-through

**Updated: `broker/fanout.rs`**
- `dm_and_persist()`: replaced explicit `username == sender || username == recipient || host_name == Some(username.as_str())` with `msg.is_visible_to(username, host_name)`
- Dropped now-redundant `sender` and `recipient` parameters from `dm_and_persist` signature

**Updated: `broker/mod.rs`**
- `run_interactive_session()`: history replay filter replaced with `msg.is_visible_to()`
- Two `dm_and_persist` call sites updated (removed `sender`/`to` args)

**Updated: `broker/ws.rs`**
- WS session history replay filter replaced with `msg.is_visible_to()`
- REST poll filter (single-room) replaced with `msg.is_visible_to()`
- REST poll filter (daemon multi-room) replaced with `msg.is_visible_to()`
- `apply_query_filter`: `is_host: bool` parameter replaced with `host: Option<&str>`; DM guard replaced with `msg.is_visible_to()`
- Four `dm_and_persist` call sites updated (removed `sender`/`to` args)

## Test plan

- 7 new unit tests in `room-protocol/src/lib.rs` covering all `is_visible_to` variants
- All 974 tests pass

Closes #352
