### PR TITLE
fix(tui): redirect stderr to log file during TUI session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1961,6 +1961,7 @@ dependencies = [
  "clap",
  "crossterm",
  "futures-util",
+ "libc",
  "ratatui",
  "regex",
  "reqwest",

--- a/crates/room-cli/Cargo.toml
+++ b/crates/room-cli/Cargo.toml
@@ -30,6 +30,7 @@ crossterm = "0.29"
 anyhow = "1"
 regex = "1"
 unicode-width = "0.2"
+libc = "0.2"
 axum = { version = "0.8.8", features = ["ws"] }
 tower-http = { version = "0.6.8", features = ["cors"] }
 futures-util = { version = "=0.3.31", features = ["sink"] }

--- a/crates/room-cli/src/tui/mod.rs
+++ b/crates/room-cli/src/tui/mod.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 use std::io;
 
+#[cfg(unix)]
+use std::os::unix::io::AsRawFd;
+
 use crossterm::{
     event::{self, DisableBracketedPaste, EnableBracketedPaste, Event},
     execute,
@@ -363,6 +366,11 @@ pub async fn run(
         msg_rx,
         write_half,
     };
+
+    // Redirect stderr to ~/.room/room.log so that eprintln! from the broker
+    // (which runs in a background task) does not corrupt the TUI alternate screen.
+    #[cfg(unix)]
+    let saved_stderr_fd = redirect_stderr_to_log();
 
     // Setup terminal
     enable_raw_mode()?;
@@ -876,7 +884,55 @@ pub async fn run(
     )?;
     terminal.show_cursor()?;
 
+    // Restore stderr so post-TUI error messages appear on the terminal.
+    #[cfg(unix)]
+    restore_stderr(saved_stderr_fd);
+
     result
+}
+
+// ── Stderr redirection ───────────────────────────────────────────────────────
+
+/// Redirect stderr (fd 2) to `~/.room/room.log` so that `eprintln!` output
+/// from the broker does not corrupt the TUI alternate screen. Returns the
+/// saved fd so it can be restored after the TUI exits.
+#[cfg(unix)]
+fn redirect_stderr_to_log() -> Option<i32> {
+    let log_path = crate::paths::room_home().join("room.log");
+
+    let file = match std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+    {
+        Ok(f) => f,
+        Err(_) => return None,
+    };
+
+    // Save the current stderr fd so we can restore it later.
+    let saved = unsafe { libc::dup(libc::STDERR_FILENO) };
+    if saved < 0 {
+        return None;
+    }
+
+    let log_fd = file.as_raw_fd();
+    if unsafe { libc::dup2(log_fd, libc::STDERR_FILENO) } < 0 {
+        unsafe { libc::close(saved) };
+        return None;
+    }
+
+    Some(saved)
+}
+
+/// Restore stderr to its original fd after leaving the TUI.
+#[cfg(unix)]
+fn restore_stderr(saved: Option<i32>) {
+    if let Some(fd) = saved {
+        unsafe {
+            libc::dup2(fd, libc::STDERR_FILENO);
+            libc::close(fd);
+        }
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Redirects stderr to ~/.room/room.log via libc::dup2 before entering TUI alternate screen
- Restores stderr after leaving TUI so post-session errors still appear on terminal
- ~50 eprintln\! calls across broker/daemon/auth/ws code were corrupting the TUI display
- No changes to eprintln call sites needed — all output captured at fd level

## Test plan
- [x] cargo check clean
- [x] cargo fmt clean
- [x] cargo clippy -- -D warnings clean
- [x] All tests pass (638 + 8 ignored)
- [ ] Manual: run room myroom joao, verify no debug output in TUI
- [ ] Verify ~/.room/room.log contains redirected broker output

Closes #387