### PR TITLE
fix(broker): echo plugin broadcast to oneshot sender

### DIFF
--- a/crates/room-cli/src/broker/commands.rs
+++ b/crates/room-cli/src/broker/commands.rs
@@ -401,9 +401,11 @@ async fn dispatch_plugin(
         }
         PluginResult::Broadcast(text) => {
             let sys = make_system(&state.room_id, &format!("plugin:{}", plugin.name()), text);
-            broadcast_and_persist(&sys, &state.clients, &state.chat_path, &state.seq_counter)
-                .await?;
-            CommandResult::Handled
+            let seq_msg =
+                broadcast_and_persist(&sys, &state.clients, &state.chat_path, &state.seq_counter)
+                    .await?;
+            let json = serde_json::to_string(&seq_msg)?;
+            CommandResult::HandledWithReply(json)
         }
         PluginResult::Handled => CommandResult::Handled,
     })
@@ -1466,5 +1468,49 @@ mod tests {
 
         let loaded = super::load_subscription_map(&state.subscription_map_path);
         assert_eq!(loaded.get("alice"), Some(&SubscriptionTier::MentionsOnly));
+    }
+
+    // ── plugin broadcast returns HandledWithReply for oneshot echo ─────
+
+    #[tokio::test]
+    async fn plugin_broadcast_returns_handled_with_reply() {
+        let tmp = NamedTempFile::new().unwrap();
+        let state = make_state(tmp.path().to_path_buf());
+        // /taskboard post produces PluginResult::Broadcast — should come
+        // back as HandledWithReply so oneshot senders receive the echo.
+        let msg = make_command(
+            "test-room",
+            "alice",
+            "taskboard",
+            vec!["post".to_owned(), "test task description".to_owned()],
+        );
+        let result = route_command(msg, "alice", &state).await.unwrap();
+        let CommandResult::HandledWithReply(json) = result else {
+            panic!("expected HandledWithReply for plugin broadcast");
+        };
+        assert!(
+            json.contains("plugin:taskboard"),
+            "reply should identify plugin source"
+        );
+        assert!(
+            json.contains("test task description"),
+            "reply should contain the task description"
+        );
+    }
+
+    #[tokio::test]
+    async fn plugin_reply_returns_reply_not_handled_with_reply() {
+        let tmp = NamedTempFile::new().unwrap();
+        let state = make_state(tmp.path().to_path_buf());
+        // /taskboard list with no tasks produces PluginResult::Reply.
+        let msg = make_command("test-room", "alice", "taskboard", vec!["list".to_owned()]);
+        let result = route_command(msg, "alice", &state).await.unwrap();
+        let CommandResult::Reply(json) = result else {
+            panic!("expected Reply for plugin list");
+        };
+        assert!(
+            json.contains("plugin:taskboard"),
+            "reply should identify plugin source"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #450 — oneshot `room send` with plugin commands that broadcast (e.g. `/taskboard claim`, `/taskboard plan`) returned EOF because `dispatch_plugin` mapped `PluginResult::Broadcast` to `CommandResult::Handled`, which sends nothing back to the oneshot sender.

- Change `PluginResult::Broadcast` mapping from `CommandResult::Handled` to `CommandResult::HandledWithReply(json)` with the serialized broadcast message
- Interactive clients are unaffected — both `Handled` and `HandledWithReply` are treated identically in the interactive session path
- Oneshot senders now receive the broadcast message as an echo, matching the behavior of regular `Passthrough` messages

## Test plan

- [x] New unit test: `plugin_broadcast_returns_handled_with_reply` — verifies `/taskboard post` returns `HandledWithReply` with plugin source and task description
- [x] New unit test: `plugin_reply_returns_reply_not_handled_with_reply` — verifies `/taskboard list` still returns `Reply` (no regression)
- [x] All existing tests pass (cargo test)
- [x] pre-push checks pass (check + fmt + clippy + test)

Closes #450
