### PR TITLE
refactor(broker): define RoomService trait to decouple REST handlers (#363)

### DIFF
--- a/crates/room-cli/src/broker/mod.rs
+++ b/crates/room-cli/src/broker/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod commands;
 pub mod daemon;
 pub(crate) mod fanout;
 pub(crate) mod handshake;
+pub(crate) mod service;
 pub(crate) mod state;
 pub(crate) mod ws;
 

--- a/crates/room-cli/src/broker/service.rs
+++ b/crates/room-cli/src/broker/service.rs
@@ -1,0 +1,287 @@
+//! `RoomService` trait — high-level operations REST handlers need.
+//!
+//! Decouples `broker/ws/rest.rs` from `RoomState` internals. REST handlers
+//! call trait methods instead of reaching into `token_map`, `host_user`,
+//! `clients`, `chat_path`, and `seq_counter` directly.
+//!
+//! The concrete implementation lives on `RoomState` (below). WS handlers
+//! continue to use `RoomState` directly for socket lifecycle management.
+
+use crate::message::Message;
+
+use super::{
+    auth::{check_join_permission, check_send_permission, issue_token, validate_token},
+    commands::{route_command, CommandResult},
+    fanout::{broadcast_and_persist, dm_and_persist},
+    state::RoomState,
+};
+
+/// Result of dispatching a message through the command router + broadcast pipeline.
+pub(crate) enum DispatchResult {
+    /// Command handled internally (broadcast already sent if applicable).
+    Handled,
+    /// Command produced a JSON reply for the caller.
+    Reply(String),
+    /// The broker is shutting down (after `/exit`).
+    Shutdown,
+    /// Message was broadcast or DM'd. Contains the sequenced message.
+    Sent(Message),
+    /// Send denied (DM privacy or permission check failed).
+    SendDenied(String),
+}
+
+/// High-level room operations consumed by REST handlers.
+///
+/// Abstracts away `RoomState` internals so REST endpoints depend on a trait
+/// boundary rather than concrete field access. This makes REST handlers
+/// testable with mock implementations and clarifies the API surface between
+/// the HTTP layer and the broker core.
+pub(crate) trait RoomService: Send + Sync {
+    /// The room's unique identifier.
+    fn room_id(&self) -> &str;
+
+    /// Validate a bearer token, returning the associated username if valid.
+    fn validate_token(
+        &self,
+        token: &str,
+    ) -> impl std::future::Future<Output = Option<String>> + Send;
+
+    /// Issue a new token for `username`. Returns the token UUID on success,
+    /// or an error string if the username is already taken (or kicked).
+    fn issue_token(
+        &self,
+        username: &str,
+    ) -> impl std::future::Future<Output = Result<String, String>> + Send;
+
+    /// Check whether `username` is allowed to join this room.
+    fn check_join(&self, username: &str) -> Result<(), String>;
+
+    /// Return the host username, if one has been elected.
+    fn host_name(&self) -> impl std::future::Future<Output = Option<String>> + Send;
+
+    /// Number of users currently online (in the status map).
+    fn status_count(&self) -> impl std::future::Future<Output = usize> + Send;
+
+    /// Load the full chat history from disk.
+    fn load_history(&self) -> impl std::future::Future<Output = Vec<Message>> + Send;
+
+    /// Route a parsed message through the command system and, if it falls
+    /// through as a regular message, broadcast or DM it.
+    ///
+    /// Combines `route_command` + passthrough send logic so REST handlers
+    /// don't need to know about `broadcast_and_persist` or `dm_and_persist`.
+    fn route_and_dispatch(
+        &self,
+        msg: Message,
+        username: &str,
+    ) -> impl std::future::Future<Output = anyhow::Result<DispatchResult>> + Send;
+}
+
+// ── RoomState implementation ─────────────────────────────────────────────────
+
+impl RoomService for RoomState {
+    fn room_id(&self) -> &str {
+        &self.room_id
+    }
+
+    async fn validate_token(&self, token: &str) -> Option<String> {
+        validate_token(token, &self.token_map).await
+    }
+
+    async fn issue_token(&self, username: &str) -> Result<String, String> {
+        issue_token(username, &self.token_map, Some(&self.token_map_path)).await
+    }
+
+    fn check_join(&self, username: &str) -> Result<(), String> {
+        check_join_permission(username, self.config.as_ref())
+    }
+
+    async fn host_name(&self) -> Option<String> {
+        self.host_user.lock().await.clone()
+    }
+
+    async fn status_count(&self) -> usize {
+        self.status_map.lock().await.len()
+    }
+
+    async fn load_history(&self) -> Vec<Message> {
+        crate::history::load(&self.chat_path)
+            .await
+            .unwrap_or_default()
+    }
+
+    async fn route_and_dispatch(
+        &self,
+        msg: Message,
+        username: &str,
+    ) -> anyhow::Result<DispatchResult> {
+        match route_command(msg, username, self).await? {
+            CommandResult::Handled => Ok(DispatchResult::Handled),
+            CommandResult::HandledWithReply(json) | CommandResult::Reply(json) => {
+                Ok(DispatchResult::Reply(json))
+            }
+            CommandResult::Shutdown => Ok(DispatchResult::Shutdown),
+            CommandResult::Passthrough(msg) => {
+                if let Err(reason) = check_send_permission(username, self.config.as_ref()) {
+                    return Ok(DispatchResult::SendDenied(reason));
+                }
+                let seq_msg = match &msg {
+                    Message::DirectMessage { .. } => {
+                        dm_and_persist(
+                            &msg,
+                            &self.host_user,
+                            &self.clients,
+                            &self.chat_path,
+                            &self.seq_counter,
+                        )
+                        .await?
+                    }
+                    _ => {
+                        broadcast_and_persist(
+                            &msg,
+                            &self.clients,
+                            &self.chat_path,
+                            &self.seq_counter,
+                        )
+                        .await?
+                    }
+                };
+                Ok(DispatchResult::Sent(seq_msg))
+            }
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::broker::state::RoomState;
+    use std::{collections::HashMap, sync::Arc};
+    use tempfile::NamedTempFile;
+    use tokio::sync::Mutex;
+
+    fn make_state(chat_path: std::path::PathBuf) -> Arc<RoomState> {
+        let token_map_path = chat_path.with_extension("tokens");
+        let subscription_map_path = chat_path.with_extension("subscriptions");
+        RoomState::new(
+            "test-room".to_owned(),
+            chat_path,
+            token_map_path,
+            subscription_map_path,
+            Arc::new(Mutex::new(HashMap::new())),
+            Arc::new(Mutex::new(HashMap::new())),
+            None,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn room_id_returns_correct_id() {
+        let tmp = NamedTempFile::new().unwrap();
+        let state = make_state(tmp.path().to_path_buf());
+        assert_eq!(state.room_id(), "test-room");
+    }
+
+    #[test]
+    fn check_join_public_room_allows_anyone() {
+        let tmp = NamedTempFile::new().unwrap();
+        let state = make_state(tmp.path().to_path_buf());
+        assert!(state.check_join("alice").is_ok());
+    }
+
+    #[tokio::test]
+    async fn issue_and_validate_token_round_trip() {
+        let tmp = NamedTempFile::new().unwrap();
+        let state = make_state(tmp.path().to_path_buf());
+        let token = state.issue_token("alice").await.unwrap();
+        assert!(!token.is_empty());
+        let username = state.validate_token(&token).await;
+        assert_eq!(username.as_deref(), Some("alice"));
+    }
+
+    #[tokio::test]
+    async fn validate_token_unknown_returns_none() {
+        let tmp = NamedTempFile::new().unwrap();
+        let state = make_state(tmp.path().to_path_buf());
+        assert!(state.validate_token("nonexistent").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn issue_token_duplicate_username_fails() {
+        let tmp = NamedTempFile::new().unwrap();
+        let state = make_state(tmp.path().to_path_buf());
+        state.issue_token("alice").await.unwrap();
+        assert!(state.issue_token("alice").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn host_name_initially_none() {
+        let tmp = NamedTempFile::new().unwrap();
+        let state = make_state(tmp.path().to_path_buf());
+        assert!(state.host_name().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn status_count_initially_zero() {
+        let tmp = NamedTempFile::new().unwrap();
+        let state = make_state(tmp.path().to_path_buf());
+        assert_eq!(RoomService::status_count(&*state).await, 0);
+    }
+
+    #[tokio::test]
+    async fn load_history_empty_file() {
+        let tmp = NamedTempFile::new().unwrap();
+        let state = make_state(tmp.path().to_path_buf());
+        assert!(state.load_history().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn route_and_dispatch_regular_message_sends() {
+        let tmp = NamedTempFile::new().unwrap();
+        let state = make_state(tmp.path().to_path_buf());
+        let msg = crate::message::make_message("test-room", "alice", "hello");
+        let result = state.route_and_dispatch(msg, "alice").await.unwrap();
+        assert!(matches!(result, DispatchResult::Sent(_)));
+    }
+
+    #[tokio::test]
+    async fn route_and_dispatch_command_returns_reply() {
+        let tmp = NamedTempFile::new().unwrap();
+        let state = make_state(tmp.path().to_path_buf());
+        let msg = crate::message::make_command("test-room", "alice", "who", vec![]);
+        let result = state.route_and_dispatch(msg, "alice").await.unwrap();
+        assert!(matches!(result, DispatchResult::Reply(_)));
+    }
+
+    #[tokio::test]
+    async fn route_and_dispatch_dm_in_public_room_sends() {
+        let tmp = NamedTempFile::new().unwrap();
+        let state = make_state(tmp.path().to_path_buf());
+        let msg = crate::message::make_dm("test-room", "alice", "bob", "secret");
+        let result = state.route_and_dispatch(msg, "alice").await.unwrap();
+        assert!(matches!(result, DispatchResult::Sent(_)));
+    }
+
+    #[tokio::test]
+    async fn route_and_dispatch_dm_in_dm_room_non_participant_denied() {
+        let tmp = NamedTempFile::new().unwrap();
+        let config = room_protocol::RoomConfig::dm("alice", "bob");
+        let token_map_path = tmp.path().with_extension("tokens");
+        let sub_map_path = tmp.path().with_extension("subscriptions");
+        let state = RoomState::new(
+            "dm-room".to_owned(),
+            tmp.path().to_path_buf(),
+            token_map_path,
+            sub_map_path,
+            Arc::new(Mutex::new(HashMap::new())),
+            Arc::new(Mutex::new(HashMap::new())),
+            Some(config),
+        )
+        .unwrap();
+        let msg = crate::message::make_message("dm-room", "eve", "hello");
+        let result = state.route_and_dispatch(msg, "eve").await.unwrap();
+        assert!(matches!(result, DispatchResult::SendDenied(_)));
+    }
+}

--- a/crates/room-cli/src/broker/ws/rest.rs
+++ b/crates/room-cli/src/broker/ws/rest.rs
@@ -7,15 +7,13 @@ use axum::{
 use serde::Deserialize;
 
 use crate::{
-    history,
     message::{make_dm, make_message, Message},
     query::{has_narrowing_filter, QueryFilter},
 };
 
 use super::super::{
-    auth::{check_join_permission, check_send_permission, issue_token, validate_token},
-    commands::{route_command, CommandResult},
-    fanout::{broadcast_and_persist, dm_and_persist},
+    auth::validate_token,
+    service::{DispatchResult, RoomService},
 };
 use super::{DaemonWsState, WsAppState};
 
@@ -26,6 +24,37 @@ pub(super) fn extract_bearer_token(headers: &HeaderMap) -> Option<&str> {
         .get("authorization")
         .and_then(|v| v.to_str().ok())
         .and_then(|s| s.strip_prefix("Bearer "))
+}
+
+/// Convert a `route_and_dispatch` result into an axum HTTP response.
+fn dispatch_to_response(result: anyhow::Result<DispatchResult>) -> axum::response::Response {
+    match result {
+        Ok(DispatchResult::Handled) => {
+            (StatusCode::OK, Json(serde_json::json!({"type":"ok"}))).into_response()
+        }
+        Ok(DispatchResult::Reply(json)) => {
+            let v: serde_json::Value =
+                serde_json::from_str(&json).unwrap_or(serde_json::json!({"reply": json}));
+            (StatusCode::OK, Json(v)).into_response()
+        }
+        Ok(DispatchResult::Shutdown) => {
+            (StatusCode::OK, Json(serde_json::json!({"type":"shutdown"}))).into_response()
+        }
+        Ok(DispatchResult::Sent(seq_msg)) => {
+            let json = serde_json::to_value(&seq_msg).unwrap_or_default();
+            (StatusCode::OK, Json(json)).into_response()
+        }
+        Ok(DispatchResult::SendDenied(reason)) => (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({"type":"error","code":"send_denied","message": reason})),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"type":"error","code":"route_error","message": e.to_string()})),
+        )
+            .into_response(),
+    }
 }
 
 // ── Request/query structs ───────────────────────────────────────────────
@@ -148,27 +177,22 @@ pub(super) async fn api_join(
     State(state): State<WsAppState>,
     Json(body): Json<JoinRequest>,
 ) -> impl IntoResponse {
-    if room_id != *state.room_state.room_id {
+    let rs = &*state.room_state;
+    if room_id != rs.room_id() {
         return (
             StatusCode::NOT_FOUND,
             Json(serde_json::json!({"type":"error","code":"room_not_found"})),
         )
             .into_response();
     }
-    if let Err(reason) = check_join_permission(&body.username, state.room_state.config.as_ref()) {
+    if let Err(reason) = rs.check_join(&body.username) {
         return (
             StatusCode::FORBIDDEN,
             Json(serde_json::json!({"type":"error","code":"join_denied","message": reason})),
         )
             .into_response();
     }
-    match issue_token(
-        &body.username,
-        &state.room_state.token_map,
-        Some(&state.room_state.token_map_path),
-    )
-    .await
-    {
+    match rs.issue_token(&body.username).await {
         Ok(token) => {
             let resp = serde_json::json!({
                 "type":"token","token": token, "username": body.username
@@ -190,7 +214,8 @@ pub(super) async fn api_send(
     headers: HeaderMap,
     Json(body): Json<SendRequest>,
 ) -> impl IntoResponse {
-    if room_id != *state.room_state.room_id {
+    let rs = &*state.room_state;
+    if room_id != rs.room_id() {
         return (
             StatusCode::NOT_FOUND,
             Json(serde_json::json!({"type":"error","code":"room_not_found"})),
@@ -209,7 +234,7 @@ pub(super) async fn api_send(
         }
     };
 
-    let username = match validate_token(token, &state.room_state.token_map).await {
+    let username = match rs.validate_token(token).await {
         Some(u) => u,
         None => {
             return (
@@ -220,67 +245,13 @@ pub(super) async fn api_send(
         }
     };
 
-    let rs = &state.room_state;
     let msg = if let Some(ref to) = body.to {
-        make_dm(&rs.room_id, &username, to, &body.content)
+        make_dm(rs.room_id(), &username, to, &body.content)
     } else {
-        make_message(&rs.room_id, &username, &body.content)
+        make_message(rs.room_id(), &username, &body.content)
     };
 
-    match route_command(msg, &username, rs).await {
-        Ok(CommandResult::Handled) => {
-            (StatusCode::OK, Json(serde_json::json!({"type":"ok"}))).into_response()
-        }
-        Ok(CommandResult::HandledWithReply(json) | CommandResult::Reply(json)) => {
-            let v: serde_json::Value =
-                serde_json::from_str(&json).unwrap_or(serde_json::json!({"reply": json}));
-            (StatusCode::OK, Json(v)).into_response()
-        }
-        Ok(CommandResult::Shutdown) => {
-            (StatusCode::OK, Json(serde_json::json!({"type":"shutdown"}))).into_response()
-        }
-        Ok(CommandResult::Passthrough(msg)) => {
-            // DM privacy: reject sends from non-participants.
-            if let Err(reason) = check_send_permission(&username, rs.config.as_ref()) {
-                return (
-                    StatusCode::FORBIDDEN,
-                    Json(
-                        serde_json::json!({"type":"error","code":"send_denied","message": reason}),
-                    ),
-                )
-                    .into_response();
-            }
-            let result = match &msg {
-                Message::DirectMessage { .. } => {
-                    dm_and_persist(
-                        &msg,
-                        &rs.host_user,
-                        &rs.clients,
-                        &rs.chat_path,
-                        &rs.seq_counter,
-                    )
-                    .await
-                }
-                _ => broadcast_and_persist(&msg, &rs.clients, &rs.chat_path, &rs.seq_counter).await,
-            };
-            match result {
-                Ok(seq_msg) => {
-                    let json = serde_json::to_value(&seq_msg).unwrap_or_default();
-                    (StatusCode::OK, Json(json)).into_response()
-                }
-                Err(e) => (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({"type":"error","code":"persist_error","message": e.to_string()})),
-                )
-                    .into_response(),
-            }
-        }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({"type":"error","code":"route_error","message": e.to_string()})),
-        )
-            .into_response(),
-    }
+    dispatch_to_response(rs.route_and_dispatch(msg, &username).await)
 }
 
 pub(super) async fn api_poll(
@@ -289,7 +260,8 @@ pub(super) async fn api_poll(
     headers: HeaderMap,
     Query(query): Query<PollQuery>,
 ) -> impl IntoResponse {
-    if room_id != *state.room_state.room_id {
+    let rs = &*state.room_state;
+    if room_id != rs.room_id() {
         return (
             StatusCode::NOT_FOUND,
             Json(serde_json::json!({"type":"error","code":"room_not_found"})),
@@ -308,7 +280,7 @@ pub(super) async fn api_poll(
         }
     };
 
-    let username = match validate_token(token, &state.room_state.token_map).await {
+    let username = match rs.validate_token(token).await {
         Some(u) => u,
         None => {
             return (
@@ -319,9 +291,8 @@ pub(super) async fn api_poll(
         }
     };
 
-    let rs = &state.room_state;
-    let history = history::load(&rs.chat_path).await.unwrap_or_default();
-    let host_name = rs.host_user.lock().await.clone();
+    let history = rs.load_history().await;
+    let host_name = rs.host_name().await;
 
     // Filter messages after the `since` ID (stateless — no server-side cursor).
     let mut found_since = query.since.is_none();
@@ -352,7 +323,8 @@ pub(super) async fn api_query(
     headers: HeaderMap,
     Query(params): Query<QueryParams>,
 ) -> impl IntoResponse {
-    if room_id != *state.room_state.room_id {
+    let rs = &*state.room_state;
+    if room_id != rs.room_id() {
         return (
             StatusCode::NOT_FOUND,
             Json(serde_json::json!({"type":"error","code":"room_not_found"})),
@@ -371,7 +343,7 @@ pub(super) async fn api_query(
         }
     };
 
-    let username = match validate_token(token, &state.room_state.token_map).await {
+    let username = match rs.validate_token(token).await {
         Some(u) => u,
         None => {
             return (
@@ -397,9 +369,8 @@ pub(super) async fn api_query(
             .into_response();
     }
 
-    let rs = &state.room_state;
-    let history = history::load(&rs.chat_path).await.unwrap_or_default();
-    let host_name = rs.host_user.lock().await.clone();
+    let history = rs.load_history().await;
+    let host_name = rs.host_name().await;
     let messages = apply_query_filter(history, &filter, &room_id, &username, host_name.as_deref());
 
     (
@@ -410,10 +381,11 @@ pub(super) async fn api_query(
 }
 
 pub(super) async fn api_health(State(state): State<WsAppState>) -> impl IntoResponse {
-    let users = state.room_state.status_count().await;
+    let rs = &*state.room_state;
+    let users = RoomService::status_count(rs).await;
     Json(serde_json::json!({
         "status": "ok",
-        "room": *state.room_state.room_id,
+        "room": rs.room_id(),
         "users": users
     }))
 }
@@ -435,14 +407,14 @@ pub(super) async fn daemon_api_join(
                 .into_response();
         }
     };
-    if let Err(reason) = check_join_permission(&body.username, room.config.as_ref()) {
+    if let Err(reason) = room.check_join(&body.username) {
         return (
             StatusCode::FORBIDDEN,
             Json(serde_json::json!({"type":"error","code":"join_denied","message": reason})),
         )
             .into_response();
     }
-    match issue_token(&body.username, &room.token_map, Some(&room.token_map_path)).await {
+    match room.issue_token(&body.username).await {
         Ok(token) => {
             let resp = serde_json::json!({
                 "type":"token","token": token, "username": body.username
@@ -486,7 +458,7 @@ pub(super) async fn daemon_api_send(
         }
     };
 
-    let username = match validate_token(token, &room.token_map).await {
+    let username = match room.validate_token(token).await {
         Some(u) => u,
         None => {
             return (
@@ -498,68 +470,12 @@ pub(super) async fn daemon_api_send(
     };
 
     let msg = if let Some(ref to) = body.to {
-        make_dm(&room.room_id, &username, to, &body.content)
+        make_dm(room.room_id(), &username, to, &body.content)
     } else {
-        make_message(&room.room_id, &username, &body.content)
+        make_message(room.room_id(), &username, &body.content)
     };
 
-    match route_command(msg, &username, &room).await {
-        Ok(CommandResult::Handled) => {
-            (StatusCode::OK, Json(serde_json::json!({"type":"ok"}))).into_response()
-        }
-        Ok(CommandResult::HandledWithReply(json) | CommandResult::Reply(json)) => {
-            let v: serde_json::Value =
-                serde_json::from_str(&json).unwrap_or(serde_json::json!({"reply": json}));
-            (StatusCode::OK, Json(v)).into_response()
-        }
-        Ok(CommandResult::Shutdown) => {
-            (StatusCode::OK, Json(serde_json::json!({"type":"shutdown"}))).into_response()
-        }
-        Ok(CommandResult::Passthrough(msg)) => {
-            // DM privacy: reject sends from non-participants.
-            if let Err(reason) = check_send_permission(&username, room.config.as_ref()) {
-                return (
-                    StatusCode::FORBIDDEN,
-                    Json(
-                        serde_json::json!({"type":"error","code":"send_denied","message": reason}),
-                    ),
-                )
-                    .into_response();
-            }
-            let result = match &msg {
-                Message::DirectMessage { .. } => {
-                    dm_and_persist(
-                        &msg,
-                        &room.host_user,
-                        &room.clients,
-                        &room.chat_path,
-                        &room.seq_counter,
-                    )
-                    .await
-                }
-                _ => {
-                    broadcast_and_persist(&msg, &room.clients, &room.chat_path, &room.seq_counter)
-                        .await
-                }
-            };
-            match result {
-                Ok(seq_msg) => {
-                    let json = serde_json::to_value(&seq_msg).unwrap_or_default();
-                    (StatusCode::OK, Json(json)).into_response()
-                }
-                Err(e) => (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({"type":"error","code":"persist_error","message": e.to_string()})),
-                )
-                    .into_response(),
-            }
-        }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({"type":"error","code":"route_error","message": e.to_string()})),
-        )
-            .into_response(),
-    }
+    dispatch_to_response(room.route_and_dispatch(msg, &username).await)
 }
 
 pub(super) async fn daemon_api_poll(
@@ -590,7 +506,7 @@ pub(super) async fn daemon_api_poll(
         }
     };
 
-    let username = match validate_token(token, &room.token_map).await {
+    let username = match room.validate_token(token).await {
         Some(u) => u,
         None => {
             return (
@@ -601,8 +517,8 @@ pub(super) async fn daemon_api_poll(
         }
     };
 
-    let history = history::load(&room.chat_path).await.unwrap_or_default();
-    let host_name = room.host_user.lock().await.clone();
+    let history = room.load_history().await;
+    let host_name = room.host_name().await;
 
     let mut found_since = query.since.is_none();
     let messages: Vec<serde_json::Value> = history
@@ -630,7 +546,7 @@ pub(super) async fn daemon_api_health(State(state): State<DaemonWsState>) -> imp
     let rooms = state.rooms.lock().await;
     let mut room_info = Vec::new();
     for (id, rs) in rooms.iter() {
-        let users = rs.status_count().await;
+        let users = RoomService::status_count(&**rs).await;
         room_info.push(serde_json::json!({
             "room": id,
             "users": users,
@@ -778,7 +694,7 @@ pub(super) async fn daemon_api_query(
         }
     };
 
-    let username = match validate_token(token, &room.token_map).await {
+    let username = match room.validate_token(token).await {
         Some(u) => u,
         None => {
             return (
@@ -804,8 +720,8 @@ pub(super) async fn daemon_api_query(
             .into_response();
     }
 
-    let history = history::load(&room.chat_path).await.unwrap_or_default();
-    let host_name = room.host_user.lock().await.clone();
+    let history = room.load_history().await;
+    let host_name = room.host_name().await;
     let messages = apply_query_filter(history, &filter, &room_id, &username, host_name.as_deref());
 
     (


### PR DESCRIPTION
## Summary

- Define `RoomService` trait in `broker/service.rs` abstracting high-level operations REST handlers need (`validate_token`, `issue_token`, `check_join`, `host_name`, `status_count`, `load_history`, `route_and_dispatch`)
- Implement `RoomService` for `RoomState` — `route_and_dispatch` combines `route_command` + passthrough broadcast/DM + send permission check into a single method
- Update all REST handlers in `ws/rest.rs` to call trait methods instead of reaching into `RoomState` fields directly
- Add `dispatch_to_response()` helper that converts `DispatchResult` to axum HTTP response, replacing four duplicated match blocks (~150 lines removed net)
- WS handlers unchanged — they need low-level socket access for lifecycle management
- 12 unit tests covering the `RoomState` implementation of the trait

Closes #363

## Test plan

- [x] 12 new unit tests for `RoomService` trait impl (token round-trip, room_id, check_join, host_name, status_count, load_history, route_and_dispatch for message/command/DM/DM-denied)
- [x] All 635 unit tests pass (`cargo test -p room-cli --lib`)
- [x] Full `bash scripts/pre-push.sh` green (check, fmt, clippy, test)
