### PR TITLE
docs: update stale references after global token migration

### DIFF
--- a/crates/room-cli/CHANGELOG.md
+++ b/crates/room-cli/CHANGELOG.md
@@ -10,6 +10,51 @@ For changes prior to the workspace restructure (v0.1.2 through v1.0.2), see the
 
 ## [Unreleased]
 
+## [3.0.0-rc.6] - 2026-03-09
+
+### Fixed
+
+- Admin `/kick` and `/reauth` now revoke `UserRegistry` tokens in daemon mode,
+  unblocking the user for `room join` after a kick/reauth. (#402)
+- `discover_joined_rooms` now checks subscription state instead of stale
+  per-room token files. (#412, #413)
+- Global join tokens (from `room join <username>`) now validate correctly for
+  room-level `TOKEN:` sends. (#414, #415)
+- WS/REST `Bearer` token validation falls back to `UserRegistry` for global
+  tokens. (#416, #418)
+
+### Added
+
+- `room daemon --isolated` flag: spawns a daemon with a private temp dir for
+  tests, prints socket path to stdout, and cleans up on exit. (#398, #417)
+
+## [3.0.0-rc.5] - 2026-03-09
+
+### Changed
+
+- `room join` no longer takes a room-id argument. It now issues a **global**
+  token (`room join <username>`) tied to the user, not to a specific room.
+  Use `room subscribe <room-id>` to subscribe to rooms after joining. (#388)
+
+### Fixed
+
+- Per-room token file cleanup: removed stale `token_file_path` and related
+  functions from the oneshot code path. (#411)
+
+### Added
+
+- TUI: inline markdown rendering — `**bold**`, `*italic*`, `` `code` ``, and
+  `- list items` rendered with terminal attributes. (#405, #410)
+- TUI: subscription tier indicators in the member status panel. (#399, #404)
+
+## [3.0.0-rc.3] - 2026-03-09
+
+### Fixed
+
+- Ralph username crash when joining rooms with long or special-character names. (#400, #403)
+- DM host visibility — `is_visible_to()` now checks host membership for DM
+  rooms so the host can see all DMs in their room. (#394, #407)
+
 ### Added
 
 - `/claim`, `/unclaim`, `/claimed` built-in commands for task coordination. (#182)
@@ -25,6 +70,25 @@ For changes prior to the workspace restructure (v0.1.2 through v1.0.2), see the
 
 - WS smoke tests clean up stale `.tokens` files from previous runs. (#184)
 - Serialized WS smoke test execution to prevent disk I/O contention. (#184)
+
+## [3.0.0-rc.1] - 2026-03-08
+
+### Added
+
+- Multi-room daemon (`room daemon`) with shared UDS socket and optional
+  WebSocket. (#251, #261)
+- Room visibility and ACLs — public, private, unlisted, and DM types with
+  invite lists and `is_visible_to()` checks. (#253, #263)
+- WebSocket + REST transport (`--ws-port`): `JOIN`, `TOKEN`, `SEND` handshakes,
+  full REST API (`/api/<room>/join`, `/send`, `/poll`, `/query`). (#254)
+- `room create` / `room destroy` subcommands for daemon room lifecycle. (#264)
+- `room list` subcommand — lists known rooms and their metadata. (#264)
+- `--socket` flag on `join`, `send`, `who`, `poll`, `watch`, `dm`. (#308)
+- `RoomService` trait for dependency-injected REST handlers. (#363)
+- Comprehensive integration test split: auth, broker, daemon, oneshot,
+  rest\_query, room\_lifecycle, scripted, ws. (#355)
+- `clippy.toml` enforcing cognitive-complexity ≤ 30, too-many-lines ≤ 600,
+  too-many-arguments ≤ 7. (#364)
 
 ## [2.1.0-rc.2] - 2026-03-08
 
@@ -65,6 +129,12 @@ For changes prior to the workspace restructure (v0.1.2 through v1.0.2), see the
   plugin system (`/help`, `/stats`), admin commands, DMs, agent mode.
 - 312 tests (236 unit + 71 integration + 5 smoke).
 
-[Unreleased]: https://github.com/knoxio/room/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/knoxio/room/compare/v3.0.0-rc.6...HEAD
+[3.0.0-rc.6]: https://github.com/knoxio/room/compare/v3.0.0-rc.5...v3.0.0-rc.6
+[3.0.0-rc.5]: https://github.com/knoxio/room/compare/v3.0.0-rc.3...v3.0.0-rc.5
+[3.0.0-rc.3]: https://github.com/knoxio/room/compare/v3.0.0-rc.1...v3.0.0-rc.3
+[3.0.0-rc.1]: https://github.com/knoxio/room/compare/v2.1.0-rc.2...v3.0.0-rc.1
+[2.1.0-rc.2]: https://github.com/knoxio/room/compare/v2.1.0-rc.1...v2.1.0-rc.2
+[2.1.0-rc.1]: https://github.com/knoxio/room/compare/v2.0.1...v2.1.0-rc.1
 [2.0.1]: https://github.com/knoxio/room/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/knoxio/room/releases/tag/v2.0.0

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -96,10 +96,12 @@ However, tokens are invalidated in these cases:
 - The host runs `/kick <user>` — that user's token is revoked at runtime.
 - The `.tokens` file is manually deleted.
 
-**Note:** `/kick` and `/clear-tokens` revoke tokens in the running broker but do not
-currently update the `.tokens` file on disk. If the broker restarts after a `/kick`,
-the kicked user's token will be restored from the file. Delete the `.tokens` file
-manually to make the revocation permanent.
+**Note on daemon mode:** In daemon mode, `/kick` and `/reauth` also revoke the
+user's entry in the `UserRegistry`, so the user cannot rejoin until `/reauth`
+is run. In single-room mode, token revocation is in-memory only; if the broker
+restarts after a `/kick`, the kicked user's token may be restored from the
+`.tokens` file. Delete the `.tokens` file manually to make the revocation
+permanent in single-room mode.
 
 For agents that run across sessions, re-join only if authentication fails:
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -8,7 +8,7 @@ For users running `room` in production or custom environments.
 |---|---|---|
 | Broker socket | `/tmp/room-<id>.sock` | Fixed (derived from room ID) |
 | Chat history | `/tmp/<id>.chat` | `-f <path>` flag when starting a new room |
-| Session tokens | `/tmp/room-<id>-<username>.token` | Fixed |
+| Session tokens | `~/.room/state/room-<username>.token` | Fixed (global, not per-room) |
 | Poll cursor | `/tmp/room-<id>-<username>.cursor` | Fixed |
 
 ## Changing the chat file path

--- a/docs/permission-prompts.md
+++ b/docs/permission-prompts.md
@@ -30,7 +30,7 @@ The `"` character inside a Bash tool call triggers the check. Use single-quoted 
 
 ```bash
 # Triggers a prompt
-TOKEN=$(cat /tmp/room-myroom-ba.token | grep ...)
+TOKEN=$(cat ~/.room/state/room-ba.token | grep ...)
 gh pr merge $(gh pr list ...)
 ```
 
@@ -122,7 +122,7 @@ This keeps all dynamic content, quoting, and redirections inside the script file
 ```bash
 #!/usr/bin/env bash
 set -euo pipefail
-TOKEN=$(python3 -c "import json; print(json.load(open('/tmp/room-myroom-ba.token'))['token'])")
+TOKEN=$(python3 -c "import json; print(json.load(open('/Users/me/.room/state/room-ba.token'))['token'])")
 room poll -t "$TOKEN" myroom > /tmp/msgs.txt
 grep -v '"user":"ba"' /tmp/msgs.txt | grep '"type":"message"'
 ```
@@ -138,7 +138,7 @@ Reading a token from the JSON file written by `room join`:
 ```bash
 # Write tool → /tmp/read_token.py
 import json, sys
-print(json.load(open('/tmp/room-myroom-ba.token'))['token'])
+print(json.load(open('/Users/me/.room/state/room-ba.token'))['token'])
 ```
 
 Then in Bash: `python3 /tmp/read_token.py`
@@ -146,7 +146,7 @@ Then in Bash: `python3 /tmp/read_token.py`
 Or use the grep approach inside a script (not inline):
 
 ```bash
-grep -o '"token":"[^"]*"' /tmp/room-myroom-ba.token | cut -d'"' -f4
+grep -o '"token":"[^"]*"' ~/.room/state/room-ba.token | cut -d'"' -f4
 ```
 
 ---

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -68,24 +68,30 @@ For scripts or AI agents that need to send and poll without a persistent connect
 ### 1. Register a session token (once per broker lifetime)
 
 ```bash
-room join myroom bot
+room join bot
 # {"type":"token","token":"<uuid>","username":"bot"}
 ```
 
-The token is written to `/tmp/room-myroom-bot.token` for reference. Save it to a variable — you must pass it explicitly with `-t` on every subsequent command:
+The token is also written to `~/.room/state/room-bot.token`. Save it to a variable — you must pass it explicitly with `-t` on every subsequent command:
 
 ```bash
-TOKEN=$(room join myroom bot | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])')
+TOKEN=$(room join bot | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])')
 ```
 
-### 2. Send a message
+### 2. Subscribe to a room
 
 ```bash
-room send myroom -t "$TOKEN" hello from a script
+room subscribe myroom -t "$TOKEN"
+```
+
+### 3. Send a message
+
+```bash
+room send myroom -t "$TOKEN" "hello from a script"
 # {"type":"message","id":"...","room":"myroom","user":"bot","ts":"...","content":"hello from a script","seq":1}
 ```
 
-### 3. Poll for new messages
+### 4. Poll for new messages
 
 ```bash
 # Poll a specific room
@@ -97,7 +103,7 @@ room poll -t "$TOKEN"
 
 A cursor file at `~/.room/state/room-myroom-bot.cursor` tracks your position. Each `poll` call returns only messages since the last cursor. Delete the file to reset to the beginning of history.
 
-### 4. Watch (block until a message arrives)
+### 5. Watch (block until a message arrives)
 
 ```bash
 # Watch all subscribed rooms
@@ -107,7 +113,7 @@ room watch -t "$TOKEN"
 room watch myroom -t "$TOKEN"
 ```
 
-### 5. Query with filters
+### 6. Query with filters
 
 ```bash
 # Search messages containing "bug" from alice

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -103,7 +103,7 @@ room pull <room-id> --token "$TOKEN" -n 200
 
 **Symptom:** `room poll` returns messages you've already processed.
 
-**Cause:** The cursor file (`/tmp/room-<room-id>-<username>.cursor`) was
+**Cause:** The cursor file (`~/.room/state/room-<room-id>-<username>.cursor`) was
 deleted, overwritten, or your username changed.
 
 **Fix:** Let the cursor advance naturally (each `poll` call updates it), or
@@ -112,7 +112,7 @@ use `--since <message-id>` to manually set the starting point for one call.
 To reset the cursor intentionally (re-read all history):
 
 ```bash
-rm /tmp/room-<room-id>-<username>.cursor
+rm ~/.room/state/room-<room-id>-<username>.cursor
 ```
 
 ---

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "room",
-  "version": "3.0.0-rc.2",
+  "version": "3.0.0-rc.6",
   "description": "Multi-agent and human-AI coordination via the room CLI. Teaches Claude when to announce intent, poll for messages, and follow the coordination protocol in projects that use room for parallel agent work.",
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary

- `docs/quick-start.md`: update join syntax (`room join bot`, not `room join myroom bot`), add `room subscribe myroom` step, fix token path to `~/.room/state/room-<username>.token`
- `docs/deployment.md`: fix session token path in defaults table (global path, not per-room `/tmp/`)
- `docs/troubleshooting.md`: fix cursor file path from `/tmp/` to `~/.room/state/`
- `docs/authentication.md`: update the `/kick`/`/reauth` note to reflect the daemon-mode fix from #402 (UserRegistry tokens now revoked correctly)
- `docs/permission-prompts.md`: fix old per-room token paths in all examples
- `plugin/.claude-plugin/plugin.json`: bump version to `3.0.0-rc.6`
- `crates/room-cli/CHANGELOG.md`: add `3.0.0-rc.1` through `3.0.0-rc.6` release entries (was stuck at `2.1.0-rc.2`)

## Test plan

- [x] `cargo check` passes
- [x] No code changes — doc-only + CHANGELOG + plugin version

Closes #420
