### PR TITLE
fix(broker): WS/REST token validation fallback to UserRegistry

### DIFF
--- a/crates/room-cli/src/broker/mod.rs
+++ b/crates/room-cli/src/broker/mod.rs
@@ -123,6 +123,7 @@ impl Broker {
             let ws_state = ws::WsAppState {
                 room_state: state.clone(),
                 next_client_id: next_client_id.clone(),
+                user_registry: None,
             };
             let app = ws::create_router(ws_state);
             let tcp = tokio::net::TcpListener::bind(("0.0.0.0", port)).await?;

--- a/crates/room-cli/src/broker/ws/mod.rs
+++ b/crates/room-cli/src/broker/ws/mod.rs
@@ -35,6 +35,8 @@ pub(crate) mod rest;
 pub(crate) struct WsAppState {
     pub(crate) room_state: Arc<RoomState>,
     pub(crate) next_client_id: Arc<AtomicU64>,
+    /// Global user registry for daemon mode. `None` in single-room mode.
+    pub(crate) user_registry: Option<Arc<Mutex<crate::registry::UserRegistry>>>,
 }
 
 /// Build the axum router with WebSocket and REST routes.
@@ -70,6 +72,7 @@ async fn ws_upgrade_handler(
 
 async fn handle_ws_client(ws: WebSocket, app_state: WsAppState) -> anyhow::Result<()> {
     let state = app_state.room_state.clone();
+    let registry = app_state.user_registry.clone();
     let cid = app_state.next_client_id.fetch_add(1, Ordering::SeqCst) + 1;
 
     let (tx, _) = broadcast::channel::<String>(256);
@@ -79,7 +82,7 @@ async fn handle_ws_client(ws: WebSocket, app_state: WsAppState) -> anyhow::Resul
         .await
         .insert(cid, (String::new(), tx.clone()));
 
-    let result = run_ws_session(cid, ws, tx, &state).await;
+    let result = run_ws_session(cid, ws, tx, &state, registry.as_ref()).await;
     state.clients.lock().await.remove(&cid);
     result
 }
@@ -89,6 +92,7 @@ async fn run_ws_session(
     ws: WebSocket,
     own_tx: broadcast::Sender<String>,
     state: &Arc<RoomState>,
+    user_registry: Option<&Arc<Mutex<crate::registry::UserRegistry>>>,
 ) -> anyhow::Result<()> {
     let (mut ws_tx, mut ws_rx) = ws.split();
 
@@ -109,7 +113,21 @@ async fn run_ws_session(
             return ws_oneshot_send(u, &mut ws_rx, &mut ws_tx, state).await;
         }
         ClientHandshake::Token(token) => {
-            return match validate_token(&token, &state.token_map).await {
+            // Try room-level token map first, then fall back to global UserRegistry.
+            let resolved = match validate_token(&token, &state.token_map).await {
+                Some(u) => Some(u),
+                None => {
+                    if let Some(reg) = user_registry {
+                        reg.lock()
+                            .await
+                            .validate_token(&token)
+                            .map(|u| u.to_owned())
+                    } else {
+                        None
+                    }
+                }
+            };
+            return match resolved {
                 Some(u) => ws_oneshot_send(u, &mut ws_rx, &mut ws_tx, state).await,
                 None => {
                     let err = serde_json::json!({"type":"error","code":"invalid_token"});
@@ -466,10 +484,12 @@ async fn daemon_ws_upgrade(
     };
 
     let next_id = state.next_client_id.clone();
+    let registry = Some(state.user_registry.clone());
     ws.on_upgrade(move |socket| async move {
         let app_state = WsAppState {
             room_state: room,
             next_client_id: next_id,
+            user_registry: registry,
         };
         if let Err(e) = handle_ws_client(socket, app_state).await {
             eprintln!("[daemon/ws] error: {e:#}");

--- a/crates/room-cli/src/broker/ws/rest.rs
+++ b/crates/room-cli/src/broker/ws/rest.rs
@@ -14,6 +14,7 @@ use crate::{
 use super::super::{
     auth::validate_token,
     service::{DispatchResult, RoomService},
+    state::RoomState,
 };
 use super::{DaemonWsState, WsAppState};
 
@@ -390,6 +391,23 @@ pub(super) async fn api_health(State(state): State<WsAppState>) -> impl IntoResp
     }))
 }
 
+// ── Daemon helpers ──────────────────────────────────────────────────────
+
+/// Validate a bearer token against the room's local token map first, then fall
+/// back to the global [`UserRegistry`] (daemon mode). This mirrors the UDS
+/// `TOKEN:` fallback added in #415.
+async fn daemon_validate_token(
+    token: &str,
+    room: &RoomState,
+    state: &DaemonWsState,
+) -> Option<String> {
+    if let Some(u) = room.validate_token(token).await {
+        return Some(u);
+    }
+    let reg = state.user_registry.lock().await;
+    reg.validate_token(token).map(|u| u.to_owned())
+}
+
 // ── Daemon REST endpoints ────────────────────────────────────────────────
 
 pub(super) async fn daemon_api_join(
@@ -458,7 +476,7 @@ pub(super) async fn daemon_api_send(
         }
     };
 
-    let username = match room.validate_token(token).await {
+    let username = match daemon_validate_token(token, &room, &state).await {
         Some(u) => u,
         None => {
             return (
@@ -506,7 +524,7 @@ pub(super) async fn daemon_api_poll(
         }
     };
 
-    let username = match room.validate_token(token).await {
+    let username = match daemon_validate_token(token, &room, &state).await {
         Some(u) => u,
         None => {
             return (
@@ -695,7 +713,7 @@ pub(super) async fn daemon_api_query(
         }
     };
 
-    let username = match room.validate_token(token).await {
+    let username = match daemon_validate_token(token, &room, &state).await {
         Some(u) => u,
         None => {
             return (

--- a/crates/room-cli/tests/daemon.rs
+++ b/crates/room-cli/tests/daemon.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use common::{
     daemon_connect, daemon_create, daemon_global_join, daemon_join, daemon_send, ws_connect,
-    TestBroker, TestClient, TestDaemon,
+    ws_recv_json, TestDaemon,
 };
 use futures_util::{SinkExt, StreamExt};
 use room_cli::message::Message;
@@ -554,4 +554,102 @@ async fn global_join_token_works_for_room_send() {
     );
     assert_eq!(echo["content"], "hello from global join");
     assert_eq!(echo["user"], "gj-sender");
+}
+
+// ── Global token fallback via WS and REST (#416) ─────────────────────────────
+
+#[tokio::test]
+async fn global_token_works_for_ws_oneshot_send() {
+    let (td, port) = TestDaemon::start_with_ws_configs(vec![("ws-lobby", None)]).await;
+
+    // Get a global token via UDS.
+    let token = daemon_global_join(&td.socket_path, "ws-gj").await;
+
+    // Use TOKEN: handshake over WS with the global token.
+    let first_frame = format!("TOKEN:{token}");
+    let (mut tx, mut rx) = ws_connect(port, "ws-lobby", &first_frame).await;
+
+    tx.send(TungsteniteMsg::Text("ws global token msg".into()))
+        .await
+        .unwrap();
+
+    let echo = ws_recv_json(&mut rx).await;
+    assert_eq!(
+        echo["type"], "message",
+        "WS global token send failed: {echo}"
+    );
+    assert_eq!(echo["content"], "ws global token msg");
+    assert_eq!(echo["user"], "ws-gj");
+}
+
+#[tokio::test]
+async fn global_token_works_for_rest_send() {
+    let (td, port) = TestDaemon::start_with_ws_configs(vec![("rest-lobby", None)]).await;
+
+    let token = daemon_global_join(&td.socket_path, "rest-gj").await;
+    let base = format!("http://127.0.0.1:{port}");
+    let client = reqwest::Client::new();
+
+    // Send via REST using the global token.
+    let echo = rest_send(&client, &base, "rest-lobby", &token, "rest global msg").await;
+    assert_eq!(
+        echo["type"], "message",
+        "REST global token send failed: {echo}"
+    );
+    assert_eq!(echo["content"], "rest global msg");
+    assert_eq!(echo["user"], "rest-gj");
+}
+
+#[tokio::test]
+async fn global_token_works_for_rest_poll() {
+    let (td, port) = TestDaemon::start_with_ws_configs(vec![("poll-lobby", None)]).await;
+
+    let token = daemon_global_join(&td.socket_path, "poll-gj").await;
+    let base = format!("http://127.0.0.1:{port}");
+    let client = reqwest::Client::new();
+
+    // Send a message first so there's something to poll.
+    rest_send(&client, &base, "poll-lobby", &token, "poll test msg").await;
+
+    // Poll via REST using the global token.
+    let resp = client
+        .get(format!("{base}/api/poll-lobby/poll"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "REST poll with global token failed");
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let messages = body["messages"].as_array().unwrap();
+    assert!(
+        messages.iter().any(|m| m["content"] == "poll test msg"),
+        "poll should contain the sent message: {body}"
+    );
+}
+
+#[tokio::test]
+async fn global_token_works_for_rest_query() {
+    let (td, port) = TestDaemon::start_with_ws_configs(vec![("query-lobby", None)]).await;
+
+    let token = daemon_global_join(&td.socket_path, "query-gj").await;
+    let base = format!("http://127.0.0.1:{port}");
+    let client = reqwest::Client::new();
+
+    // Send a message first so there's something to query.
+    rest_send(&client, &base, "query-lobby", &token, "query test msg").await;
+
+    // Query via REST using the global token.
+    let resp = client
+        .get(format!("{base}/api/query-lobby/query?user=query-gj"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "REST query with global token failed");
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let messages = body["messages"].as_array().unwrap();
+    assert!(
+        messages.iter().any(|m| m["content"] == "query test msg"),
+        "query should contain the sent message: {body}"
+    );
 }


### PR DESCRIPTION
## Summary

- Add UserRegistry fallback to WS `TOKEN:` handshake validation (`ws/mod.rs`)
- Add UserRegistry fallback to daemon REST Bearer token validation in `daemon_api_send`, `daemon_api_poll`, and `daemon_api_query` (`ws/rest.rs`)
- Extract `daemon_validate_token` helper to DRY the fallback pattern across 3 REST handlers
- Pass optional `user_registry` through `WsAppState` (None in single-room mode, Some in daemon mode)
- 4 new integration tests: WS oneshot send, REST send, REST poll, REST query with global tokens

Same pattern as UDS fix in #415 — global join tokens issued via UserRegistry are now recognized across all transports.

Closes #416

## Test plan

- [x] `global_token_works_for_ws_oneshot_send` — global token via WS TOKEN: handshake
- [x] `global_token_works_for_rest_send` — global token via REST /api/{room}/send
- [x] `global_token_works_for_rest_poll` — global token via REST /api/{room}/poll
- [x] `global_token_works_for_rest_query` — global token via REST /api/{room}/query
- [x] All 1009 tests pass, clippy clean, fmt clean