### PR TITLE
docs(hive): initial PRDs for orchestration layer

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,3 +20,9 @@ The README covers installation and basic usage. This folder contains deep-dive d
 | [troubleshooting.md](troubleshooting.md) | FAQ and common errors |
 | [contributing.md](contributing.md) | Contributor guide: build, test, pre-push checklist |
 | [permission-prompts.md](permission-prompts.md) | Preventing Claude Code permission prompts — known triggers and safe alternatives |
+
+## Hive (product layer)
+
+| Folder | Description |
+|--------|-------------|
+| [hive/](hive/) | PRDs for the Hive orchestration layer — workspaces, teams, agent discovery |

--- a/docs/hive/README.md
+++ b/docs/hive/README.md
@@ -1,0 +1,86 @@
+# Hive — Multi-Room Orchestration Layer
+
+## What is Hive?
+
+Hive is the product layer that sits above `room`. Where `room` provides the
+low-level primitives (broker, sockets, messages, plugins), Hive provides the
+user-facing experience for managing teams of agents across multiple rooms.
+
+Think of it this way:
+
+- **room** = a single chat room with a broker, message history, and plugins.
+- **room daemon** = multiple rooms running on one host, with shared auth.
+- **Hive** = the workspace that ties rooms, agents, teams, and tasks together
+  into a coherent product experience.
+
+## Relationship to room
+
+Hive does not replace room — it orchestrates it. Every Hive feature is built on
+top of existing room primitives:
+
+| Hive concept | Built on |
+|---|---|
+| Workspace | Daemon multi-room + UserRegistry |
+| Team | Agent personalities + /spawn + room subscriptions |
+| Task board | /taskboard plugin + room messages |
+| Agent discovery | /who + /stats + agent status tracking |
+| Multi-room view | room poll --rooms + subscription tiers |
+
+Hive never bypasses room's socket protocol. All communication flows through the
+broker. Hive is a client-side experience layer, not a new server.
+
+## Design principles
+
+1. **room stays simple.** Hive adds features as plugins, CLI wrappers, and UI
+   components — not by modifying broker internals.
+
+2. **Agents are users.** Hive treats AI agents and human users identically at the
+   protocol level. A spawned agent joins via `room join`, subscribes via
+   `room subscribe`, and communicates via `room send`. The distinction is in the
+   management layer (spawn, stop, monitor), not the protocol.
+
+3. **Rooms are boundaries.** Each room is an independent coordination context.
+   Cross-room coordination happens via agents subscribed to multiple rooms, not
+   via server-side room linking.
+
+4. **Progressive disclosure.** A user running `room myroom alice` today should
+   get value immediately. Hive features like teams, workspaces, and agent
+   discovery are additive — they enhance the experience without requiring
+   migration.
+
+## PRDs in this folder
+
+| Document | Status | Summary |
+|---|---|---|
+| [prd-workspace.md](prd-workspace.md) | Draft | Multi-room workspace concept, team management |
+| [prd-team-provisioning.md](prd-team-provisioning.md) | Draft | /team create, agent manifests, ephemeral teams |
+| [prd-agent-discovery.md](prd-agent-discovery.md) | Draft | Expertise indexing, agent reputation, skill matching |
+
+## Dependencies on room features
+
+Hive depends on several room features that are in various stages of readiness:
+
+| Feature | Status | Hive dependency |
+|---|---|---|
+| Multi-room daemon | Shipped (v3) | Required for workspaces |
+| UserRegistry | Shipped (v3) | Required for cross-room identity |
+| /spawn + personalities | In progress (#434, #439) | Required for team provisioning |
+| /taskboard | In progress (#444) | Required for task management |
+| Subscription tiers | Shipped (v3) | Required for multi-room views |
+| Agent status tracking | Shipped (v3) | Required for agent discovery |
+
+## Open questions for joao
+
+1. **Should Hive be a separate binary or part of `room`?** Current assumption:
+   Hive commands are subcommands of `room` (e.g. `room hive workspace create`).
+   A separate `hive` binary adds deployment complexity but cleaner separation.
+
+2. **Web UI or CLI-only?** These PRDs assume CLI-first. A web dashboard (reading
+   room state via REST API) is a natural next step but not scoped here.
+
+3. **Multi-host support?** Room daemon is currently single-host. Hive workspaces
+   spanning multiple hosts would require WebSocket relay between daemons. Is this
+   a near-term goal or future aspiration?
+
+4. **Billing/metering?** If agents consume API credits (Claude API calls), should
+   Hive track per-agent or per-team costs? This affects the /stats plugin design.

--- a/docs/hive/prd-agent-discovery.md
+++ b/docs/hive/prd-agent-discovery.md
@@ -1,0 +1,269 @@
+# PRD: Agent Discovery
+
+> Status: Draft
+> Author: r2d2
+> Date: 2026-03-12
+> Dependencies: /who (shipped), /stats (shipped), personalities (#439),
+>   /taskboard (#444)
+
+## Problem
+
+In a workspace with 10+ agents across multiple rooms, finding the right agent
+for a task is non-trivial. Questions like "which agent knows about the broker
+code?", "who has capacity right now?", and "which reviewer has the best track
+record on CLI changes?" have no good answer today. The host manually assigns
+work based on memory and gut feel.
+
+As the number of agents grows, manual assignment doesn't scale. Agents idle
+while others are overloaded. Expertise is invisible — an agent that spent 20
+iterations deep in `broker/mod.rs` has knowledge that is lost when it goes
+offline.
+
+## Goal
+
+Provide an **agent discovery** system that indexes agent expertise, tracks
+capacity, and helps the host (or coordinator agent) make informed assignment
+decisions.
+
+## Non-goals
+
+- Autonomous task assignment (agents don't self-assign — the host or coordinator
+  decides).
+- Replacing the room coordination protocol.
+- Training or fine-tuning agents based on history.
+
+---
+
+## Core concepts
+
+### 1. Expertise index
+
+Every agent builds an implicit expertise profile through its work:
+
+- **Files touched**: tracked from git history (`git log --author=<username>`).
+- **Issues completed**: tracked from merged PRs with `Closes #N`.
+- **Domains**: inferred from file paths (e.g. `broker/` → broker internals,
+  `tui/` → terminal UI, `tests/` → testing infrastructure).
+
+The expertise index is a per-agent record stored in the workspace state:
+
+```json
+{
+  "agent": "r2d2",
+  "domains": {
+    "broker": {"files_touched": 12, "prs_merged": 5, "last_active": "2026-03-12"},
+    "oneshot": {"files_touched": 8, "prs_merged": 3, "last_active": "2026-03-10"},
+    "ralph": {"files_touched": 6, "prs_merged": 4, "last_active": "2026-03-12"}
+  },
+  "total_prs": 12,
+  "total_issues": 12,
+  "avg_time_to_merge": "45m"
+}
+```
+
+### 2. Capacity tracking
+
+Capacity is derived from agent status and current assignments:
+
+- **Idle**: agent is online but has no active claim or issue.
+- **Active**: agent has claimed a task via `/taskboard claim` or `/claim`.
+- **Blocked**: agent has set status containing "blocked" or "waiting".
+- **Offline**: agent is not connected to any room.
+
+```bash
+room hive agents --capacity
+```
+
+```
+ agent      | status     | current task   | domains
+ r2d2       | idle       | —              | broker, oneshot, ralph
+ saphire    | active     | #444 taskboard | tui, plugin
+ bumblebee  | active     | #438 subs      | broker, ws
+ ba         | monitoring | sprint coord   | all
+```
+
+### 3. Skill matching
+
+Given a new issue, suggest which agent is best suited:
+
+```bash
+room hive suggest-agent --issue 450
+```
+
+The system:
+1. Reads the issue title and body from GitHub (`gh issue view 450`).
+2. Extracts keywords and file path hints (e.g. "fix bug in broker/commands.rs").
+3. Matches against the expertise index.
+4. Filters by capacity (prefer idle agents over active ones).
+5. Returns a ranked list of suggestions.
+
+```
+Suggested agents for #450 (broker command routing bug):
+  1. r2d2     — 12 files in broker/, 5 merged PRs, idle
+  2. bumblebee — 4 files in broker/, 2 merged PRs, active (#438)
+  3. saphire   — 1 file in broker/, 0 merged PRs, active (#444)
+```
+
+This is a suggestion, not an assignment. The host or coordinator makes the
+final decision.
+
+---
+
+## User flows
+
+### 1. Build the expertise index
+
+```bash
+room hive agents index
+```
+
+Scans git history for all known agent usernames, builds the domain map, and
+writes to `~/.room/state/expertise.json`. This is an offline operation that
+can be run periodically or triggered after sprints close.
+
+For incremental updates:
+
+```bash
+room hive agents index --since 2026-03-01
+```
+
+### 2. Query agent expertise
+
+```bash
+room hive agents expertise r2d2
+```
+
+```
+Agent: r2d2
+Total PRs: 12 | Total issues: 12 | Avg time to merge: 45m
+
+Domains:
+  broker/     12 files, 5 PRs (last: 2026-03-12)
+  oneshot/     8 files, 3 PRs (last: 2026-03-10)
+  ralph/       6 files, 4 PRs (last: 2026-03-12)
+  protocol/    2 files, 1 PR  (last: 2026-02-28)
+```
+
+### 3. Find agents by domain
+
+```bash
+room hive agents find --domain tui
+```
+
+```
+Agents with TUI expertise:
+  saphire    — 15 files, 6 PRs (last: 2026-03-12)
+  bumblebee  — 3 files, 1 PR (last: 2026-03-05)
+```
+
+### 4. Agent reputation (stretch goal)
+
+Track quality metrics per agent over time:
+
+- **Merge rate**: PRs merged vs. PRs opened (indicates clean implementation).
+- **Review cycles**: average number of review rounds before merge.
+- **Regression rate**: bugs introduced by merged PRs (tracked by
+  `git bisect` or issue references).
+- **Test contribution**: net change in test count per PR.
+
+```bash
+room hive agents reputation r2d2
+```
+
+```
+Agent: r2d2 (sprint 10-12)
+  Merge rate:      100% (12/12)
+  Avg review cycles: 1.2
+  Regressions:     1 (#411 caused by #408)
+  Test contribution: +42 net tests
+```
+
+This data helps the coordinator decide whether an agent needs supervision
+(pair with a reviewer) or can be trusted with autonomous work.
+
+---
+
+## Data model
+
+### Expertise index
+
+Location: `~/.room/state/expertise.json`
+
+Built from git history. Updated on-demand via `room hive agents index`.
+
+### Agent profiles
+
+Location: `~/.room/state/agent-profiles/<username>.json`
+
+Per-agent profile including expertise, reputation, and preferences. Written
+by the index command and updated incrementally.
+
+### Capacity snapshot
+
+Not persisted — derived live from:
+- `/who` output (online/offline).
+- Agent status (`/set_status` values).
+- `/taskboard` claims (active assignments).
+
+---
+
+## Dependencies on room features
+
+| Feature | Status | How agent discovery uses it |
+|---|---|---|
+| /who | Shipped | Online/offline detection |
+| /stats | Shipped | Agent activity metrics |
+| /set_status | Shipped | Capacity inference (idle/active/blocked) |
+| /taskboard (#444) | In progress | Current assignments |
+| Agent status tracking | Shipped | Real-time status in capacity view |
+| UserRegistry | Shipped | Agent identity across rooms |
+| Personalities (#439) | Shipped | Personality metadata in profiles |
+| Git history | External | Expertise index source data |
+| GitHub API (gh) | External | Issue details for skill matching |
+
+---
+
+## Implementation considerations
+
+### Data freshness
+
+The expertise index is built from git history — it is always stale by the
+duration of the current sprint. For accurate suggestions, run
+`room hive agents index` at the start of each sprint and after each major
+merge batch.
+
+Capacity is live — it reads current `/who` and status data. No staleness
+concern.
+
+### Privacy
+
+Agent expertise data is derived from public git history and room messages. No
+new data is collected — the index is a materialized view of existing information.
+
+### Performance
+
+Git history scanning for ~1000 commits takes <1 second. The expertise index
+is small (KB range). No performance concern for workspaces with <50 agents.
+
+---
+
+## Open questions for joao
+
+1. **Should expertise indexing be automatic?** Current proposal: manual
+   (`room hive agents index`). Alternative: daemon runs periodic indexing in
+   the background. Risk: resource usage on large repos.
+
+2. **Agent reputation — useful or premature?** Reputation metrics (merge rate,
+   regression rate) are valuable for the coordinator but could create perverse
+   incentives if agents optimize for metrics over quality. Should this be
+   host-only data?
+
+3. **Cross-workspace expertise.** If an agent works in workspace A and then
+   is assigned to workspace B, should its expertise from A be visible? Current
+   proposal: expertise is global (not workspace-scoped) since it is derived
+   from git history which is repo-scoped.
+
+4. **Suggest-agent automation.** Should the coordinator agent be able to call
+   `suggest-agent` programmatically and auto-assign, or should it always be a
+   human decision? The coordination protocol today requires host approval for
+   assignments — auto-assignment would bypass that.

--- a/docs/hive/prd-team-provisioning.md
+++ b/docs/hive/prd-team-provisioning.md
@@ -1,0 +1,222 @@
+# PRD: Team Provisioning
+
+> Status: Draft
+> Author: r2d2
+> Date: 2026-03-12
+> Dependencies: /spawn + personalities (#434, #439), workspaces (prd-workspace.md)
+
+## Problem
+
+Spawning a team of agents today is a manual, repetitive process. For a typical
+sprint, the host runs 3-5 `room-ralph` commands with different personalities,
+models, and issue assignments. If the broker restarts, agents die and must be
+re-spawned individually. There is no declarative way to say "I want a team of
+coder + reviewer + coordinator in this workspace" and have it materialize.
+
+## Goal
+
+Let users define **team manifests** — declarative descriptions of agent teams
+that can be provisioned with a single command. Teams are ephemeral (spawn, use,
+tear down) but the manifest is reusable.
+
+## Non-goals
+
+- Persistent agent processes (agents still die on broker restart — ralph handles
+  reconnection).
+- Agent-to-agent delegation or hierarchy.
+- Resource scheduling across multiple hosts.
+
+---
+
+## User flows
+
+### 1. Define a team manifest
+
+```toml
+# ~/.room/teams/sprint-dev.toml
+[team]
+name = "sprint-dev"
+description = "Standard sprint development team"
+
+[[agent]]
+personality = "coder"
+username_prefix = "coder"
+model = "opus"
+count = 2
+
+[[agent]]
+personality = "reviewer"
+username_prefix = "reviewer"
+model = "sonnet"
+
+[[agent]]
+personality = "coordinator"
+username_prefix = "ba"
+model = "opus"
+```
+
+Each `[[agent]]` entry maps to a `/spawn` invocation. The `count` field
+(default 1) allows spawning multiple agents of the same personality.
+
+### 2. Provision a team
+
+```bash
+room hive team spawn sprint-dev --room triage --issue-prefix 430
+```
+
+This:
+1. Reads `~/.room/teams/sprint-dev.toml`.
+2. For each agent entry, calls `/spawn` (or `room-ralph` directly):
+   - `coder-a1b2` with personality=coder, model=opus, issue=430
+   - `coder-c3d4` with personality=coder, model=opus, issue=431
+   - `reviewer-e5f6` with personality=reviewer, model=sonnet
+   - `ba-g7h8` with personality=coordinator, model=opus
+3. Each agent joins the specified room automatically.
+4. A summary is broadcast to the room.
+
+### 3. Check team status
+
+```bash
+room hive team status sprint-dev
+```
+
+```
+Team: sprint-dev (room: triage)
+ agent       | personality | model  | status           | uptime
+ coder-a1b2  | coder       | opus   | implementing #430 | 14m
+ coder-c3d4  | coder       | opus   | running tests     | 12m
+ reviewer-e5 | reviewer    | sonnet | reviewing PR #443 | 8m
+ ba-g7h8     | coordinator | opus   | monitoring sprint | 14m
+```
+
+Uses `/agent list` and `/who` data combined with status information.
+
+### 4. Tear down a team
+
+```bash
+room hive team stop sprint-dev
+```
+
+Sends `/agent stop` for every agent in the team. Broadcasts a shutdown
+summary to the room. The manifest is preserved for re-use.
+
+### 5. Scale a team
+
+```bash
+room hive team scale sprint-dev --add coder --issue 445
+```
+
+Adds one more coder agent to the running team, assigned to issue 445.
+
+```bash
+room hive team scale sprint-dev --remove reviewer-e5f6
+```
+
+Stops a specific agent from the team.
+
+---
+
+## Agent manifests (advanced)
+
+For more control than personalities provide, users can define full agent
+manifests that specify custom prompts, tool restrictions, and environment:
+
+```toml
+# ~/.room/teams/security-audit.toml
+[team]
+name = "security-audit"
+
+[[agent]]
+username_prefix = "auditor"
+profile = "reader"
+model = "opus"
+prompt_file = "~/.room/prompts/security-audit.md"
+disallow_tools = ["Write", "Edit", "Bash(git push *)"]
+add_dirs = ["/path/to/target-repo"]
+max_iter = 10
+```
+
+This gives full control over the `room-ralph` invocation without needing
+a custom personality definition.
+
+---
+
+## Ephemeral teams
+
+Teams spawned with `--ephemeral` auto-destroy when a condition is met:
+
+```bash
+room hive team spawn sprint-dev --room triage --ephemeral=idle:30m
+```
+
+Options:
+- `--ephemeral=idle:30m` — tear down after 30 minutes of no agent activity.
+- `--ephemeral=task:445` — tear down when issue #445 is closed.
+- `--ephemeral=time:2h` — tear down after 2 hours regardless.
+
+Ephemeral teams are tracked via a metadata file alongside the manifest. A
+background check (in the daemon or a helper process) polls for the condition
+and runs `team stop` when met.
+
+---
+
+## Data model
+
+### Team manifest file
+
+Location: `~/.room/teams/<name>.toml`
+
+### Active team state
+
+Location: `~/.room/state/teams/<name>.json`
+
+```json
+{
+  "team": "sprint-dev",
+  "room": "triage",
+  "spawned_at": "2026-03-12T10:00:00Z",
+  "agents": [
+    {"username": "coder-a1b2", "pid": 12345, "personality": "coder", "issue": "430"},
+    {"username": "reviewer-e5f6", "pid": 12400, "personality": "reviewer", "issue": null}
+  ],
+  "ephemeral": null
+}
+```
+
+This file is written on spawn and updated on scale/stop. It is the source of
+truth for `team status` and `team stop`.
+
+---
+
+## Dependencies on room features
+
+| Feature | Status | How team provisioning uses it |
+|---|---|---|
+| /spawn + personalities | In progress (#434, #439) | Core spawn mechanism |
+| /agent list + stop | Planned (#434 phase 1) | Team status and teardown |
+| PID persistence | Planned (#434 phase 3) | Survive broker restarts |
+| Agent status tracking | Shipped | Team status dashboard |
+| Workspaces | Proposed (prd-workspace.md) | Team-workspace association |
+
+---
+
+## Open questions for joao
+
+1. **Issue assignment strategy.** Should `--issue-prefix` auto-increment
+   (430, 431, 432...) or should each agent entry in the manifest specify its
+   own issue? Auto-increment is convenient but fragile (gaps in issue numbers).
+
+2. **Team-level resource limits.** Should there be a max total agents across
+   all teams per daemon (e.g. 20)? Or per-team limits in the manifest? Current
+   `/agent` has a per-room limit of 5.
+
+3. **Team restart semantics.** If an agent in a team crashes (context exhaustion,
+   error), ralph already handles restart. But if the whole team is stopped and
+   re-spawned (`team spawn` again), should it resume from progress files or
+   start fresh? Progress files are per-issue, so they'd survive — but the team
+   state file would need reconciliation.
+
+4. **Shared vs. personal manifests.** Like workspaces, team manifests are
+   currently personal (`~/.room/teams/`). Should there be a shared location
+   (e.g. in the repo under `teams/`) so all team members use the same
+   definition?

--- a/docs/hive/prd-workspace.md
+++ b/docs/hive/prd-workspace.md
@@ -1,0 +1,191 @@
+# PRD: Hive Workspaces
+
+> Status: Draft
+> Author: r2d2
+> Date: 2026-03-12
+> Dependencies: daemon multi-room (shipped), UserRegistry (shipped), /taskboard (#444)
+
+## Problem
+
+Today, managing multiple rooms requires running separate `room` commands per room
+or a daemon with manual `room create` / `room subscribe` invocations. There is no
+concept of a "workspace" — a named collection of rooms with shared configuration,
+team membership, and a unified view of activity across rooms.
+
+For a team running 5-10 rooms (one per feature, one for triage, one for CI
+notifications), the cognitive overhead of subscribing to the right rooms, tracking
+which agent is in which room, and finding messages across rooms is significant.
+
+## Goal
+
+Provide a **workspace** abstraction that groups rooms, manages cross-room
+subscriptions, and gives users a single entry point for multi-room workflows.
+
+## Non-goals
+
+- Replacing the daemon — workspaces are a layer on top of daemon rooms.
+- Cross-host workspaces (see open questions).
+- Room-level ACLs beyond what room already supports.
+
+---
+
+## User flows
+
+### 1. Create a workspace
+
+```bash
+room hive workspace create sprint-12 \
+  --rooms triage,feature-auth,feature-taskboard,ci-notifications \
+  --default-room triage
+```
+
+This:
+1. Ensures all listed rooms exist in the daemon (creates missing ones).
+2. Stores workspace metadata in `~/.room/workspaces/sprint-12.toml`.
+3. Auto-subscribes the user to all listed rooms.
+
+```toml
+# ~/.room/workspaces/sprint-12.toml
+[workspace]
+name = "sprint-12"
+default_room = "triage"
+rooms = ["triage", "feature-auth", "feature-taskboard", "ci-notifications"]
+created_at = "2026-03-12T10:00:00Z"
+```
+
+### 2. Join a workspace
+
+```bash
+room hive workspace join sprint-12
+```
+
+Reads the workspace TOML, subscribes the user to all rooms, and opens the TUI
+with the default room selected. The room list in the TUI sidebar shows only
+workspace rooms (not all daemon rooms).
+
+### 3. Multi-room view
+
+```bash
+room hive inbox
+# or within TUI: /inbox
+```
+
+Shows recent messages from all workspace rooms, merged by timestamp:
+
+```
+[triage]          ba: sprint 12 scorecard updated
+[feature-auth]    saphire: PR #445 merged
+[ci-notifications] ci-bot: all checks passed on master
+[triage]          joao: @r2d2 pick up #435
+```
+
+This is a read-only view. To reply, the user switches to the specific room.
+
+Implementation: uses `room poll --rooms <list>` under the hood.
+
+### 4. Add/remove rooms
+
+```bash
+room hive workspace add-room sprint-12 hotfix-queue
+room hive workspace remove-room sprint-12 ci-notifications
+```
+
+Updates the TOML and adjusts subscriptions.
+
+### 5. Archive a workspace
+
+```bash
+room hive workspace archive sprint-12
+```
+
+Unsubscribes from all rooms, moves the TOML to `~/.room/workspaces/archive/`.
+Rooms are not destroyed — they persist in the daemon with their history.
+
+---
+
+## Team management within workspaces
+
+Each workspace can have a **team roster** — named users and agents assigned to it.
+The roster is informational (it does not enforce access control) but drives:
+
+- Default agent spawning: `room hive team spawn sprint-12` spawns all agents
+  defined in the team manifest (see prd-team-provisioning.md).
+- Status dashboard: `room hive team status sprint-12` shows the status of every
+  team member across all workspace rooms.
+- Notifications: `room hive team notify sprint-12 "standup in 5"` sends a message
+  to each team member via their subscribed room.
+
+```toml
+# Added to workspace TOML
+[team]
+members = ["joao", "ba", "r2d2", "saphire", "bumblebee"]
+```
+
+---
+
+## Data model
+
+### Workspace file
+
+Location: `~/.room/workspaces/<name>.toml`
+
+```toml
+[workspace]
+name = "sprint-12"
+default_room = "triage"
+rooms = ["triage", "feature-auth", "feature-taskboard"]
+created_at = "2026-03-12T10:00:00Z"
+
+[team]
+members = ["joao", "ba", "r2d2", "saphire"]
+```
+
+### Workspace registry
+
+Location: `~/.room/workspaces/registry.json`
+
+```json
+{
+  "active": "sprint-12",
+  "workspaces": ["sprint-12", "sprint-11"]
+}
+```
+
+The `active` field tracks the last-used workspace for commands that don't specify
+one explicitly.
+
+---
+
+## Dependencies on room features
+
+| Feature | Status | How workspace uses it |
+|---|---|---|
+| Daemon multi-room | Shipped | Workspace rooms are daemon rooms |
+| room create / destroy | Shipped | Workspace create ensures rooms exist |
+| room subscribe | Shipped | Workspace join subscribes to all rooms |
+| room poll --rooms | Shipped | Multi-room inbox view |
+| UserRegistry | Shipped | Cross-room identity for team roster |
+| /taskboard (#444) | In progress | Task tracking across workspace rooms |
+| Subscription persistence (#438) | In progress | Survives broker restarts |
+
+---
+
+## Open questions for joao
+
+1. **Should workspaces be shared or personal?** Current proposal: personal
+   (each user has their own `~/.room/workspaces/`). Shared workspaces would
+   require storing the TOML in the daemon's data directory and broadcasting
+   changes.
+
+2. **Should workspace rooms auto-create on workspace create?** Current proposal:
+   yes — `workspace create` calls `room create` for any listed room that doesn't
+   exist. Alternative: require rooms to exist first (fail-fast).
+
+3. **TUI integration depth.** Options:
+   - (a) Workspace-aware sidebar (show only workspace rooms, grouped).
+   - (b) Full workspace TUI mode (tabs per room, unified notification).
+   - (c) CLI-only for v1, TUI later.
+
+4. **Workspace-scoped taskboard.** Should `/taskboard` commands be workspace-wide
+   (tasks visible across all rooms) or per-room? Per-room is simpler but
+   fragments task tracking.


### PR DESCRIPTION
## Summary

- Create `docs/hive/` folder with initial PRDs for the Hive orchestration layer
- 3 PRDs covering workspaces, team provisioning, and agent discovery
- Update `docs/README.md` to reference the new folder

## Documents

| File | Summary |
|---|---|
| `docs/hive/README.md` | Hive overview, relationship to room, design principles, dependency matrix |
| `docs/hive/prd-workspace.md` | Multi-room workspace concept: create/join/archive, team rosters, inbox view |
| `docs/hive/prd-team-provisioning.md` | Declarative team manifests, `/team spawn`, ephemeral teams, scaling |
| `docs/hive/prd-agent-discovery.md` | Expertise indexing from git history, capacity tracking, skill matching |

## Key design decisions

- Hive is a client-side experience layer, not a new server — all communication flows through room's broker
- Workspaces are personal (`~/.room/workspaces/`) not shared (avoids coordination complexity)
- Team manifests map 1:1 to `/spawn` invocations — no new protocol needed
- Expertise index is built from git history — no new data collection

## Open questions flagged for joao

Each PRD includes 3-4 open questions. The most impactful:
- Should Hive be a separate binary or part of `room`?
- Multi-host support timeline (single-host daemon today)
- Workspace-scoped vs global taskboard
- Agent reputation metrics: useful or premature?

## Test plan

- [x] Docs-only change, no code
- [x] Markdown renders correctly (verified locally)

Closes #435
