### PR TITLE
docs: fix remaining stale paths in troubleshooting.md and testing.md

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -59,7 +59,14 @@ crates/room-cli/src/
   oneshot/poll.rs       — unit tests for DM filter, cursor advancement, multiplexed poll
 crates/room-cli/tests/
   common/mod.rs         — shared test helpers (free_port, wait_for_socket, wait_for_tcp)
-  integration.rs        — integration tests against a live broker (UDS + WS + daemon)
+  auth.rs               — token issuance, validation, join permissions
+  broker.rs             — UDS broker lifecycle, broadcast, admin commands
+  daemon.rs             — multi-room daemon, room create/destroy
+  oneshot.rs            — one-shot send, poll, cursor advancement
+  rest_query.rs         — REST query endpoint, filters
+  room_lifecycle.rs     — room create/destroy lifecycle
+  scripted.rs           — multi-agent scripted scenario tests
+  ws.rs                 — WebSocket transport tests
   ws_smoke.rs           — end-to-end smoke tests spawning the real binary with --ws-port
 
 crates/room-ralph/src/

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -11,7 +11,8 @@ Error: cannot connect to broker: No such file or directory (os error 2)
 ```
 
 **Cause:** No broker is running for the room. The broker socket
-(`/tmp/room-<room-id>.sock`) does not exist.
+(`$TMPDIR/room-<room-id>.sock` on macOS, `$XDG_RUNTIME_DIR/room/room-<room-id>.sock`
+on Linux) does not exist.
 
 **Fix:** Start the broker by opening an interactive session:
 
@@ -132,7 +133,7 @@ in-flight history before exiting.
 
 ## Chat history file is very large
 
-**Symptom:** The chat file at `/tmp/<room-id>.chat` (or your custom path) has
+**Symptom:** The chat file at `~/.room/data/<room-id>.chat` (or your custom path) has
 grown very large.
 
 **Fix:** The host can run `/clear` to truncate the history file. Note this


### PR DESCRIPTION
## Summary

Follow-up to #423 (merged). Fixes remaining stale paths flagged in ba's review.

- `docs/troubleshooting.md`: replace `/tmp/room-<id>.sock` with platform runtime dir paths (`$TMPDIR` on macOS, `$XDG_RUNTIME_DIR/room` on Linux) matching `paths::room_single_socket_path()`
- `docs/troubleshooting.md`: replace `/tmp/<room-id>.chat` with correct persistent path `~/.room/data/<room-id>.chat` matching `paths::room_data_dir()`
- `docs/testing.md`: replace monolithic `tests/integration.rs` reference with the 8 split test modules from sprint 9 (#355): auth, broker, daemon, oneshot, rest_query, room_lifecycle, scripted, ws

## Test plan

- [x] `cargo check` passes
- [x] No code changes — doc-only

Closes #420
