### PR TITLE
docs: add /taskboard and /queue to commands, fix stale test references

### DIFF
--- a/docs/broker-internals.md
+++ b/docs/broker-internals.md
@@ -168,12 +168,12 @@ All writes go through `history::append`, which opens the file in append mode. To
 | `status_map` | `Arc<Mutex<HashMap<String, String>>>` | Maps username to status string (ephemeral) |
 | `host_user` | `Arc<Mutex<Option<String>>>` | Username of the first connected client |
 | `token_map` | `Arc<Mutex<HashMap<String, String>>>` | Maps token UUID to username (persisted to `.tokens` file) |
-| `claim_map` | `Arc<Mutex<HashMap<String, String>>>` | Maps username to claimed task (ephemeral) |
+| `claim_map` | `Arc<Mutex<HashMap<String, ClaimEntry>>>` | Maps username to claim entry (task + timestamp, 30min TTL, lazily swept) |
 | `chat_path` | `Arc<PathBuf>` | Path to the NDJSON chat file |
 | `room_id` | `Arc<String>` | Room identifier |
 | `shutdown` | `Arc<watch::Sender<bool>>` | Shutdown signal |
 | `seq_counter` | `Arc<AtomicU64>` | Monotonic sequence counter |
-| `plugin_registry` | `Arc<PluginRegistry>` | Compiled-in plugin dispatch (`/help`, `/stats`) |
+| `plugin_registry` | `Arc<PluginRegistry>` | Compiled-in plugin dispatch (`/help`, `/stats`, `/queue`, `/taskboard`) |
 | `config` | `Option<RoomConfig>` | Room visibility and access control (daemon mode) |
 
 ## Admin commands

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -200,9 +200,10 @@ a `reply_to` reference so clients can thread it visually.
 
 ### `/claim <task>`
 
-Register a task claim. The broker stores the claim in memory and broadcasts
-a system message to all users. Each user can hold at most one claim at a
-time — a new `/claim` replaces any existing claim.
+Register a task claim. The broker stores the claim as a `ClaimEntry` with a
+30-minute TTL. Claims are lazily swept on access — expired claims are
+automatically removed. Each user can hold at most one claim at a time — a
+new `/claim` replaces any existing claim and resets the TTL.
 
 ```
 /claim implement the /dm command
@@ -256,6 +257,65 @@ statuses.
 ```
 
 Example response: `online — alice, bob: away, charlie`
+
+---
+
+## Plugin commands
+
+Plugin commands are provided by compiled-in plugins registered in the
+`PluginRegistry`. They are dispatched via `dispatch_plugin` in the broker.
+
+### `/queue <action> [args]`
+
+Manage a persistent task backlog. Items are stored in an NDJSON file alongside
+the chat file.
+
+| Action | Description |
+|--------|-------------|
+| `add <description>` | Add a task to the backlog. Broadcasts to the room. |
+| `list` | List all queued tasks with their index. Private reply. |
+| `remove <index>` | Remove a task by its 1-based index. Broadcasts to the room. |
+| `pop` | Claim and remove the first task from the queue. Broadcasts to the room. |
+
+```
+/queue add implement caching layer
+/queue list
+/queue remove 2
+/queue pop
+```
+
+---
+
+### `/taskboard <action> [args]`
+
+Manage task lifecycle with claim ownership, plan submission, approval gates,
+and lease-based expiry. Tasks are stored in an NDJSON file alongside the chat
+file. Each claimed task has a 10-minute lease TTL — expired leases auto-release
+the task back to open status.
+
+| Action | Description |
+|--------|-------------|
+| `post <description>` | Create a new task. Broadcasts to the room. |
+| `list` | List all tasks with status and assignee. Private reply. |
+| `show <task-id>` | Show full detail for a task (status, description, poster, assignee, plan, approved_by, notes, lease elapsed). Private reply. |
+| `claim <task-id>` | Claim an open task. Only open tasks can be claimed. Broadcasts to the room. |
+| `plan <task-id> <plan-text>` | Submit or resubmit a plan for a claimed task. Only the assignee can submit. Broadcasts the plan text to the room for review. |
+| `approve <task-id>` | Approve a planned task. Only the task poster or room host can approve. Broadcasts to the room. |
+| `update <task-id> [notes]` | Update progress notes and renew the lease. Only the assignee can update. Warns if the task is not yet approved. |
+| `release <task-id>` | Release a task back to open status. Only the assignee or room host can release. Broadcasts to the room. |
+| `finish <task-id>` | Mark a task as finished. Only the assignee can finish. Broadcasts to the room. |
+
+```
+/taskboard post implement caching layer
+/taskboard list
+/taskboard show tb-001
+/taskboard claim tb-001
+/taskboard plan tb-001 add LRU cache in broker state with 5m TTL
+/taskboard approve tb-001
+/taskboard update tb-001 cache struct done, writing tests
+/taskboard release tb-001
+/taskboard finish tb-001
+```
 
 ---
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -84,7 +84,7 @@ The project room is the coordination layer. Use it.
 New behaviour must have tests. The test split:
 
 - **Unit tests** (`src/*.rs` via `#[cfg(test)]`): test individual functions and logic in isolation.
-- **Integration tests** (`tests/integration.rs`): test the full broker stack with a live `UnixListener`. Use the helpers already in that file (`TestBroker::start`, `TestClient::connect`, `send_text`, `send_json`, `recv`, `recv_until`, etc.) to keep tests concise. Shared lifecycle helpers are in `tests/common/mod.rs`.
+- **Integration tests** (focused modules under `tests/` — auth.rs, broker.rs, daemon.rs, oneshot.rs, rest_query.rs, room_lifecycle.rs, scripted.rs, ws.rs, ws_smoke.rs): test the full broker stack with a live `UnixListener`. Use the helpers in `tests/common/mod.rs` (`TestBroker::start`, `TestClient::connect`, `send_text`, `send_json`, `recv`, `recv_until`, etc.) to keep tests concise.
 
 When writing integration tests:
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,7 +1,7 @@
 # Testing
 
 `room` has two test suites: **unit tests** (inside `src/`) and **integration
-tests** (`tests/integration.rs`) that run a real broker over a Unix socket.
+tests** (focused modules under `tests/`) that run a real broker over a Unix socket.
 
 ---
 
@@ -52,6 +52,9 @@ crates/room-cli/src/
   plugin/mod.rs         — unit tests for PluginRegistry, builtin_command_infos
   plugin/help.rs        — unit tests for /help output
   plugin/stats.rs       — unit tests for /stats output
+  plugin/queue.rs       — unit tests for /queue NDJSON persistence and subcommands
+  plugin/taskboard/mod.rs — unit tests for /taskboard subcommands, approve permissions, lifecycle
+  plugin/taskboard/task.rs — unit tests for Task model, LiveTask lease, NDJSON round-trip
   tui/input.rs          — unit tests for handle_key, cursor, key bindings
   tui/render.rs         — unit tests for wrap_words, format_message
   tui/widgets.rs        — unit tests for CommandPalette, MentionPicker


### PR DESCRIPTION
## Summary
- **docs/commands.md**: Add /taskboard (9 subcommands: post, list, show, claim, plan, approve, update, release, finish) and /queue (4 subcommands: add, list, remove, pop) sections. Update /claim to document 30min TTL with ClaimEntry and lazy sweep.
- **docs/broker-internals.md**: Update plugin_registry description to include /queue and /taskboard. Fix claim_map type from `HashMap<String, String>` to `HashMap<String, ClaimEntry>`.
- **docs/testing.md**: Fix stale `tests/integration.rs` reference (tests are now split into focused modules). Add missing test entries for plugin/queue.rs and plugin/taskboard/.
- **docs/contributing.md**: Fix stale `tests/integration.rs` reference to match current test structure.

Addresses bumblebee audit issues #12-19.