### PR TITLE
feat: add --isolated flag to room daemon (#398)

### DIFF
--- a/crates/room-cli/Cargo.toml
+++ b/crates/room-cli/Cargo.toml
@@ -34,6 +34,7 @@ libc = "0.2"
 axum = { version = "0.8.8", features = ["ws"] }
 tower-http = { version = "0.6.8", features = ["cors"] }
 futures-util = { version = "=0.3.31", features = ["sink"] }
+tempfile = "3"
 
 [dev-dependencies]
 reqwest = { version = "0.13.2", features = ["json"] }

--- a/crates/room-cli/src/main.rs
+++ b/crates/room-cli/src/main.rs
@@ -290,6 +290,19 @@ enum Cmd {
         /// Mutually exclusive with --grace-period.
         #[arg(long, conflicts_with = "grace_period")]
         persistent: bool,
+        /// Start an isolated daemon in a private temp directory for testing.
+        ///
+        /// When set, the daemon:
+        /// - Creates a temporary directory and uses it for all state (socket, data, tokens).
+        /// - Does NOT touch the shared PID file or well-known socket path.
+        /// - Prints connection info to stdout before starting:
+        ///   `{"socket":"/tmp/.room-isolated-XXXX/roomd.sock","pid":12345}`
+        /// - Cleans up the temp directory on exit.
+        ///
+        /// Callers pass the printed socket path via `--socket` or `ROOM_SOCKET=<path>`
+        /// to subsequent commands to target the isolated instance.
+        #[arg(long)]
+        isolated: bool,
     },
 }
 
@@ -639,14 +652,49 @@ async fn main() -> anyhow::Result<()> {
             rooms,
             grace_period,
             persistent,
+            isolated,
         }) => {
             let effective_grace = if persistent { u64::MAX } else { grace_period };
-            // Resolution order: --socket flag > ROOM_SOCKET env > platform default.
-            let effective_socket = paths::effective_socket_path(socket.as_deref());
+
+            // When --isolated: create a private temp dir for all state.
+            // `_isolated_tmp` is kept alive until run_daemon returns, then dropped
+            // (which deletes the temp directory and the socket inside it).
+            let _isolated_tmp: Option<tempfile::TempDir>;
+            let (effective_socket, effective_data, effective_state) = if isolated {
+                let tmp = tempfile::Builder::new()
+                    .prefix(".room-isolated-")
+                    .tempdir()
+                    .map_err(|e| anyhow::anyhow!("--isolated: failed to create temp dir: {e}"))?;
+                let sock = tmp.path().join("roomd.sock");
+                let data = tmp.path().join("data");
+                let state_d = tmp.path().join("state");
+                std::fs::create_dir_all(&data)?;
+                std::fs::create_dir_all(&state_d)?;
+                // Print connection info before blocking in run_daemon so the caller
+                // can read the socket path from stdout.
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "socket": sock.to_string_lossy(),
+                        "pid": std::process::id()
+                    })
+                );
+                _isolated_tmp = Some(tmp);
+                (sock, data, state_d)
+            } else {
+                _isolated_tmp = None;
+                // Resolution order: --socket flag > ROOM_SOCKET env > platform default.
+                (
+                    paths::effective_socket_path(socket.as_deref()),
+                    data_dir.unwrap_or_else(paths::room_data_dir),
+                    state_dir.unwrap_or_else(paths::room_state_dir),
+                )
+            };
+
             run_daemon(
                 effective_socket,
-                data_dir.unwrap_or_else(paths::room_data_dir),
-                state_dir.unwrap_or_else(paths::room_state_dir),
+                effective_data,
+                effective_state,
                 ws_port,
                 rooms,
                 effective_grace,

--- a/crates/room-cli/tests/ws_smoke.rs
+++ b/crates/room-cli/tests/ws_smoke.rs
@@ -29,6 +29,7 @@ use std::{
 
 use futures_util::{SinkExt, StreamExt};
 use tempfile::TempDir;
+use tokio::io::AsyncBufReadExt;
 use tokio::time::timeout;
 use tokio_tungstenite::{connect_async, tungstenite::Message as TungsteniteMsg};
 
@@ -389,4 +390,136 @@ async fn recv_json(rx: &mut WsRx) -> serde_json::Value {
         Ok(None) => panic!("WS stream ended"),
         Err(_) => panic!("timed out waiting for WS frame"),
     }
+}
+
+// ── Isolated daemon smoke tests ─────────────────────────────────────────────
+
+/// Verify that `room daemon --isolated` prints a valid JSON connection object
+/// to stdout and starts an accessible UDS socket at the reported path.
+///
+/// Ignored by default — spawns a real OS process. Run with:
+/// ```
+/// cargo test -p room-cli -- --ignored smoke_isolated_
+/// ```
+#[tokio::test]
+#[ignore = "spawns real OS processes; run explicitly with `cargo test -- --ignored`"]
+async fn smoke_isolated_daemon_prints_socket_json_and_is_reachable() {
+    let _guard = SMOKE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let bin = room_binary();
+
+    let mut child = tokio::process::Command::new(&bin)
+        .args([
+            "daemon",
+            "--isolated",
+            "--room",
+            "test-isolated",
+            "--grace-period",
+            "0",
+        ])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .unwrap_or_else(|e| panic!("failed to spawn room daemon at {}: {e}", bin.display()));
+
+    // Read the first stdout line — it must be the connection JSON.
+    let stdout = child.stdout.take().expect("stdout not piped");
+    let mut reader = tokio::io::BufReader::new(stdout);
+    let mut line = String::new();
+    timeout(Duration::from_secs(10), reader.read_line(&mut line))
+        .await
+        .expect("timed out waiting for isolated daemon stdout")
+        .expect("I/O error reading stdout");
+
+    let info: serde_json::Value =
+        serde_json::from_str(line.trim()).expect("isolated daemon stdout is not valid JSON");
+
+    let socket_path = info["socket"]
+        .as_str()
+        .expect("connection JSON missing 'socket' field");
+    let pid = info["pid"]
+        .as_u64()
+        .expect("connection JSON missing 'pid' field");
+
+    assert!(!socket_path.is_empty(), "socket path must not be empty");
+    assert!(pid > 0, "pid must be a positive integer");
+
+    // The socket must appear on disk.
+    let sock = std::path::PathBuf::from(socket_path);
+    common::wait_for_socket(&sock, Duration::from_secs(10)).await;
+
+    // Connect to the isolated daemon and create a room — verifies the socket is functional.
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+    let mut stream = tokio::net::UnixStream::connect(&sock)
+        .await
+        .expect("failed to connect to isolated daemon socket");
+    stream
+        .write_all(b"CREATE:test-isolated\n{\"visibility\":\"public\"}\n")
+        .await
+        .expect("failed to write CREATE command");
+    let mut reader2 = tokio::io::BufReader::new(&mut stream);
+    let mut resp = String::new();
+    timeout(Duration::from_secs(5), reader2.read_line(&mut resp))
+        .await
+        .expect("timed out reading daemon response")
+        .expect("I/O error reading daemon response");
+    // Accept either "already exists" (room was pre-created via --room) or "created".
+    assert!(
+        resp.contains("created") || resp.contains("exists") || resp.contains("ok"),
+        "unexpected daemon response: {resp:?}"
+    );
+
+    child.kill().await.ok();
+}
+
+/// Verify that `room daemon --isolated` does not write to the shared PID file
+/// or well-known socket path.
+#[tokio::test]
+#[ignore = "spawns real OS processes; run explicitly with `cargo test -- --ignored`"]
+async fn smoke_isolated_daemon_does_not_touch_shared_paths() {
+    let _guard = SMOKE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let bin = room_binary();
+
+    let shared_socket = room_cli::paths::room_socket_path();
+    let shared_pid = room_cli::paths::room_pid_path();
+
+    // Record pre-test state.
+    let socket_existed_before = shared_socket.exists();
+    let pid_existed_before = shared_pid.exists();
+
+    let mut child = tokio::process::Command::new(&bin)
+        .args(["daemon", "--isolated", "--grace-period", "0"])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .kill_on_drop(true)
+        .spawn()
+        .unwrap_or_else(|e| panic!("failed to spawn room daemon at {}: {e}", bin.display()));
+
+    // Read the JSON line to confirm daemon started.
+    let stdout = child.stdout.take().unwrap();
+    let mut reader = tokio::io::BufReader::new(stdout);
+    let mut line = String::new();
+    timeout(Duration::from_secs(10), reader.read_line(&mut line))
+        .await
+        .expect("timed out")
+        .unwrap();
+    let info: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+    let sock = std::path::PathBuf::from(info["socket"].as_str().unwrap());
+    common::wait_for_socket(&sock, Duration::from_secs(10)).await;
+
+    // Shared socket and PID file must not have been created by the isolated daemon.
+    assert_eq!(
+        shared_socket.exists(),
+        socket_existed_before,
+        "isolated daemon must not create/modify the shared socket"
+    );
+    assert_eq!(
+        shared_pid.exists(),
+        pid_existed_before,
+        "isolated daemon must not create/modify the shared PID file"
+    );
+
+    child.kill().await.ok();
 }


### PR DESCRIPTION
## Summary

- Adds `--isolated` flag to `room daemon`
- When set, creates a private temp directory for all state (socket, data, tokens)
- Does not touch the shared PID file or well-known socket path
- Prints connection info to stdout before blocking: `{"socket":"...","pid":...}`
- Temp directory is cleaned up automatically on exit
- Callers use `--socket <path>` or `ROOM_SOCKET=<path>` to target the instance

## Files changed

- `crates/room-cli/Cargo.toml` — `tempfile` promoted from dev-dep to regular dep
- `crates/room-cli/src/main.rs` — `--isolated` flag added to `Cmd::Daemon`, path isolation logic
- `crates/room-cli/tests/ws_smoke.rs` — 2 new `#[ignore]` smoke tests

## Tests

Two `#[ignore]` smoke tests added to `tests/ws_smoke.rs`:
- `smoke_isolated_daemon_prints_socket_json_and_is_reachable` — verifies JSON output format and that the socket is functional
- `smoke_isolated_daemon_does_not_touch_shared_paths` — verifies shared PID file and socket are not modified

Run with: `cargo test -p room-cli -- --ignored smoke_isolated_`

Closes #398