### PR TITLE
feat(ralph): add --allow-all flag to skip tool restrictions

### DIFF
--- a/crates/room-ralph/src/lib.rs
+++ b/crates/room-ralph/src/lib.rs
@@ -91,6 +91,12 @@ pub struct Cli {
     #[arg(long, env = "ROOM_SOCKET")]
     pub socket: Option<PathBuf>,
 
+    /// Skip all tool restrictions — passes no --allowedTools or --disallowedTools
+    /// to claude, giving full unrestricted tool access.
+    /// Overrides --profile, --allow-tools, and --disallow-tools when set.
+    #[arg(long, env = "RALPH_ALLOW_ALL")]
+    pub allow_all: bool,
+
     /// Print the prompt that would be sent, then exit
     #[arg(long)]
     pub dry_run: bool,
@@ -114,6 +120,7 @@ mod tests {
             "RALPH_ISSUE",
             "RALPH_DISALLOWED_TOOLS",
             "RALPH_PROFILE",
+            "RALPH_ALLOW_ALL",
             "ROOM_SOCKET",
         ] {
             unsafe { std::env::remove_var(key) };
@@ -356,6 +363,59 @@ mod tests {
             Some(PathBuf::from("/tmp/flag.sock")),
             "CLI --socket should override ROOM_SOCKET env var"
         );
+        clear_ralph_env();
+    }
+
+    #[test]
+    fn allow_all_flag_defaults_to_false() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_ralph_env();
+
+        let cli = Cli::try_parse_from(["room-ralph", "myroom", "myuser"]).unwrap();
+        assert!(!cli.allow_all, "allow_all should default to false");
+        clear_ralph_env();
+    }
+
+    #[test]
+    fn allow_all_flag_sets_true() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_ralph_env();
+
+        let cli = Cli::try_parse_from(["room-ralph", "myroom", "myuser", "--allow-all"]).unwrap();
+        assert!(cli.allow_all, "allow_all should be true when flag is set");
+        clear_ralph_env();
+    }
+
+    #[test]
+    fn allow_all_from_env_var() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_ralph_env();
+
+        unsafe { std::env::set_var("RALPH_ALLOW_ALL", "true") };
+        let cli = Cli::try_parse_from(["room-ralph", "myroom", "myuser"]).unwrap();
+        assert!(
+            cli.allow_all,
+            "allow_all should be true from RALPH_ALLOW_ALL env var"
+        );
+        clear_ralph_env();
+    }
+
+    #[test]
+    fn allow_all_coexists_with_profile() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_ralph_env();
+
+        let cli = Cli::try_parse_from([
+            "room-ralph",
+            "myroom",
+            "myuser",
+            "--allow-all",
+            "--profile",
+            "reviewer",
+        ])
+        .unwrap();
+        assert!(cli.allow_all);
+        assert_eq!(cli.profile, Some(claude::Profile::Reviewer));
         clear_ralph_env();
     }
 }

--- a/crates/room-ralph/src/loop_runner.rs
+++ b/crates/room-ralph/src/loop_runner.rs
@@ -152,10 +152,20 @@ fn try_invoke_claude(
         cli.model,
         iteration
     );
-    let (profile_allow, profile_disallow) =
-        claude::merge_profile_with_overrides(cli.profile, &cli.allow_tools, &cli.disallow_tools);
-    let effective_tools = claude::resolve_allowed_tools(&profile_allow);
-    let effective_disallowed = claude::resolve_disallowed_tools(&profile_disallow);
+    let (effective_tools, effective_disallowed) = if cli.allow_all {
+        tracing::info!("--allow-all: skipping all tool restrictions");
+        (Vec::new(), Vec::new())
+    } else {
+        let (profile_allow, profile_disallow) = claude::merge_profile_with_overrides(
+            cli.profile,
+            &cli.allow_tools,
+            &cli.disallow_tools,
+        );
+        (
+            claude::resolve_allowed_tools(&profile_allow),
+            claude::resolve_disallowed_tools(&profile_disallow),
+        )
+    };
 
     match claude::spawn_claude(
         &cli.model,

--- a/crates/room-ralph/src/main.rs
+++ b/crates/room-ralph/src/main.rs
@@ -76,6 +76,9 @@ fn launch_tmux(cli: &Cli) -> Result<(), String> {
         args.push("--socket".into());
         args.push(socket.display().to_string());
     }
+    if cli.allow_all {
+        args.push("--allow-all".into());
+    }
 
     let cmd_str = format!("{} {}", exe.display(), args.join(" "));
     std::process::Command::new("tmux")
@@ -163,12 +166,13 @@ async fn main() -> ExitCode {
     }
 
     tracing::info!(
-        "room-ralph starting: room={} user={} model={} issue={} max_iter={}",
+        "room-ralph starting: room={} user={} model={} issue={} max_iter={} allow_all={}",
         cli.room_id,
         cli.username,
         cli.model,
         cli.issue.as_deref().unwrap_or("none"),
         cli.max_iter,
+        cli.allow_all,
     );
 
     let socket_str = cli.socket.as_ref().map(|p| p.display().to_string());
@@ -192,10 +196,17 @@ async fn main() -> ExitCode {
         cli.username = join_result.username;
     }
 
-    let announce = format!(
-        "online (room-ralph, model={}, iter limit={})",
-        cli.model, cli.max_iter
-    );
+    let announce = if cli.allow_all {
+        format!(
+            "online (room-ralph, model={}, iter limit={}, allow-all)",
+            cli.model, cli.max_iter
+        )
+    } else {
+        format!(
+            "online (room-ralph, model={}, iter limit={})",
+            cli.model, cli.max_iter
+        )
+    };
     room::send_message(&cli.room_id, &token, &announce, socket_ref).ok();
 
     match loop_runner::run_loop(&cli, token, &running).await {

--- a/crates/room-ralph/tests/integration.rs
+++ b/crates/room-ralph/tests/integration.rs
@@ -33,6 +33,7 @@ fn test_cli(f: impl FnOnce(&mut Cli)) -> Cli {
         disallow_tools: vec![],
         profile: None,
         socket: None,
+        allow_all: false,
         dry_run: false,
     };
     f(&mut cli);
@@ -376,7 +377,29 @@ async fn personality_appears_in_dry_run_output() {
     cleanup("integ-personality", None);
 }
 
-// ── Test 9: live broker join and announce ────────────────────────────────────
+// ── Test 9: --allow-all skips tool restrictions in dry-run ───────────────────
+
+#[tokio::test]
+async fn allow_all_dry_run_succeeds() {
+    let cli = test_cli(|c| {
+        c.dry_run = true;
+        c.allow_all = true;
+        c.username = "integ-allow-all".to_string();
+        // Also set a profile to verify allow_all takes precedence
+        c.profile = Some(room_ralph::claude::Profile::Reader);
+        c.disallow_tools = vec!["Bash".to_string()];
+    });
+    let running = Arc::new(AtomicBool::new(true));
+
+    let result = loop_runner::run_loop(&cli, "fake-token".to_string(), &running).await;
+    assert!(
+        result.is_ok(),
+        "allow_all + dry_run should succeed: {result:?}"
+    );
+    cleanup("integ-allow-all", None);
+}
+
+// ── Test 10: live broker join and announce ───────────────────────────────────
 
 #[tokio::test]
 #[ignore = "requires a running broker: `room ralph-live-test host &`"]


### PR DESCRIPTION
## Summary
- Adds `--allow-all` CLI flag and `RALPH_ALLOW_ALL` env var to room-ralph
- When set, passes no `--allowedTools` or `--disallowedTools` to claude, giving full unrestricted tool access in `-p` mode
- Silently takes precedence over `--profile`, `--allow-tools`, and `--disallow-tools` with a warning log
- Includes audit logging in startup message and tracing output
- Passes `--allow-all` through to tmux subprocess

## Files changed
- `crates/room-ralph/src/lib.rs` — Cli flag + 4 unit tests + env cleanup
- `crates/room-ralph/src/loop_runner.rs` — bypass tool resolution when allow_all=true
- `crates/room-ralph/src/main.rs` — tmux passthrough + startup log/announce
- `crates/room-ralph/tests/integration.rs` — 1 integration test + allow_all field

## Test plan
- [x] 4 new CLI parsing unit tests (default false, flag sets true, env var, coexists with profile)
- [x] 1 new integration test (allow_all + dry_run with profile and disallow_tools)
- [x] All 1057 Rust tests pass
- [x] pre-push checks pass (check + fmt + clippy + test)

Closes #433