### PR TITLE
tighten cognitive-complexity to 30, extract DmRoom handler from tui::run() (#364)

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,18 +1,18 @@
 # Clippy configuration for the room workspace.
 #
-# Thresholds are currently set conservatively above the existing maximums
-# in the codebase while the sprint-9 refactor sprint resolves known violations.
-# Tighten these progressively as wave-1 and wave-2 refactor PRs (#351–#363) land:
-#
-#   cognitive-complexity: target ≤ 25 after handle_key (#354) and loop_runner land
-#   too-many-lines:       target ≤ 200 after run() / main() / dispatch() refactors
+# Tighten thresholds progressively as wave-2 refactor PRs (#357–#363) land:
+#   cognitive-complexity: target ≤ 25 once broker/commands.rs (26) and tui/mod.rs (26) are refactored
+#   too-many-lines:       target ≤ 200 once tui/mod.rs::run() and main() are split
 #   too-many-arguments:   keep at 7 (no current violations)
 
 # Flag functions whose cognitive complexity exceeds this threshold.
-# Set to 40 so that tui/input.rs::handle_key (complexity 38, assigned to #354)
-# does not break CI until bumblebee's wave-1 refactor lands.
-# Target: tighten to 25 after #354 and #363 (tui/mod.rs::run at 33) are resolved.
-cognitive-complexity-threshold = 40
+# Tightened from 40 → 30 in this PR after:
+#   - bumblebee's #354 (handle_key decomposition) and saphire's #351 (handshake extraction)
+#   - tui/mod.rs::run() DmRoom handler extracted to handle_dm_action()
+#   - loop_runner.rs::run_loop() extracted to focused helpers
+# Current maximum: broker/commands.rs::route_command (26 — wave-2 #357 target).
+# Next target: 25 after wave-2 refactors resolve broker/commands.rs.
+cognitive-complexity-threshold = 30
 
 # Flag functions with more lines than this threshold.
 # Current maximum: tui/mod.rs::run (559 lines — wave-2 refactor target).

--- a/crates/room-cli/src/tui/mod.rs
+++ b/crates/room-cli/src/tui/mod.rs
@@ -211,6 +211,93 @@ async fn open_dm_tab(
     })
 }
 
+/// Switch the active tab and sync scroll state between input and the new tab.
+fn switch_to_tab(
+    tabs: &mut [RoomTab],
+    active_tab: &mut usize,
+    input_state: &mut InputState,
+    idx: usize,
+) {
+    tabs[*active_tab].scroll_offset = input_state.scroll_offset;
+    *active_tab = idx;
+    tabs[*active_tab].unread_count = 0;
+    input_state.scroll_offset = tabs[*active_tab].scroll_offset;
+}
+
+/// Write a newline-terminated payload to a write half.
+async fn write_payload_to_tab(
+    write_half: &mut tokio::net::unix::OwnedWriteHalf,
+    payload: &str,
+) -> anyhow::Result<()> {
+    write_half
+        .write_all(format!("{payload}\n").as_bytes())
+        .await
+        .map_err(Into::into)
+}
+
+/// Parameters for opening a DM room tab. Bundles the session-scoped constants
+/// so `handle_dm_action` stays under the `too-many-arguments` threshold.
+struct DmTabConfig<'a> {
+    socket_path: &'a std::path::Path,
+    username: &'a str,
+    history_lines: usize,
+}
+
+/// Handle `Action::DmRoom` — open or reuse a DM tab and send the first message.
+///
+/// Returns `Ok(())` on success. On `Err`, the caller should set `result` and
+/// `break 'main` to exit the event loop cleanly.
+async fn handle_dm_action(
+    tabs: &mut Vec<RoomTab>,
+    active_tab: &mut usize,
+    input_state: &mut InputState,
+    cfg: &DmTabConfig<'_>,
+    target_user: String,
+    content: String,
+) -> anyhow::Result<()> {
+    let fallback = serde_json::json!({
+        "type": "dm",
+        "to": target_user,
+        "content": content
+    })
+    .to_string();
+
+    let Ok(dm_id) = room_protocol::dm_room_id(cfg.username, &target_user) else {
+        // Same user — send as intra-room DM; the broker will reject it cleanly.
+        return write_payload_to_tab(&mut tabs[*active_tab].write_half, &fallback).await;
+    };
+
+    if let Some(idx) = tabs.iter().position(|t| t.room_id == dm_id) {
+        // Tab already open — switch and send.
+        switch_to_tab(tabs, active_tab, input_state, idx);
+        return write_payload_to_tab(&mut tabs[*active_tab].write_half, &build_payload(&content))
+            .await;
+    }
+
+    // Create the DM room and open a new tab.
+    match open_dm_tab(
+        cfg.socket_path,
+        &dm_id,
+        cfg.username,
+        &target_user,
+        cfg.history_lines,
+    )
+    .await
+    {
+        Ok(new_tab) => {
+            tabs.push(new_tab);
+            tabs[*active_tab].scroll_offset = input_state.scroll_offset;
+            *active_tab = tabs.len() - 1;
+            input_state.scroll_offset = 0;
+            write_payload_to_tab(&mut tabs[*active_tab].write_half, &build_payload(&content)).await
+        }
+        Err(_) => {
+            // DM room creation failed — fall back to intra-room DM.
+            write_payload_to_tab(&mut tabs[*active_tab].write_half, &fallback).await
+        }
+    }
+}
+
 pub async fn run(
     reader: BufReader<tokio::net::unix::OwnedReadHalf>,
     write_half: tokio::net::unix::OwnedWriteHalf,
@@ -709,123 +796,46 @@ pub async fn run(
                         Some(Action::Quit) => break 'main,
                         Some(Action::NextTab) => {
                             if tabs.len() > 1 {
-                                tabs[active_tab].scroll_offset = input_state.scroll_offset;
-                                active_tab = (active_tab + 1) % tabs.len();
-                                tabs[active_tab].unread_count = 0;
-                                input_state.scroll_offset = tabs[active_tab].scroll_offset;
+                                let next = (active_tab + 1) % tabs.len();
+                                switch_to_tab(&mut tabs, &mut active_tab, &mut input_state, next);
                             }
                         }
                         Some(Action::PrevTab) => {
                             if tabs.len() > 1 {
-                                tabs[active_tab].scroll_offset = input_state.scroll_offset;
-                                active_tab = if active_tab == 0 {
+                                let prev = if active_tab == 0 {
                                     tabs.len() - 1
                                 } else {
                                     active_tab - 1
                                 };
-                                tabs[active_tab].unread_count = 0;
-                                input_state.scroll_offset = tabs[active_tab].scroll_offset;
+                                switch_to_tab(&mut tabs, &mut active_tab, &mut input_state, prev);
                             }
                         }
                         Some(Action::SwitchTab(idx)) => {
                             if idx < tabs.len() {
-                                tabs[active_tab].scroll_offset = input_state.scroll_offset;
-                                active_tab = idx;
-                                tabs[active_tab].unread_count = 0;
-                                input_state.scroll_offset = tabs[active_tab].scroll_offset;
+                                switch_to_tab(&mut tabs, &mut active_tab, &mut input_state, idx);
                             }
                         }
                         Some(Action::DmRoom {
                             target_user,
                             content,
                         }) => {
-                            match room_protocol::dm_room_id(username, &target_user) {
-                                Ok(dm_id) => {
-                                    // Check if a tab for this DM room already exists.
-                                    if let Some(idx) = tabs.iter().position(|t| t.room_id == dm_id)
-                                    {
-                                        // Switch to existing DM tab and send the message.
-                                        tabs[active_tab].scroll_offset = input_state.scroll_offset;
-                                        active_tab = idx;
-                                        tabs[active_tab].unread_count = 0;
-                                        input_state.scroll_offset = tabs[active_tab].scroll_offset;
-                                        let payload = build_payload(&content);
-                                        if let Err(e) = tabs[active_tab]
-                                            .write_half
-                                            .write_all(format!("{payload}\n").as_bytes())
-                                            .await
-                                        {
-                                            result = Err(e.into());
-                                            break 'main;
-                                        }
-                                    } else {
-                                        // Create/reuse DM room and open a new tab.
-                                        match open_dm_tab(
-                                            &socket_path,
-                                            &dm_id,
-                                            username,
-                                            &target_user,
-                                            history_lines,
-                                        )
-                                        .await
-                                        {
-                                            Ok(new_tab) => {
-                                                tabs.push(new_tab);
-                                                tabs[active_tab].scroll_offset =
-                                                    input_state.scroll_offset;
-                                                active_tab = tabs.len() - 1;
-                                                input_state.scroll_offset = 0;
-
-                                                // Send the message in the new DM tab.
-                                                let payload = build_payload(&content);
-                                                if let Err(e) = tabs[active_tab]
-                                                    .write_half
-                                                    .write_all(format!("{payload}\n").as_bytes())
-                                                    .await
-                                                {
-                                                    result = Err(e.into());
-                                                    break 'main;
-                                                }
-                                            }
-                                            Err(_) => {
-                                                // DM room creation failed — fall back to
-                                                // intra-room DM in the current tab.
-                                                let fallback = serde_json::json!({
-                                                    "type": "dm",
-                                                    "to": target_user,
-                                                    "content": content
-                                                })
-                                                .to_string();
-                                                if let Err(e) = tabs[active_tab]
-                                                    .write_half
-                                                    .write_all(format!("{fallback}\n").as_bytes())
-                                                    .await
-                                                {
-                                                    result = Err(e.into());
-                                                    break 'main;
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                                Err(_) => {
-                                    // Same user — cannot DM yourself. Send as intra-room DM
-                                    // which the broker will reject with a sensible error.
-                                    let fallback = serde_json::json!({
-                                        "type": "dm",
-                                        "to": target_user,
-                                        "content": content
-                                    })
-                                    .to_string();
-                                    if let Err(e) = tabs[active_tab]
-                                        .write_half
-                                        .write_all(format!("{fallback}\n").as_bytes())
-                                        .await
-                                    {
-                                        result = Err(e.into());
-                                        break 'main;
-                                    }
-                                }
+                            let cfg = DmTabConfig {
+                                socket_path: &socket_path,
+                                username,
+                                history_lines,
+                            };
+                            if let Err(e) = handle_dm_action(
+                                &mut tabs,
+                                &mut active_tab,
+                                &mut input_state,
+                                &cfg,
+                                target_user,
+                                content,
+                            )
+                            .await
+                            {
+                                result = Err(e);
+                                break 'main;
                             }
                         }
                         None => {}


### PR DESCRIPTION
## Summary

Follow-up to #369. After wave-1 PRs (#354, #351, #353+#360, #361) merged:

- `handle_key()` complexity dropped to < 25 (bumblebee's #354)
- `broker/` handshake duplication resolved (saphire's #351)
- Unlocks tightening the threshold further

### Changes

**`clippy.toml`**: tighten `cognitive-complexity-threshold` from 40 → 30

**`crates/room-cli/src/tui/mod.rs`**: extract from `run()` to bring complexity 33 → < 30:
- `switch_to_tab()` — reusable tab-switch helper, replaces 3 identical inline blocks
- `write_payload_to_tab()` — common write-half helper
- `DmTabConfig<'_>` — bundles session-scoped constants to keep `handle_dm_action` under 7-arg threshold
- `handle_dm_action()` — full `DmRoom` logic extracted (~90 lines removed from `run()`)

No behavior changes. `cargo clippy -- -D warnings` clean. 618 tests pass.

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (618 unit + integration tests)
- [x] `run()` complexity < 30 (verified by clippy threshold)