### PR TITLE
fix(oneshot): eliminate per-room token files from oneshot path

### DIFF
--- a/crates/room-cli/src/main.rs
+++ b/crates/room-cli/src/main.rs
@@ -394,7 +394,7 @@ async fn main() -> anyhow::Result<()> {
             } else if let Some(id) = room_id {
                 vec![id]
             } else if use_all {
-                let username = oneshot::username_from_token_any_room(&token)?;
+                let username = oneshot::username_from_token(&token)?;
                 let discovered = oneshot::discover_joined_rooms(&username);
                 if discovered.is_empty() {
                     anyhow::bail!(
@@ -517,7 +517,7 @@ async fn main() -> anyhow::Result<()> {
                 vec![id]
             } else {
                 // Auto-discover rooms the user has joined.
-                let username = oneshot::username_from_token_any_room(&token)?;
+                let username = oneshot::username_from_token(&token)?;
                 let discovered = oneshot::discover_joined_rooms(&username);
                 if discovered.is_empty() {
                     anyhow::bail!(
@@ -560,7 +560,7 @@ async fn main() -> anyhow::Result<()> {
                 vec![id]
             } else {
                 // Auto-discover rooms the user has joined.
-                let username = oneshot::username_from_token_any_room(&token)?;
+                let username = oneshot::username_from_token(&token)?;
                 let discovered = oneshot::discover_joined_rooms(&username);
                 if discovered.is_empty() {
                     anyhow::bail!(

--- a/crates/room-cli/src/oneshot/mod.rs
+++ b/crates/room-cli/src/oneshot/mod.rs
@@ -11,7 +11,7 @@ pub use poll::{
     pull_messages, QueryOptions,
 };
 pub use subscribe::cmd_subscribe;
-pub use token::{cmd_join, token_file_path, username_from_token, username_from_token_any_room};
+pub use token::{cmd_join, username_from_token};
 pub use transport::{create_room, destroy_room};
 pub use transport::{
     ensure_daemon_running, global_join_session, join_session, join_session_target,
@@ -78,7 +78,7 @@ pub async fn cmd_dm(
     socket: Option<&std::path::Path>,
 ) -> anyhow::Result<()> {
     // Resolve the caller's username from the token
-    let caller = username_from_token_any_room(token)?;
+    let caller = username_from_token(token)?;
 
     // Compute canonical DM room ID
     let dm_id = dm_room_id(&caller, recipient).map_err(|e| anyhow::anyhow!("{e}"))?;

--- a/crates/room-cli/src/oneshot/poll.rs
+++ b/crates/room-cli/src/oneshot/poll.rs
@@ -162,7 +162,7 @@ pub async fn pull_messages(
 /// Reads from the chat file directly (no broker connection required).
 /// Does **not** update the poll cursor.
 pub async fn cmd_pull(room_id: &str, token: &str, n: usize) -> anyhow::Result<()> {
-    let username = username_from_token(room_id, token)?;
+    let username = username_from_token(token)?;
     let meta_path = paths::room_meta_path(room_id);
     let chat_path = chat_path_from_meta(room_id, &meta_path);
 
@@ -184,7 +184,7 @@ pub async fn cmd_pull(room_id: &str, token: &str, n: usize) -> anyhow::Result<()
 /// Shares the cursor file with `room poll` — the two subcommands never re-deliver
 /// the same message.
 pub async fn cmd_watch(room_id: &str, token: &str, interval_secs: u64) -> anyhow::Result<()> {
-    let username = username_from_token(room_id, token)?;
+    let username = username_from_token(token)?;
     let meta_path = paths::room_meta_path(room_id);
     let chat_path = chat_path_from_meta(room_id, &meta_path);
     let cursor_path = paths::cursor_path(room_id, &username);
@@ -231,7 +231,7 @@ pub async fn cmd_poll(
     since: Option<String>,
     mentions_only: bool,
 ) -> anyhow::Result<()> {
-    let username = username_from_token(room_id, token)?;
+    let username = username_from_token(token)?;
     let meta_path = paths::room_meta_path(room_id);
     let chat_path = chat_path_from_meta(room_id, &meta_path);
     let cursor_path = paths::cursor_path(room_id, &username);
@@ -294,7 +294,7 @@ pub async fn cmd_poll_multi(
     mentions_only: bool,
 ) -> anyhow::Result<()> {
     // Resolve username by trying the token against each room
-    let username = resolve_username_from_rooms(room_ids, token)?;
+    let username = username_from_token(token)?;
 
     // Resolve chat paths for all rooms
     let mut rooms: Vec<(&str, PathBuf)> = Vec::new();
@@ -339,7 +339,7 @@ pub async fn cmd_query(
         anyhow::bail!("at least one room ID is required");
     }
 
-    let username = resolve_username_from_rooms(room_ids, token)?;
+    let username = username_from_token(token)?;
 
     // Resolve mention_user from caller if mentions_only is requested.
     if opts.mentions_only {
@@ -487,18 +487,6 @@ fn apply_sort_and_limit(messages: &mut Vec<Message>, filter: &QueryFilter) {
     if let Some(limit) = filter.limit {
         messages.truncate(limit);
     }
-}
-
-/// Try to resolve a username from a token by scanning token files for each room.
-///
-/// Returns the username from the first room where the token is found.
-fn resolve_username_from_rooms(room_ids: &[String], token: &str) -> anyhow::Result<String> {
-    for room_id in room_ids {
-        if let Ok(username) = username_from_token(room_id, token) {
-            return Ok(username);
-        }
-    }
-    anyhow::bail!("token not recognised in any of the specified rooms — run: room join <username>")
 }
 
 /// Read the room host username from the meta file, if present.
@@ -887,13 +875,13 @@ mod tests {
         let token_dir = TempDir::new().unwrap();
 
         let room_id = format!("test-cqh-{}", std::process::id());
-        write_token_file(&token_dir, &room_id, "alice", "tok-alice");
+        write_token_file(&token_dir, &room_id, "alice-cqh", "tok-cqh");
         write_meta_file(&room_id, chat.path());
 
         for i in 0..3u32 {
             crate::history::append(
                 chat.path(),
-                &make_message(&room_id, "alice", format!("{i}")),
+                &make_message(&room_id, "alice-cqh", format!("{i}")),
             )
             .await
             .unwrap();
@@ -913,11 +901,11 @@ mod tests {
         };
 
         // cursor should NOT advance (historical mode)
-        let cursor_path = crate::paths::cursor_path(&room_id, "alice");
+        let cursor_path = crate::paths::cursor_path(&room_id, "alice-cqh");
         let _ = std::fs::remove_file(&cursor_path);
 
         // Run cmd_query — captures stdout indirectly by ensuring cursor unchanged.
-        oneshot_cmd_query_to_vec(&[room_id.clone()], "tok-alice", filter, opts, &cursor_dir)
+        oneshot_cmd_query_to_vec(&[room_id.clone()], "tok-cqh", filter, opts, &cursor_dir)
             .await
             .unwrap();
 
@@ -928,7 +916,7 @@ mod tests {
         );
 
         let _ = std::fs::remove_file(crate::paths::room_meta_path(&room_id));
-        let _ = std::fs::remove_file(&token_path(&room_id, "alice"));
+        let _ = std::fs::remove_file(&global_token_path("alice-cqh"));
     }
 
     /// cmd_query in --new mode advances the cursor.
@@ -939,7 +927,7 @@ mod tests {
         let token_dir = TempDir::new().unwrap();
 
         let room_id = format!("test-cqn-{}", std::process::id());
-        write_token_file(&token_dir, &room_id, "alice", "tok-cqn");
+        write_token_file(&token_dir, &room_id, "alice-cqn", "tok-cqn");
         write_meta_file(&room_id, chat.path());
 
         let msg = make_message(&room_id, "bob", "hello");
@@ -981,7 +969,7 @@ mod tests {
         );
 
         let _ = std::fs::remove_file(crate::paths::room_meta_path(&room_id));
-        let _ = std::fs::remove_file(&token_path(&room_id, "alice"));
+        let _ = std::fs::remove_file(&global_token_path("alice-cqn"));
     }
 
     /// cmd_query with content_search only returns matching messages.
@@ -992,7 +980,7 @@ mod tests {
         let token_dir = TempDir::new().unwrap();
 
         let room_id = format!("test-cqs-{}", std::process::id());
-        write_token_file(&token_dir, &room_id, "alice", "tok-cqs");
+        write_token_file(&token_dir, &room_id, "alice-cqs", "tok-cqs");
         write_meta_file(&room_id, chat.path());
 
         crate::history::append(chat.path(), &make_message(&room_id, "bob", "hello world"))
@@ -1024,7 +1012,7 @@ mod tests {
         assert!(result[0].content().unwrap().contains("hello"));
 
         let _ = std::fs::remove_file(crate::paths::room_meta_path(&room_id));
-        let _ = std::fs::remove_file(&token_path(&room_id, "alice"));
+        let _ = std::fs::remove_file(&global_token_path("alice-cqs"));
     }
 
     /// cmd_query with user filter only returns messages from that user.
@@ -1035,7 +1023,7 @@ mod tests {
         let token_dir = TempDir::new().unwrap();
 
         let room_id = format!("test-cqu-{}", std::process::id());
-        write_token_file(&token_dir, &room_id, "alice", "tok-cqu");
+        write_token_file(&token_dir, &room_id, "alice-cqu", "tok-cqu");
         write_meta_file(&room_id, chat.path());
 
         crate::history::append(chat.path(), &make_message(&room_id, "alice", "from alice"))
@@ -1067,7 +1055,7 @@ mod tests {
         assert_eq!(result[0].user(), "bob");
 
         let _ = std::fs::remove_file(crate::paths::room_meta_path(&room_id));
-        let _ = std::fs::remove_file(&token_path(&room_id, "alice"));
+        let _ = std::fs::remove_file(&global_token_path("alice-cqu"));
     }
 
     /// cmd_query with limit returns only N messages.
@@ -1078,7 +1066,7 @@ mod tests {
         let token_dir = TempDir::new().unwrap();
 
         let room_id = format!("test-cql-{}", std::process::id());
-        write_token_file(&token_dir, &room_id, "alice", "tok-cql");
+        write_token_file(&token_dir, &room_id, "alice-cql", "tok-cql");
         write_meta_file(&room_id, chat.path());
 
         for i in 0..5u32 {
@@ -1111,17 +1099,17 @@ mod tests {
         assert_eq!(result.len(), 2, "limit should restrict to 2 messages");
 
         let _ = std::fs::remove_file(crate::paths::room_meta_path(&room_id));
-        let _ = std::fs::remove_file(&token_path(&room_id, "alice"));
+        let _ = std::fs::remove_file(&global_token_path("alice-cql"));
     }
 
     // ── Test helpers ──────────────────────────────────────────────────────────
 
-    fn token_path(room_id: &str, username: &str) -> PathBuf {
-        crate::paths::token_path(room_id, username)
+    fn global_token_path(username: &str) -> PathBuf {
+        crate::paths::global_token_path(username)
     }
 
-    fn write_token_file(_dir: &TempDir, room_id: &str, username: &str, token: &str) {
-        let path = token_path(room_id, username);
+    fn write_token_file(_dir: &TempDir, _room_id: &str, username: &str, token: &str) {
+        let path = global_token_path(username);
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).unwrap();
         }
@@ -1155,7 +1143,7 @@ mod tests {
             .first()
             .map(|id| {
                 // Resolve username by reading the token file for this room.
-                super::super::token::username_from_token(id, token)
+                super::super::token::username_from_token(token)
                     .ok()
                     .map(|u| {
                         let p = crate::paths::cursor_path(id, &u);
@@ -1172,7 +1160,7 @@ mod tests {
         let cursor_after = room_ids
             .first()
             .map(|id| {
-                super::super::token::username_from_token(id, token)
+                super::super::token::username_from_token(token)
                     .ok()
                     .map(|u| {
                         let p = crate::paths::cursor_path(id, &u);
@@ -1194,7 +1182,7 @@ mod tests {
                 let msgs = history::load(&chat_path).await?;
                 all.extend(msgs);
             }
-            let username = resolve_username_from_rooms(room_ids, token).unwrap_or_default();
+            let username = username_from_token(token).unwrap_or_default();
             let mut result: Vec<Message> = all
                 .into_iter()
                 .filter(|m| filter.matches(m, m.room()))
@@ -1235,12 +1223,10 @@ mod tests {
         }
     }
 
-    /// resolve_username_from_rooms finds username from the first matching room.
+    /// username_from_token returns an error for an unknown token.
     #[test]
-    fn resolve_username_finds_token_in_second_room() {
-        // This test can't easily be hermetic since resolve_username_from_rooms
-        // calls username_from_token which scans /tmp. We test the error case instead.
-        let result = resolve_username_from_rooms(&["nonexistent-room-xyz".to_owned()], "bad-token");
+    fn unknown_token_returns_error() {
+        let result = super::super::token::username_from_token("bad-token-nonexistent");
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -1341,15 +1327,15 @@ mod tests {
         let cursor_dir = TempDir::new().unwrap();
 
         let room_id = format!("test-pub-tier-{}", std::process::id());
-        write_token_file(&token_dir, &room_id, "alice", "tok-pub-tier");
+        write_token_file(&token_dir, &room_id, "alice-pub", "tok-pub-tier");
         write_meta_file(&room_id, chat.path());
 
-        // Write subscription map marking alice as Unsubscribed.
+        // Write subscription map marking alice-pub as Unsubscribed.
         let state_dir = crate::paths::room_state_dir();
         let _ = std::fs::create_dir_all(&state_dir);
         let sub_path = crate::paths::broker_subscriptions_path(&state_dir, &room_id);
         let mut map = std::collections::HashMap::new();
-        map.insert("alice".to_string(), SubscriptionTier::Unsubscribed);
+        map.insert("alice-pub".to_string(), SubscriptionTier::Unsubscribed);
         std::fs::write(&sub_path, serde_json::to_string(&map).unwrap()).unwrap();
 
         // Add a message.
@@ -1389,7 +1375,7 @@ mod tests {
 
         let _ = std::fs::remove_file(&sub_path);
         let _ = std::fs::remove_file(crate::paths::room_meta_path(&room_id));
-        let _ = std::fs::remove_file(&token_path(&room_id, "alice"));
+        let _ = std::fs::remove_file(&global_token_path("alice-pub"));
     }
 
     /// MentionsOnly tier sets mention_user filter, narrowing results to @mentions.

--- a/crates/room-cli/src/oneshot/token.rs
+++ b/crates/room-cli/src/oneshot/token.rs
@@ -3,15 +3,6 @@ use std::path::{Path, PathBuf};
 use super::transport::global_join_session;
 use crate::paths;
 
-/// Returns the canonical token file path for a given room/user pair (legacy).
-///
-/// Resolves to `~/.room/state/room-<room_id>-<username>.token`.
-/// One file per (room, user) pair — multiple agents on the same machine never
-/// overwrite each other's tokens.
-pub fn token_file_path(room_id: &str, username: &str) -> PathBuf {
-    paths::token_path(room_id, username)
-}
-
 /// One-shot join subcommand: register username globally, receive token, write token file.
 ///
 /// Writes to `~/.room/state/room-<username>.token`. The token is global —
@@ -31,50 +22,13 @@ pub async fn cmd_join(username: &str, socket: Option<&std::path::Path>) -> anyho
     Ok(())
 }
 
-/// Look up the username associated with `token` by scanning stored token files for `room_id`.
+/// Look up the username associated with `token` by scanning global token files.
 ///
-/// Checks both the global token file (`room-<username>.token`) and legacy per-room
-/// files (`room-<room_id>-<username>.token`). Used by `poll` and `watch` to resolve the
-/// cursor file path without requiring the caller to pass a username explicitly.
-pub fn username_from_token(room_id: &str, token: &str) -> anyhow::Result<String> {
+/// Scans `~/.room/state/room-<username>.token` files and returns the username
+/// whose token matches. Used by `poll`, `watch`, and `dm` to resolve the caller's
+/// identity without requiring a username argument.
+pub fn username_from_token(token: &str) -> anyhow::Result<String> {
     let state_dir = paths::room_state_dir();
-    let prefix = format!("room-{room_id}-");
-    let suffix = ".token";
-    let files: Vec<PathBuf> = std::fs::read_dir(&state_dir)
-        .map_err(|e| anyhow::anyhow!("cannot read {}: {e}", state_dir.display()))?
-        .filter_map(|e| e.ok())
-        .map(|e| e.path())
-        .filter(|p| {
-            p.file_name()
-                .and_then(|n| n.to_str())
-                .map(|n| n.starts_with(&prefix) && n.ends_with(suffix))
-                .unwrap_or(false)
-        })
-        .collect();
-
-    for path in files {
-        if let Ok(data) = std::fs::read_to_string(&path) {
-            if let Ok(v) = serde_json::from_str::<serde_json::Value>(data.trim()) {
-                if v["token"].as_str() == Some(token) {
-                    if let Some(u) = v["username"].as_str() {
-                        return Ok(u.to_owned());
-                    }
-                }
-            }
-        }
-    }
-
-    anyhow::bail!("token not recognised — run: room join <username> to get a fresh token")
-}
-
-/// Look up the username associated with `token` by scanning ALL token files in the state dir.
-///
-/// Unlike [`username_from_token`], this does not require a room_id. It scans every
-/// `room-*-*.token` file in `~/.room/state/` and returns the username from the first match.
-/// Used by `room dm` where the caller's room_id is unknown (the DM room_id depends on the
-/// caller's username, creating a chicken-and-egg problem).
-pub fn username_from_token_any_room(token: &str) -> anyhow::Result<String> {
-    let state_dir = crate::paths::room_state_dir();
     let prefix = "room-";
     let suffix = ".token";
     let files: Vec<PathBuf> = std::fs::read_dir(&state_dir)
@@ -129,111 +83,15 @@ mod tests {
     use std::fs;
     use tempfile::TempDir;
 
-    /// Write a token file into a temp dir.
-    fn write_token_file(dir: &std::path::Path, room_id: &str, username: &str, token: &str) {
-        let name = format!("room-{room_id}-{username}.token");
+    /// Write a global token file into a temp dir.
+    fn write_token_file(dir: &std::path::Path, username: &str, token: &str) {
+        let name = format!("room-{username}.token");
         let data = serde_json::json!({"username": username, "token": token});
         fs::write(dir.join(name), format!("{data}\n")).unwrap();
     }
 
     /// A version of username_from_token that scans a custom directory (for hermetic tests).
-    fn username_from_token_in(
-        dir: &std::path::Path,
-        room_id: &str,
-        token: &str,
-    ) -> anyhow::Result<String> {
-        let prefix = format!("room-{room_id}-");
-        let suffix = ".token";
-        let files: Vec<PathBuf> = fs::read_dir(dir)
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .map(|e| e.path())
-            .filter(|p| {
-                p.file_name()
-                    .and_then(|n| n.to_str())
-                    .map(|n| n.starts_with(&prefix) && n.ends_with(suffix))
-                    .unwrap_or(false)
-            })
-            .collect();
-
-        for path in files {
-            if let Ok(data) = fs::read_to_string(&path) {
-                if let Ok(v) = serde_json::from_str::<serde_json::Value>(data.trim()) {
-                    if v["token"].as_str() == Some(token) {
-                        if let Some(u) = v["username"].as_str() {
-                            return Ok(u.to_owned());
-                        }
-                    }
-                }
-            }
-        }
-        anyhow::bail!("token not recognised — run: room join <username>")
-    }
-
-    #[test]
-    fn token_file_path_is_per_user() {
-        let alice = token_file_path("myroom", "alice");
-        let bob = token_file_path("myroom", "bob");
-        assert_ne!(alice, bob);
-        assert!(alice.to_str().unwrap().contains("alice"));
-        assert!(bob.to_str().unwrap().contains("bob"));
-    }
-
-    #[test]
-    fn username_from_token_finds_correct_user() {
-        let dir = TempDir::new().unwrap();
-        write_token_file(dir.path(), "r1", "alice", "tok-alice");
-        let user = username_from_token_in(dir.path(), "r1", "tok-alice").unwrap();
-        assert_eq!(user, "alice");
-    }
-
-    #[test]
-    fn username_from_token_disambiguates_multiple_users() {
-        let dir = TempDir::new().unwrap();
-        write_token_file(dir.path(), "r2", "alice", "tok-alice");
-        write_token_file(dir.path(), "r2", "bob", "tok-bob");
-
-        assert_eq!(
-            username_from_token_in(dir.path(), "r2", "tok-alice").unwrap(),
-            "alice"
-        );
-        assert_eq!(
-            username_from_token_in(dir.path(), "r2", "tok-bob").unwrap(),
-            "bob"
-        );
-    }
-
-    #[test]
-    fn username_from_token_unknown_errors_with_join_hint() {
-        let dir = TempDir::new().unwrap();
-        let err = username_from_token_in(dir.path(), "r3", "not-a-real-token").unwrap_err();
-        assert!(
-            err.to_string().contains("room join"),
-            "expected 'room join' hint in: {err}"
-        );
-    }
-
-    #[test]
-    fn two_agents_tokens_do_not_collide() {
-        let dir = TempDir::new().unwrap();
-        write_token_file(dir.path(), "r4", "alice", "tok-alice");
-        write_token_file(dir.path(), "r4", "bob", "tok-bob");
-
-        assert_eq!(
-            username_from_token_in(dir.path(), "r4", "tok-alice").unwrap(),
-            "alice"
-        );
-        assert_eq!(
-            username_from_token_in(dir.path(), "r4", "tok-bob").unwrap(),
-            "bob"
-        );
-    }
-
-    /// A version of username_from_token_any_room that scans a custom directory.
-    fn username_from_token_any_room_in(
-        dir: &std::path::Path,
-        token: &str,
-    ) -> anyhow::Result<String> {
+    fn username_from_token_in(dir: &std::path::Path, token: &str) -> anyhow::Result<String> {
         let prefix = "room-";
         let suffix = ".token";
         let files: Vec<PathBuf> = fs::read_dir(dir)
@@ -259,63 +117,69 @@ mod tests {
                 }
             }
         }
-        anyhow::bail!("token not recognised")
+        anyhow::bail!("token not recognised — run: room join <username>")
     }
 
     #[test]
-    fn any_room_finds_token_across_rooms() {
+    fn finds_correct_user() {
         let dir = TempDir::new().unwrap();
-        write_token_file(dir.path(), "lobby", "alice", "tok-alice");
-        write_token_file(dir.path(), "dev", "alice", "tok-alice-dev");
+        write_token_file(dir.path(), "alice", "tok-alice");
+        let user = username_from_token_in(dir.path(), "tok-alice").unwrap();
+        assert_eq!(user, "alice");
+    }
+
+    #[test]
+    fn disambiguates_multiple_users() {
+        let dir = TempDir::new().unwrap();
+        write_token_file(dir.path(), "alice", "tok-alice");
+        write_token_file(dir.path(), "bob", "tok-bob");
 
         assert_eq!(
-            username_from_token_any_room_in(dir.path(), "tok-alice").unwrap(),
+            username_from_token_in(dir.path(), "tok-alice").unwrap(),
             "alice"
         );
         assert_eq!(
-            username_from_token_any_room_in(dir.path(), "tok-alice-dev").unwrap(),
-            "alice"
-        );
-    }
-
-    #[test]
-    fn any_room_unknown_token_errors() {
-        let dir = TempDir::new().unwrap();
-        write_token_file(dir.path(), "lobby", "alice", "tok-alice");
-        let err = username_from_token_any_room_in(dir.path(), "bogus").unwrap_err();
-        assert!(
-            err.to_string().contains("token not recognised"),
-            "expected error hint in: {err}"
-        );
-    }
-
-    #[test]
-    fn any_room_ignores_non_token_files() {
-        let dir = TempDir::new().unwrap();
-        // Write a non-token file that matches partially
-        fs::write(dir.path().join("room-lobby.sock"), "not a token").unwrap();
-        write_token_file(dir.path(), "lobby", "bob", "tok-bob");
-
-        assert_eq!(
-            username_from_token_any_room_in(dir.path(), "tok-bob").unwrap(),
+            username_from_token_in(dir.path(), "tok-bob").unwrap(),
             "bob"
         );
     }
 
     #[test]
-    fn any_room_same_user_different_tokens_per_room() {
+    fn unknown_token_errors_with_join_hint() {
         let dir = TempDir::new().unwrap();
-        write_token_file(dir.path(), "r1", "carol", "tok-r1");
-        write_token_file(dir.path(), "r2", "carol", "tok-r2");
+        let err = username_from_token_in(dir.path(), "not-a-real-token").unwrap_err();
+        assert!(
+            err.to_string().contains("room join"),
+            "expected 'room join' hint in: {err}"
+        );
+    }
 
-        // Both tokens resolve to carol
+    #[test]
+    fn two_agents_tokens_do_not_collide() {
+        let dir = TempDir::new().unwrap();
+        write_token_file(dir.path(), "alice", "tok-alice");
+        write_token_file(dir.path(), "bob", "tok-bob");
+
         assert_eq!(
-            username_from_token_any_room_in(dir.path(), "tok-r1").unwrap(),
-            "carol"
+            username_from_token_in(dir.path(), "tok-alice").unwrap(),
+            "alice"
         );
         assert_eq!(
-            username_from_token_any_room_in(dir.path(), "tok-r2").unwrap(),
-            "carol"
+            username_from_token_in(dir.path(), "tok-bob").unwrap(),
+            "bob"
+        );
+    }
+
+    #[test]
+    fn ignores_non_token_files() {
+        let dir = TempDir::new().unwrap();
+        // Write a non-token file that matches the prefix
+        fs::write(dir.path().join("room-lobby.sock"), "not a token").unwrap();
+        write_token_file(dir.path(), "bob", "tok-bob");
+
+        assert_eq!(
+            username_from_token_in(dir.path(), "tok-bob").unwrap(),
+            "bob"
         );
     }
 

--- a/crates/room-cli/tests/oneshot.rs
+++ b/crates/room-cli/tests/oneshot.rs
@@ -606,7 +606,7 @@ async fn pull_messages_does_not_update_cursor() {
     let (_user, token) = room_cli::oneshot::join_session(&broker.socket_path, "alice")
         .await
         .unwrap();
-    let token_path = room_cli::oneshot::token_file_path(room_id, "alice");
+    let token_path = room_cli::paths::global_token_path("alice");
     let token_data = serde_json::json!({ "username": "alice", "token": token });
     std::fs::write(&token_path, format!("{token_data}\n")).unwrap();
 


### PR DESCRIPTION
## Summary

Follow-up to #408. Eliminates all per-room token file logic from the oneshot code path.

- Removed `token_file_path`, `username_from_token_any_room`, and `resolve_username_from_rooms` — these scanned per-room token files which no longer exist after the join/subscribe decoupling
- Simplified `username_from_token` to scan only global `room-<username>.token` files
- Updated all callers in `main.rs`, `poll.rs`, and integration tests
- Fixed test race conditions: global token files share a namespace (no room_id prefix), so each test now uses a unique username

Net -150 lines. No new dependencies.

## Test plan

- [x] All existing tests pass (`cargo test`)
- [x] Pre-push checks green (`cargo check` + `cargo fmt` + `cargo clippy -- -D warnings` + `cargo test`)
- [x] poll.rs tests use unique usernames to prevent file collision

Closes #388