### PR TITLE
feat(broker): add lease TTL to /claim with auto-expiry

### DIFF
--- a/crates/room-cli/src/broker/commands.rs
+++ b/crates/room-cli/src/broker/commands.rs
@@ -169,8 +169,13 @@ pub(crate) async fn route_command(
             let content = if raw.is_empty() {
                 "no active claims".to_owned()
             } else {
-                let entries: Vec<String> =
-                    raw.into_iter().map(|(u, t)| format!("{u}: {t}")).collect();
+                let entries: Vec<String> = raw
+                    .into_iter()
+                    .map(|(u, t, elapsed)| {
+                        let mins = elapsed.as_secs() / 60;
+                        format!("{u}: {t} ({mins}m ago)")
+                    })
+                    .collect();
                 format!("claimed — {}", entries.join(", "))
             };
             let sys = make_system(&state.room_id, "broker", content);
@@ -1028,7 +1033,7 @@ mod tests {
                 .lock()
                 .await
                 .get("alice")
-                .map(String::as_str),
+                .map(|e| e.task.as_str()),
             Some("fix bug #42")
         );
     }
@@ -1047,7 +1052,7 @@ mod tests {
                 .lock()
                 .await
                 .get("alice")
-                .map(String::as_str),
+                .map(|e| e.task.as_str()),
             Some("task B"),
             "new claim should overwrite the old one"
         );
@@ -1057,11 +1062,7 @@ mod tests {
     async fn route_command_unclaim_removes_claim() {
         let tmp = NamedTempFile::new().unwrap();
         let state = make_state(tmp.path().to_path_buf());
-        state
-            .claim_map
-            .lock()
-            .await
-            .insert("alice".to_owned(), "task A".to_owned());
+        state.set_claim("alice", "task A".to_owned()).await;
         let msg = make_command("test-room", "alice", "unclaim", vec![]);
         let result = route_command(msg, "alice", &state).await.unwrap();
         let CommandResult::HandledWithReply(json) = result else {
@@ -1100,11 +1101,8 @@ mod tests {
     async fn route_command_claimed_shows_all_claims() {
         let tmp = NamedTempFile::new().unwrap();
         let state = make_state(tmp.path().to_path_buf());
-        {
-            let mut map = state.claim_map.lock().await;
-            map.insert("alice".to_owned(), "task A".to_owned());
-            map.insert("bob".to_owned(), "task B".to_owned());
-        }
+        state.set_claim("alice", "task A".to_owned()).await;
+        state.set_claim("bob", "task B".to_owned()).await;
         let msg = make_command("test-room", "alice", "claimed", vec![]);
         let result = route_command(msg, "alice", &state).await.unwrap();
         let CommandResult::Reply(json) = result else {
@@ -1112,17 +1110,16 @@ mod tests {
         };
         assert!(json.contains("alice: task A"));
         assert!(json.contains("bob: task B"));
+        // Should include elapsed time
+        assert!(json.contains("0m ago"), "should show elapsed time");
     }
 
     #[tokio::test]
     async fn route_command_claimed_is_sorted() {
         let tmp = NamedTempFile::new().unwrap();
         let state = make_state(tmp.path().to_path_buf());
-        {
-            let mut map = state.claim_map.lock().await;
-            map.insert("zara".to_owned(), "z-task".to_owned());
-            map.insert("alice".to_owned(), "a-task".to_owned());
-        }
+        state.set_claim("zara", "z-task".to_owned()).await;
+        state.set_claim("alice", "a-task".to_owned()).await;
         let msg = make_command("test-room", "alice", "claimed", vec![]);
         let CommandResult::Reply(json) = route_command(msg, "alice", &state).await.unwrap() else {
             panic!("expected Reply");

--- a/crates/room-cli/src/broker/state.rs
+++ b/crates/room-cli/src/broker/state.rs
@@ -25,9 +25,20 @@ pub(crate) type HostUser = Arc<Mutex<Option<String>>>;
 /// Cleared when the broker process exits; token files on disk survive restarts.
 pub(crate) type TokenMap = Arc<Mutex<HashMap<String, String>>>;
 
-/// Maps username → claimed task description. Ephemeral; cleared on broker exit.
+/// Default claim TTL: 30 minutes. Claims expire after this duration unless renewed.
+pub(crate) const CLAIM_TTL: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+
+/// A single task claim with creation timestamp for lease-based expiry.
+#[derive(Debug, Clone)]
+pub(crate) struct ClaimEntry {
+    pub(crate) task: String,
+    pub(crate) claimed_at: std::time::Instant,
+}
+
+/// Maps username → claim entry. Ephemeral; cleared on broker exit.
 /// Users can hold at most one claim at a time (new claim replaces old).
-pub(crate) type ClaimMap = Arc<Mutex<HashMap<String, String>>>;
+/// Claims expire after [`CLAIM_TTL`] and are lazily swept on access.
+pub(crate) type ClaimMap = Arc<Mutex<HashMap<String, ClaimEntry>>>;
 
 /// Maps username → subscription tier for this room. Persisted as JSON at
 /// `~/.room/state/<room_id>.subscriptions` on every mutation; loaded on
@@ -175,23 +186,31 @@ impl RoomState {
     // ── claim_map accessors ───────────────────────────────────────────────────
 
     /// Record a task claim for `user`. Replaces any existing claim.
+    /// Stores the current timestamp for lease-based expiry.
     pub(crate) async fn set_claim(&self, user: &str, task: String) {
-        self.claim_map.lock().await.insert(user.to_owned(), task);
+        self.claim_map.lock().await.insert(
+            user.to_owned(),
+            ClaimEntry {
+                task,
+                claimed_at: std::time::Instant::now(),
+            },
+        );
     }
 
-    /// Remove and return a user's active claim, if any.
+    /// Remove and return a user's active claim task, if any.
     pub(crate) async fn remove_claim(&self, user: &str) -> Option<String> {
-        self.claim_map.lock().await.remove(user)
+        self.claim_map.lock().await.remove(user).map(|e| e.task)
     }
 
-    /// Return all (username, task) claim pairs, sorted by username.
-    pub(crate) async fn claim_entries(&self) -> Vec<(String, String)> {
-        let mut entries: Vec<(String, String)> = self
-            .claim_map
-            .lock()
-            .await
+    /// Sweep expired claims and return remaining (username, task, elapsed)
+    /// triples, sorted by username.
+    pub(crate) async fn claim_entries(&self) -> Vec<(String, String, std::time::Duration)> {
+        let mut map = self.claim_map.lock().await;
+        let now = std::time::Instant::now();
+        map.retain(|_, entry| now.duration_since(entry.claimed_at) < CLAIM_TTL);
+        let mut entries: Vec<(String, String, std::time::Duration)> = map
             .iter()
-            .map(|(u, t)| (u.clone(), t.clone()))
+            .map(|(u, e)| (u.clone(), e.task.clone(), now.duration_since(e.claimed_at)))
             .collect();
         entries.sort_by(|a, b| a.0.cmp(&b.0));
         entries
@@ -364,7 +383,10 @@ mod tests {
         state.set_claim("alice", "fix #42".to_owned()).await;
         let entries = state.claim_entries().await;
         assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0], ("alice".to_owned(), "fix #42".to_owned()));
+        assert_eq!(entries[0].0, "alice");
+        assert_eq!(entries[0].1, "fix #42");
+        // elapsed should be very small (just created)
+        assert!(entries[0].2.as_secs() < 2);
     }
 
     #[tokio::test]
@@ -393,6 +415,47 @@ mod tests {
         let entries = state.claim_entries().await;
         assert_eq!(entries[0].0, "alice");
         assert_eq!(entries[1].0, "bob");
+    }
+
+    #[tokio::test]
+    async fn claim_entries_sweeps_expired() {
+        let dir = TempDir::new().unwrap();
+        let state = make_state(&dir);
+        // Insert a claim with a backdated timestamp (expired)
+        {
+            let mut map = state.claim_map.lock().await;
+            map.insert(
+                "stale".to_owned(),
+                ClaimEntry {
+                    task: "old task".to_owned(),
+                    claimed_at: std::time::Instant::now()
+                        - CLAIM_TTL
+                        - std::time::Duration::from_secs(1),
+                },
+            );
+        }
+        // Also insert a fresh claim
+        state.set_claim("fresh", "new task".to_owned()).await;
+        let entries = state.claim_entries().await;
+        assert_eq!(entries.len(), 1, "expired claim should be swept");
+        assert_eq!(entries[0].0, "fresh");
+    }
+
+    #[tokio::test]
+    async fn claim_reclaim_by_owner_resets_timestamp() {
+        let dir = TempDir::new().unwrap();
+        let state = make_state(&dir);
+        state.set_claim("alice", "task A".to_owned()).await;
+        // Re-claim should replace entry
+        state.set_claim("alice", "task B".to_owned()).await;
+        let entries = state.claim_entries().await;
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].1, "task B");
+    }
+
+    #[tokio::test]
+    async fn claim_ttl_is_30_minutes() {
+        assert_eq!(CLAIM_TTL, std::time::Duration::from_secs(30 * 60));
     }
 
     // ── subscription_map accessors ────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Claims now have a 30-minute TTL via `ClaimEntry` struct (task + `Instant` timestamp)
- Expired claims are lazily swept on `claim_entries()` access — no background timer needed
- `/claimed` output shows elapsed time per claim (e.g. `alice: fix #42 (5m ago)`)
- Existing `/claim`, `/unclaim`, `/claimed` interface unchanged
- `CLAIM_TTL` const for easy tuning

## Files changed
- `crates/room-cli/src/broker/state.rs` — `ClaimEntry` struct, modified `ClaimMap` type, expiry sweep in `claim_entries()`, 3 new tests
- `crates/room-cli/src/broker/commands.rs` — `/claimed` shows elapsed time, tests updated for new type

## Test plan
- [x] `claim_entries_sweeps_expired` — backdated claim is removed
- [x] `claim_reclaim_by_owner_resets_timestamp` — re-claim replaces entry
- [x] `claim_ttl_is_30_minutes` — const value check
- [x] `route_command_claimed_shows_all_claims` — now verifies elapsed display
- [x] All 1060 Rust tests pass
- [x] pre-push checks pass

Closes #429