### PR TITLE
docs: fix stale paths in AGENTS/deployment, add plugin commands to README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ room watch <room-id> -t <token> --interval 5
 room who <room-id> -t <token>
 ```
 
-The `room poll` cursor is stored at `/tmp/room-<id>-<username>.cursor`. Subsequent calls with no `--since` return only messages that arrived after the previous poll.
+The `room poll` cursor is stored at `~/.room/state/room-<id>-<username>.cursor`. Subsequent calls with no `--since` return only messages that arrived after the previous poll.
 
 ## Coordination protocol
 
@@ -93,5 +93,5 @@ All events carry `id` (UUID), `room`, `user`, `ts` (ISO 8601 UTC), and `seq` (mo
 
 - Socket: `/tmp/room-<id>.sock`
 - Chat history: `/tmp/<id>.chat` (NDJSON, broker is sole writer)
-- Token persistence: `/tmp/<id>.tokens` (survives broker restarts)
-- Poll cursor: `/tmp/room-<id>-<username>.cursor`
+- Token persistence: `~/.room/state/tokens.json` (survives broker restarts)
+- Poll cursor: `~/.room/state/room-<id>-<username>.cursor`

--- a/README.md
+++ b/README.md
@@ -231,7 +231,15 @@ Prefix your input with `/` to send a command instead of a plain message:
 /set_status reviewing PRs
 /who
 /dm bob hey, can we sync?
+/taskboard post fix the login bug
+/queue add deploy staging
 ```
+
+Claims expire after 30 minutes of inactivity (TTL-based with lazy sweep). The `/claim` command returns your claim or replaces an existing one.
+
+The `/taskboard` plugin provides a full task lifecycle: `post`, `list`, `show`, `claim`, `plan`, `approve`, `update`, `release`, `finish`. Tasks move through statuses: open → claimed → planned → approved → done.
+
+The `/queue` plugin manages a shared FIFO queue: `add`, `list`, `remove`, `pop`.
 
 The command and its arguments are sent as a `command` message (see [Wire format](#wire-format)).
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -9,7 +9,7 @@ For users running `room` in production or custom environments.
 | Broker socket | `/tmp/room-<id>.sock` | Fixed (derived from room ID) |
 | Chat history | `/tmp/<id>.chat` | `-f <path>` flag when starting a new room |
 | Session tokens | `~/.room/state/room-<username>.token` | Fixed (global, not per-room) |
-| Poll cursor | `/tmp/room-<id>-<username>.cursor` | Fixed |
+| Poll cursor | `~/.room/state/room-<id>-<username>.cursor` | Fixed |
 
 ## Changing the chat file path
 


### PR DESCRIPTION
## Summary

Fixes documentation staleness issues from bumblebee's audit (issues 6-11, 20):

- **AGENTS.md**: Fix cursor path from `/tmp/room-<id>-<username>.cursor` to `~/.room/state/room-<id>-<username>.cursor` (lines 44, 97). Fix token persistence path from `/tmp/<id>.tokens` to `~/.room/state/tokens.json` (line 96).
- **docs/deployment.md**: Fix poll cursor path in default paths table to `~/.room/state/` (line 12).
- **README.md**: Add `/taskboard` (9 subcommands) and `/queue` (4 subcommands) to TUI slash command examples. Document `/claim` 30-minute TTL with ClaimEntry.

All paths verified against `crates/room-cli/src/paths.rs` — `cursor_path()` returns `~/.room/state/room-<room_id>-<username>.cursor`, `system_tokens_path()` returns `~/.room/state/tokens.json`.

## Test plan

- [ ] Verify all paths in AGENTS.md match `paths.rs` source of truth
- [ ] Verify deployment.md cursor path matches `paths.rs`
- [ ] Verify /taskboard subcommand list matches `plugin/taskboard/mod.rs`
- [ ] Verify /queue subcommand list matches `plugin/queue.rs`
