### PR TITLE
fix(daemon): global join tokens now work for room-level TOKEN: sends

### DIFF
--- a/crates/room-cli/src/broker/daemon.rs
+++ b/crates/room-cli/src/broker/daemon.rs
@@ -1018,7 +1018,15 @@ async fn dispatch_connection(
             return handle_oneshot_send(u, reader, write_half, &state).await;
         }
         ClientHandshake::Token(token) => {
-            return match super::auth::validate_token(&token, &state.token_map).await {
+            // Try room-level token map first, then fall back to global UserRegistry.
+            let resolved = match super::auth::validate_token(&token, &state.token_map).await {
+                Some(u) => Some(u),
+                None => {
+                    let reg = user_registry.lock().await;
+                    reg.validate_token(&token).map(|u| u.to_owned())
+                }
+            };
+            return match resolved {
                 Some(u) => handle_oneshot_send(u, reader, write_half, &state).await,
                 None => {
                     let err = serde_json::json!({"type":"error","code":"invalid_token"});

--- a/crates/room-cli/tests/daemon.rs
+++ b/crates/room-cli/tests/daemon.rs
@@ -538,3 +538,20 @@ async fn global_join_empty_username_rejected() {
     let v: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
     assert_eq!(v["type"], "error", "empty username should be rejected: {v}");
 }
+
+#[tokio::test]
+async fn global_join_token_works_for_room_send() {
+    let td = TestDaemon::start(&["lobby"]).await;
+
+    // Global join — no room specified.
+    let token = daemon_global_join(&td.socket_path, "gj-sender").await;
+
+    // Use that global token to send to "lobby" via ROOM:lobby:TOKEN:<token>.
+    let echo = daemon_send(&td.socket_path, "lobby", &token, "hello from global join").await;
+    assert_eq!(
+        echo["type"], "message",
+        "global token should work for room send: {echo}"
+    );
+    assert_eq!(echo["content"], "hello from global join");
+    assert_eq!(echo["user"], "gj-sender");
+}


### PR DESCRIPTION
## Summary

- **Bug**: Global join (`JOIN:<username>` at daemon level) registered tokens in the UserRegistry but not in each room's local token_map. Room-level `TOKEN:` validation only checked the local token_map, so global tokens were rejected with "invalid token".
- **Fix**: Added UserRegistry fallback to the UDS TOKEN: validation path in `daemon.rs`. When the room's token_map doesn't recognize a token, the daemon checks the global UserRegistry before returning an error.
- **Impact**: Fixes the primary blocker for ralph-spawned agents — they use global join but need to send to rooms via TOKEN: prefix.

Found while helping the openloco team get ralph sub-agents working.

## Test plan

- [x] New integration test: `global_join_token_works_for_room_send`
- [x] All existing tests pass (`cargo test` — 1012 tests)
- [x] Pre-push checks green

Note: WS and REST paths have the same issue but are lower priority — UDS is the primary transport for CLI `room send`.
