### PR TITLE
docs: audit and update all per-crate CHANGELOGs

### DIFF
--- a/crates/room-cli/CHANGELOG.md
+++ b/crates/room-cli/CHANGELOG.md
@@ -10,7 +10,25 @@ For changes prior to the workspace restructure (v0.1.2 through v1.0.2), see the
 
 ## [Unreleased]
 
-## [3.0.0-rc.6] - 2026-03-09
+### Added
+
+- `/taskboard` plugin — lease-based task lifecycle with `post`, `list`, `show`,
+  `claim`, `plan`, `approve`, `update`, `release`, `finish` subcommands. Tasks have
+  lease TTLs with auto-expiry. (#444, #451, #453)
+- `/queue` plugin — persistent FIFO queue with NDJSON storage. Subcommands: `add`,
+  `list`, `remove`, `pop`. (#442)
+- TUI: `ChoicePicker` widget for command parameter autocomplete. (#437, #445)
+- TUI: vertically center splash screen in the message area. (#427, #428)
+- Lease TTL on `/claim` with automatic expiry of stale claims. (#429, #443)
+
+### Fixed
+
+- Broker echoes plugin broadcast messages back to the oneshot sender. (#450)
+- Oneshot `watch` filter now includes system messages from plugins. (#452)
+- Persist subscription state on join so it survives broker restarts. (#438)
+- TUI: arrow-down on last line moves cursor to end before scrolling. (#422, #424)
+
+## [3.0.0-rc.6] - 2026-03-10
 
 ### Fixed
 
@@ -28,7 +46,7 @@ For changes prior to the workspace restructure (v0.1.2 through v1.0.2), see the
 - `room daemon --isolated` flag: spawns a daemon with a private temp dir for
   tests, prints socket path to stdout, and cleans up on exit. (#398, #417)
 
-## [3.0.0-rc.5] - 2026-03-09
+## [3.0.0-rc.5] - 2026-03-10
 
 ### Changed
 
@@ -49,14 +67,10 @@ For changes prior to the workspace restructure (v0.1.2 through v1.0.2), see the
 
 ## [3.0.0-rc.3] - 2026-03-09
 
-### Fixed
-
-- Ralph username crash when joining rooms with long or special-character names. (#400, #403)
-- DM host visibility — `is_visible_to()` now checks host membership for DM
-  rooms so the host can see all DMs in their room. (#394, #407)
-
 ### Added
 
+- TUI: use daemon exclusively for room join — all `room <room-id> <user>` sessions
+  now go through the daemon. (#385, #391)
 - `/claim`, `/unclaim`, `/claimed` built-in commands for task coordination. (#182)
 - Parameter validation for built-in commands against `CommandInfo` schemas. (#265)
 - Token persistence across broker restarts via `.tokens` files. (#183)
@@ -68,8 +82,26 @@ For changes prior to the workspace restructure (v0.1.2 through v1.0.2), see the
 
 ### Fixed
 
+- `room join` now sets `Full` subscription to prevent auto-subscribe downgrade. (#392)
+- TUI: redirect stderr to `~/.room/room.log` during TUI sessions. (#395)
+- DM host visibility — `is_visible_to()` now checks host membership for DM
+  rooms so the host can see all DMs in their room. (#394, #407)
 - WS smoke tests clean up stale `.tokens` files from previous runs. (#184)
 - Serialized WS smoke test execution to prevent disk I/O contention. (#184)
+
+## [3.0.0-rc.2] - 2026-03-09
+
+### Added
+
+- Sprint 9 refactor wave: `handshake.rs`, `admin.rs`, `render_bots.rs`, `ws/rest.rs`
+  split, `paths.rs`, Plugin trait defaults, RoomState factory and accessors, handle\_key
+  decomposition, `is_visible_to()` on Message. (#351–#379)
+- P0 test coverage: duplicate-username join, concurrent room creation, destroy with
+  connected clients, host disconnect/reconnect + DM history replay. (#381–#384)
+
+### Fixed
+
+- Daemon auto-start timeout increased to 15s to handle slow volumes. (#380)
 
 ## [3.0.0-rc.1] - 2026-03-08
 
@@ -132,7 +164,8 @@ For changes prior to the workspace restructure (v0.1.2 through v1.0.2), see the
 [Unreleased]: https://github.com/knoxio/room/compare/v3.0.0-rc.6...HEAD
 [3.0.0-rc.6]: https://github.com/knoxio/room/compare/v3.0.0-rc.5...v3.0.0-rc.6
 [3.0.0-rc.5]: https://github.com/knoxio/room/compare/v3.0.0-rc.3...v3.0.0-rc.5
-[3.0.0-rc.3]: https://github.com/knoxio/room/compare/v3.0.0-rc.1...v3.0.0-rc.3
+[3.0.0-rc.3]: https://github.com/knoxio/room/compare/v3.0.0-rc.2...v3.0.0-rc.3
+[3.0.0-rc.2]: https://github.com/knoxio/room/compare/v3.0.0-rc.1...v3.0.0-rc.2
 [3.0.0-rc.1]: https://github.com/knoxio/room/compare/v2.1.0-rc.2...v3.0.0-rc.1
 [2.1.0-rc.2]: https://github.com/knoxio/room/compare/v2.1.0-rc.1...v2.1.0-rc.2
 [2.1.0-rc.1]: https://github.com/knoxio/room/compare/v2.0.1...v2.1.0-rc.1

--- a/crates/room-protocol/CHANGELOG.md
+++ b/crates/room-protocol/CHANGELOG.md
@@ -7,7 +7,34 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [2.1.0-rc.2] - 2026-03-08
+## [3.0.0-rc.6] - 2026-03-10
+
+Version bump to stay in sync with room-cli 3.0.0-rc.6. No protocol changes.
+
+## [3.0.0-rc.5] - 2026-03-10
+
+Version bump to stay in sync with room-cli 3.0.0-rc.5. No protocol changes.
+
+## [3.0.0-rc.3] - 2026-03-09
+
+Version bump to stay in sync with room-cli 3.0.0-rc.3. No protocol changes.
+
+## [3.0.0-rc.2] - 2026-03-09
+
+### Added
+
+- `Message::is_visible_to()` — centralised DM visibility check, replacing scattered
+  filter patterns across the codebase. (#352)
+- `SubscriptionTier` enum (`Full`, `MentionsOnly`, `Unsubscribed`) for tiered room
+  subscriptions. (#323)
+- `format_message_id()` and `parse_message_id()` helpers for structured message ID
+  handling. (#321)
+
+### Changed
+
+- `dm_room_id()` now returns an error when both users are the same. (#296)
+
+## [3.0.0-rc.1] - 2026-03-09
 
 ### Added
 
@@ -15,6 +42,15 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `Message::content()` and `Message::mentions()` accessors. (#256)
 - `RoomConfig` and `RoomVisibility` types for room access control. (#253)
 - `dm_room_id()` — deterministic room ID for DM pairs.
+
+### Changed
+
+- Major version bump to v3 for breaking wire format additions (new types and
+  visibility model).
+
+## [2.1.0-rc.2] - 2026-03-08
+
+Version bump to stay in sync with room-cli 2.1.0-rc.2. No functional changes.
 
 ## [2.1.0-rc.1] - 2026-03-07
 
@@ -44,6 +80,13 @@ Version bump to stay in sync with room-cli 2.1.0. No functional changes.
 - Extracted from `agentroom` crate into `room-protocol` as part of the workspace
   restructure. (#197, #204)
 
-[Unreleased]: https://github.com/knoxio/room/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/knoxio/room/compare/v3.0.0-rc.6...HEAD
+[3.0.0-rc.6]: https://github.com/knoxio/room/compare/v3.0.0-rc.5...v3.0.0-rc.6
+[3.0.0-rc.5]: https://github.com/knoxio/room/compare/v3.0.0-rc.3...v3.0.0-rc.5
+[3.0.0-rc.3]: https://github.com/knoxio/room/compare/v3.0.0-rc.2...v3.0.0-rc.3
+[3.0.0-rc.2]: https://github.com/knoxio/room/compare/v3.0.0-rc.1...v3.0.0-rc.2
+[3.0.0-rc.1]: https://github.com/knoxio/room/compare/v2.1.0-rc.2...v3.0.0-rc.1
+[2.1.0-rc.2]: https://github.com/knoxio/room/compare/v2.1.0-rc.1...v2.1.0-rc.2
+[2.1.0-rc.1]: https://github.com/knoxio/room/compare/v2.0.1...v2.1.0-rc.1
 [2.0.1]: https://github.com/knoxio/room/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/knoxio/room/releases/tag/v2.0.0

--- a/crates/room-protocol/README.md
+++ b/crates/room-protocol/README.md
@@ -8,7 +8,7 @@ This crate defines the `Message` enum and constructor functions shared by all ro
 
 ```toml
 [dependencies]
-room-protocol = "2"
+room-protocol = "3"
 ```
 
 ## Message types

--- a/crates/room-ralph/CHANGELOG.md
+++ b/crates/room-ralph/CHANGELOG.md
@@ -7,6 +7,63 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `--allow-all` flag to skip all tool restrictions for trusted environments. (#433, #440)
+- Builtin personality templates — predefined personality files (`Coder`, `Reviewer`,
+  `Coordinator`, etc.) selectable via `--personality builtin:<name>` without an
+  external file. (#439, #446)
+
+## [0.4.0-rc.6] - 2026-03-10
+
+Version bump to stay in sync with room-cli 3.0.0-rc.6. No functional changes.
+
+## [0.4.0-rc.5] - 2026-03-10
+
+### Changed
+
+- Updated for global token migration: `room join` no longer requires a room-id
+  argument. Ralph now calls `room join <username>` and `room subscribe <room-id>`
+  separately. (#408)
+
+### Fixed
+
+- Retry with suffixed username (e.g. `alice-1`) when `room join` fails due to
+  duplicate username. (#403)
+
+## [0.4.0-rc.3] - 2026-03-09
+
+Version bump to stay in sync with room-cli 3.0.0-rc.3. No functional changes.
+
+## [0.4.0-rc.2] - 2026-03-09
+
+### Added
+
+- `--socket <path>` flag and `RALPH_SOCKET` environment variable for broker socket
+  path passthrough. Passed through to all `room` subcommands. (#309)
+
+### Fixed
+
+- Clippy complexity warnings in `loop_runner.rs` resolved. (#364)
+
+## [0.4.0-rc.1] - 2026-03-09
+
+### Added
+
+- `--profile <name>` flag and `RALPH_PROFILE` environment variable for tool profiles.
+  Built-in profiles (`Coder`, `Reviewer`, `Coordinator`, `Notion`, `Reader`) define curated
+  sets of allowed and disallowed tools. Profiles merge with explicit
+  `--allow-tools`/`--disallow-tools`. (#241)
+
+### Fixed
+
+- Token re-join after broker restart — ralph now detects auth failures and automatically
+  re-runs `room join` to obtain a fresh token. (#247, #248)
+
+### Changed
+
+- Removed EOF workaround from `/set_status` command dispatch. (#250)
+
 ## [0.3.0-rc.2] - 2026-03-08
 
 ### Added
@@ -16,10 +73,6 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   granular patterns like `Bash(python3:*)`. Empty by default. (#242)
 - Automatic `/set_status` updates at loop milestones: before claude spawn, on context
   restart, on claude error, and on shutdown. Handles #234 EOF gracefully. (#243)
-- `--profile <name>` flag and `RALPH_PROFILE` environment variable for tool profiles.
-  Built-in profiles (`Coder`, `Reviewer`, `Coordinator`, `Notion`, `Reader`) define curated
-  sets of allowed and disallowed tools. Profiles merge with explicit
-  `--allow-tools`/`--disallow-tools`. (#241)
 
 ### Fixed
 
@@ -70,8 +123,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Logging to stderr and `/tmp/ralph-room-<username>.log`.
 - 81 unit tests + 8 integration tests.
 
-[Unreleased]: https://github.com/knoxio/room/compare/v2.0.1...HEAD
-[0.3.0-rc.2]: https://github.com/knoxio/room/compare/v2.0.1...HEAD
-[0.3.0-rc.1]: https://github.com/knoxio/room/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/knoxio/room/compare/v3.0.0-rc.6...HEAD
+[0.4.0-rc.6]: https://github.com/knoxio/room/compare/v3.0.0-rc.5...v3.0.0-rc.6
+[0.4.0-rc.5]: https://github.com/knoxio/room/compare/v3.0.0-rc.3...v3.0.0-rc.5
+[0.4.0-rc.3]: https://github.com/knoxio/room/compare/v3.0.0-rc.2...v3.0.0-rc.3
+[0.4.0-rc.2]: https://github.com/knoxio/room/compare/v3.0.0-rc.1...v3.0.0-rc.2
+[0.4.0-rc.1]: https://github.com/knoxio/room/compare/v2.1.0-rc.2...v3.0.0-rc.1
+[0.3.0-rc.2]: https://github.com/knoxio/room/compare/v2.1.0-rc.1...v2.1.0-rc.2
+[0.3.0-rc.1]: https://github.com/knoxio/room/compare/v2.0.1...v2.1.0-rc.1
 [0.2.0]: https://github.com/knoxio/room/compare/v2.0.0...v2.0.1
 [0.1.0]: https://github.com/knoxio/room/releases/tag/v2.0.0


### PR DESCRIPTION
## Summary

- **room-protocol CHANGELOG**: Add entries for 3.0.0-rc.1 through rc.6. Fix 2.1.0-rc.2 entry where `parse_mentions`, `Message::content()`, `RoomConfig`, and `dm_room_id` were misattributed (they shipped in 3.0.0-rc.1 per git log). Add rc.2 entries for `is_visible_to`, `SubscriptionTier`, message ID helpers. Update all comparison links.
- **room-ralph CHANGELOG**: Add entries for 0.4.0-rc.1 through rc.6. Move `--profile` from 0.3.0-rc.2 to 0.4.0-rc.1 (confirmed via `git log v2.1.0-rc.1..v2.1.0-rc.2`). Add unreleased features (`--allow-all`, builtin personalities). Update all comparison links.
- **room-cli CHANGELOG**: Add missing rc.2 section (sprint 9 refactors + P0 tests). Add sprint 10 features to rc.3 (daemon-exclusive join, stderr redirect, subscription fix). Add unreleased section (taskboard, queue, splash centering, choice picker, claim TTL, 4 bug fixes). Fix rc.5/rc.6 dates.
- **room-protocol README**: Update dependency version `"2"` → `"3"`.

## Test plan

- [x] No code changes — docs only, `cargo check` not affected
- [ ] Visual review of CHANGELOG entries against `git log` for each version range
