### PR TITLE
fix(admin): revoke UserRegistry tokens on /kick and /reauth in daemon mode (#402)

### DIFF
--- a/crates/room-cli/src/broker/admin.rs
+++ b/crates/room-cli/src/broker/admin.rs
@@ -59,6 +59,13 @@ pub(crate) async fn handle_admin_cmd(
             map.retain(|_, u| u != &target);
             map.insert(format!("KICKED:{target}"), target.clone());
             drop(map);
+            // In daemon mode, also revoke from the UserRegistry so the kicked user
+            // cannot rejoin via issue_token_via_registry (which checks has_token_for_user).
+            if let Some(reg) = state.registry.get() {
+                if let Err(e) = reg.lock().await.revoke_user_tokens(&target) {
+                    eprintln!("[admin] registry revoke failed for {target}: {e}");
+                }
+            }
             // Remove from status map immediately so /who no longer shows the kicked user.
             state.remove_status(&target).await;
             let content = format!("{issuer} kicked {target} (token invalidated)");
@@ -73,6 +80,13 @@ pub(crate) async fn handle_admin_cmd(
             let mut map = token_map.lock().await;
             map.retain(|_, u| u != &target);
             drop(map);
+            // In daemon mode, also revoke from the UserRegistry so the reauthed user
+            // can obtain a fresh token via issue_token_via_registry.
+            if let Some(reg) = state.registry.get() {
+                if let Err(e) = reg.lock().await.revoke_user_tokens(&target) {
+                    eprintln!("[admin] registry revoke failed for {target}: {e}");
+                }
+            }
             // Remove the on-disk token file so the user can join afresh.
             let prefix = format!("room-{room_id}-");
             let suffix = format!("-{target}.token");
@@ -136,7 +150,7 @@ pub(crate) async fn handle_admin_cmd(
 #[cfg(test)]
 mod tests {
     use super::handle_admin_cmd;
-    use crate::broker::state::RoomState;
+    use crate::{broker::state::RoomState, registry::UserRegistry};
     use std::{collections::HashMap, sync::Arc};
     use tempfile::NamedTempFile;
     use tokio::sync::Mutex;
@@ -259,6 +273,100 @@ mod tests {
         assert!(
             *rx.borrow_and_update(),
             "shutdown signal should be true after /exit"
+        );
+    }
+
+    // ── registry-aware admin commands ─────────────────────────────────────────
+
+    fn make_state_with_registry(
+        chat_path: std::path::PathBuf,
+        registry: Arc<Mutex<UserRegistry>>,
+    ) -> Arc<RoomState> {
+        let token_map_path = chat_path.with_extension("tokens");
+        let subscription_map_path = chat_path.with_extension("subscriptions");
+        let state = RoomState::new(
+            "test-room".to_owned(),
+            chat_path,
+            token_map_path,
+            subscription_map_path,
+            Arc::new(Mutex::new(HashMap::new())),
+            Arc::new(Mutex::new(HashMap::new())),
+            None,
+        )
+        .unwrap();
+        state.set_registry(registry);
+        state
+    }
+
+    #[tokio::test]
+    async fn kick_revokes_token_from_registry_in_daemon_mode() {
+        let tmp = NamedTempFile::new().unwrap();
+        let reg_dir = tempfile::tempdir().unwrap();
+        let registry = Arc::new(Mutex::new(UserRegistry::new(reg_dir.path().to_owned())));
+
+        // Register bob and issue a token in the registry.
+        let bob_token = {
+            let mut reg = registry.lock().await;
+            reg.register_user("bob").unwrap();
+            reg.issue_token("bob").unwrap()
+        };
+
+        let state = make_state_with_registry(tmp.path().to_path_buf(), registry.clone());
+        *state.host_user.lock().await = Some("alice".to_owned());
+        state
+            .token_map
+            .lock()
+            .await
+            .insert(bob_token.clone(), "bob".to_owned());
+
+        let err = handle_admin_cmd("kick bob", "alice", &state).await;
+        assert!(err.is_none(), "kick should succeed");
+
+        // Registry token must be gone so bob cannot rejoin via issue_token_via_registry.
+        let reg = registry.lock().await;
+        assert!(
+            reg.validate_token(&bob_token).is_none(),
+            "kick must revoke bob's token from the registry"
+        );
+        assert!(
+            !reg.has_token_for_user("bob"),
+            "kick must remove all registry tokens for bob"
+        );
+    }
+
+    #[tokio::test]
+    async fn reauth_revokes_token_from_registry_in_daemon_mode() {
+        let tmp = NamedTempFile::new().unwrap();
+        let reg_dir = tempfile::tempdir().unwrap();
+        let registry = Arc::new(Mutex::new(UserRegistry::new(reg_dir.path().to_owned())));
+
+        // Register bob and issue a token in the registry.
+        let bob_token = {
+            let mut reg = registry.lock().await;
+            reg.register_user("bob").unwrap();
+            reg.issue_token("bob").unwrap()
+        };
+
+        let state = make_state_with_registry(tmp.path().to_path_buf(), registry.clone());
+        *state.host_user.lock().await = Some("alice".to_owned());
+        state
+            .token_map
+            .lock()
+            .await
+            .insert(bob_token.clone(), "bob".to_owned());
+
+        let err = handle_admin_cmd("reauth bob", "alice", &state).await;
+        assert!(err.is_none(), "reauth should succeed");
+
+        // Registry token must be gone so bob can obtain a new token on the next join.
+        let reg = registry.lock().await;
+        assert!(
+            reg.validate_token(&bob_token).is_none(),
+            "reauth must revoke bob's token from the registry"
+        );
+        assert!(
+            !reg.has_token_for_user("bob"),
+            "reauth must remove all registry tokens for bob so rejoin is unblocked"
         );
     }
 }

--- a/crates/room-cli/src/broker/daemon.rs
+++ b/crates/room-cli/src/broker/daemon.rs
@@ -265,6 +265,7 @@ impl DaemonState {
             &self.rooms,
             &self.config,
             &self.system_token_map,
+            Some(self.user_registry.clone()),
         )
         .await
     }
@@ -282,6 +283,7 @@ impl DaemonState {
             &self.rooms,
             &self.config,
             &self.system_token_map,
+            Some(self.user_registry.clone()),
         )
         .await
     }
@@ -394,6 +396,7 @@ impl DaemonState {
                 next_client_id: self.next_client_id.clone(),
                 config: self.config.clone(),
                 system_token_map: self.system_token_map.clone(),
+                user_registry: self.user_registry.clone(),
             };
             let app = ws::create_daemon_router(ws_state);
             let tcp = tokio::net::TcpListener::bind(("0.0.0.0", port)).await?;
@@ -636,12 +639,17 @@ fn build_initial_subscriptions(
 /// Validates the room ID, checks for duplicates, builds a [`RoomState`], and
 /// inserts it into the room map. Pass `config: None` to create a configless
 /// room (no invite list, no visibility constraint).
+///
+/// `registry` is attached to the [`RoomState`] via [`RoomState::set_registry`]
+/// so that admin commands (`/kick`, `/reauth`) can also revoke tokens from the
+/// daemon-level [`UserRegistry`] in addition to the in-memory token map.
 pub(crate) async fn create_room_entry(
     room_id: &str,
     config: Option<room_protocol::RoomConfig>,
     rooms: &RoomMap,
     daemon_config: &DaemonConfig,
     system_token_map: &TokenMap,
+    registry: Option<Arc<tokio::sync::Mutex<UserRegistry>>>,
 ) -> Result<(), String> {
     validate_room_id(room_id)?;
     {
@@ -674,6 +682,9 @@ pub(crate) async fn create_room_entry(
         Arc::new(Mutex::new(merged_subs)),
         config,
     )?;
+    if let Some(reg) = registry {
+        state.set_registry(reg);
+    }
 
     rooms.lock().await.insert(room_id.to_owned(), state);
 
@@ -755,6 +766,7 @@ async fn handle_create(
     rooms: &RoomMap,
     daemon_config: &DaemonConfig,
     system_token_map: &TokenMap,
+    user_registry: &Arc<tokio::sync::Mutex<UserRegistry>>,
 ) -> anyhow::Result<()> {
     use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 
@@ -861,6 +873,7 @@ async fn handle_create(
         rooms,
         daemon_config,
         system_token_map,
+        Some(user_registry.clone()),
     )
     .await
     {
@@ -922,6 +935,7 @@ async fn dispatch_connection(
                 rooms,
                 daemon_config,
                 system_token_map,
+                user_registry,
             )
             .await;
         }

--- a/crates/room-cli/src/broker/mod.rs
+++ b/crates/room-cli/src/broker/mod.rs
@@ -114,6 +114,7 @@ impl Broker {
             seq_counter: Arc::new(AtomicU64::new(0)),
             plugin_registry: Arc::new(registry),
             config: None,
+            registry: std::sync::OnceLock::new(),
         });
         let next_client_id = Arc::new(AtomicU64::new(0));
 
@@ -608,6 +609,7 @@ mod tests {
             seq_counter: Arc::new(AtomicU64::new(0)),
             plugin_registry: Arc::new(PluginRegistry::new()),
             config: None,
+            registry: std::sync::OnceLock::new(),
         })
     }
 

--- a/crates/room-cli/src/broker/state.rs
+++ b/crates/room-cli/src/broker/state.rs
@@ -7,7 +7,8 @@ use std::{
 use room_protocol::{RoomConfig, SubscriptionTier};
 use tokio::sync::{broadcast, watch, Mutex};
 
-use crate::plugin::PluginRegistry;
+use crate::{plugin::PluginRegistry, registry::UserRegistry};
+use std::sync::OnceLock;
 
 /// Maps client ID → (username, broadcast sender).
 /// Username is set after the handshake completes.
@@ -61,6 +62,14 @@ pub(crate) struct RoomState {
     /// Room visibility and access control configuration.
     /// `None` for rooms created without explicit config (backward compat).
     pub(crate) config: Option<RoomConfig>,
+    /// Daemon-level user registry for cross-room identity. Unset in
+    /// single-room mode. When set, admin commands (`/kick`, `/reauth`)
+    /// also revoke tokens from the registry so users can rejoin after reauth.
+    ///
+    /// Uses `OnceLock` so it can be set after [`RoomState::new`] without
+    /// requiring an extra constructor parameter (which would exceed the
+    /// clippy `too-many-arguments` threshold).
+    pub(crate) registry: OnceLock<Arc<Mutex<UserRegistry>>>,
 }
 
 impl RoomState {
@@ -80,6 +89,10 @@ impl RoomState {
     ///   for a fresh map or supply an existing shared map (daemon mode uses one map per daemon).
     /// - `subscription_map` — pre-populated subscription map loaded from disk (or empty).
     /// - `config` — room visibility/ACL config; `None` for legacy configless rooms.
+    ///
+    /// To attach a daemon-level [`UserRegistry`] (needed for admin commands in
+    /// daemon mode), call [`RoomState::set_registry`] on the returned `Arc`
+    /// immediately after construction — before handing it to other tasks.
     pub(crate) fn new(
         room_id: String,
         chat_path: PathBuf,
@@ -89,11 +102,11 @@ impl RoomState {
         subscription_map: SubscriptionMap,
         config: Option<RoomConfig>,
     ) -> Result<Arc<Self>, String> {
-        let mut registry = crate::plugin::PluginRegistry::new();
-        registry
+        let mut plugins = crate::plugin::PluginRegistry::new();
+        plugins
             .register(Box::new(crate::plugin::help::HelpPlugin))
             .map_err(|e| format!("plugin error: {e}"))?;
-        registry
+        plugins
             .register(Box::new(crate::plugin::stats::StatsPlugin))
             .map_err(|e| format!("plugin error: {e}"))?;
 
@@ -112,9 +125,21 @@ impl RoomState {
             room_id: Arc::new(room_id),
             shutdown: Arc::new(shutdown_tx),
             seq_counter: Arc::new(AtomicU64::new(0)),
-            plugin_registry: Arc::new(registry),
+            plugin_registry: Arc::new(plugins),
             config,
+            registry: OnceLock::new(),
         }))
+    }
+
+    // ── registry ──────────────────────────────────────────────────────────────
+
+    /// Attach the daemon-level [`UserRegistry`] to this room.
+    ///
+    /// Must be called at most once, immediately after construction, before the
+    /// `Arc<RoomState>` is shared with other tasks. Silently no-ops if called
+    /// a second time (consistent with `OnceLock` semantics).
+    pub(crate) fn set_registry(&self, registry: Arc<Mutex<UserRegistry>>) {
+        let _ = self.registry.set(registry);
     }
 
     // ── status_map accessors ──────────────────────────────────────────────────

--- a/crates/room-cli/src/broker/ws/mod.rs
+++ b/crates/room-cli/src/broker/ws/mod.rs
@@ -427,6 +427,7 @@ pub(crate) struct DaemonWsState {
     pub(crate) next_client_id: Arc<AtomicU64>,
     pub(crate) config: super::daemon::DaemonConfig,
     pub(crate) system_token_map: super::state::TokenMap,
+    pub(crate) user_registry: Arc<Mutex<crate::registry::UserRegistry>>,
 }
 
 impl DaemonWsState {

--- a/crates/room-cli/src/broker/ws/rest.rs
+++ b/crates/room-cli/src/broker/ws/rest.rs
@@ -645,6 +645,7 @@ pub(super) async fn daemon_api_create_room(
         &state.rooms,
         &state.config,
         &state.system_token_map,
+        Some(state.user_registry.clone()),
     )
     .await
     {


### PR DESCRIPTION
## Summary

- `RoomState` gains a `registry: OnceLock<Arc<Mutex<UserRegistry>>>` field; populated via `set_registry()` immediately after construction in `create_room_entry()` (daemon mode only — single-room mode leaves it unset)
- `/kick` and `/reauth` in `handle_admin_cmd` now call `registry.revoke_user_tokens(target)` when the registry is set, clearing the persistent token so `issue_token_via_registry` unblocks the next join
- `UserRegistry` reference is threaded from `DaemonState` through `create_room_entry()`, `handle_create()`, and `DaemonWsState` so every daemon-mode room gets a registry reference at construction time

## Root cause

In daemon mode, `issue_token_via_registry` calls `has_token_for_user()` before issuing a token. The old `/kick` and `/reauth` handlers only cleared the in-memory `token_map`, leaving the `UserRegistry` entry intact. After a kick or reauth, the kicked/reauthed user could not rejoin because `has_token_for_user` still returned `true`.

## Test plan

- [x] `kick_revokes_token_from_registry_in_daemon_mode` — verifies kick clears registry token
- [x] `reauth_revokes_token_from_registry_in_daemon_mode` — verifies reauth clears registry token so rejoin is unblocked
- [x] All existing admin tests pass (no regression in single-room mode)
- [x] All 1017+ Rust tests pass, clippy clean

Closes #402
