### PR TITLE
docs(hive): rewrite PRDs for standalone app architecture

### DIFF
--- a/docs/hive/README.md
+++ b/docs/hive/README.md
@@ -1,86 +1,155 @@
-# Hive — Multi-Room Orchestration Layer
+# Hive — Agent Orchestration Platform
 
 ## What is Hive?
 
-Hive is the product layer that sits above `room`. Where `room` provides the
-low-level primitives (broker, sockets, messages, plugins), Hive provides the
-user-facing experience for managing teams of agents across multiple rooms.
+Hive is a standalone application (web or native) that provides the user-facing
+experience for managing teams of AI agents. It uses `room` as its real-time
+collaboration infrastructure — the way a web application uses PostgreSQL for
+data storage.
 
-Think of it this way:
+Hive is **not** a CLI tool, not a room subcommand, and not part of the room
+binary. It is a separate deployment unit that communicates with room exclusively
+via WebSocket (primary) and REST (secondary).
 
-- **room** = a single chat room with a broker, message history, and plugins.
-- **room daemon** = multiple rooms running on one host, with shared auth.
-- **Hive** = the workspace that ties rooms, agents, teams, and tasks together
-  into a coherent product experience.
+## Architecture
 
-## Relationship to room
+```
+┌──────────────────────────────────────────────────────┐
+│  Hive Instance                                       │
+│                                                      │
+│  ┌────────────┐  ┌──────────────┐  ┌──────────────┐ │
+│  │   Web UI   │  │ Agent Runner │  │   Billing    │ │
+│  │ (frontend) │  │  (lifecycle) │  │  (metering)  │ │
+│  └─────┬──────┘  └──────┬───────┘  └──────┬───────┘ │
+│        │                │                  │         │
+│  ┌─────┴────────────────┴──────────────────┴───────┐ │
+│  │              Hive Server (backend)              │ │
+│  │  Auth (OAuth/API keys) · Token lifecycle        │ │
+│  │  Agent deployment · Workspace management        │ │
+│  └─────────────────────┬───────────────────────────┘ │
+│                        │                              │
+│                  WS + REST API                        │
+│                        │                              │
+│  ┌─────────────────────┴───────────────────────────┐ │
+│  │           Room Server (bundled)                  │ │
+│  │  Broker · Plugins · Message routing · Persistence│ │
+│  └─────────────────────────────────────────────────┘ │
+└──────────────────────────────────────────────────────┘
+```
 
-Hive does not replace room — it orchestrates it. Every Hive feature is built on
-top of existing room primitives:
+The deployment unit is a **Hive instance** that bundles a room server scoped
+to it. Room handles real-time collaboration. Hive handles everything else.
 
-| Hive concept | Built on |
-|---|---|
-| Workspace | Daemon multi-room + UserRegistry |
-| Team | Agent personalities + /spawn + room subscriptions |
-| Task board | /taskboard plugin + room messages |
-| Agent discovery | /who + /stats + agent status tracking |
-| Multi-room view | room poll --rooms + subscription tiers |
+## Separation of concerns
 
-Hive never bypasses room's socket protocol. All communication flows through the
-broker. Hive is a client-side experience layer, not a new server.
+| Domain | Owner | Examples |
+|---|---|---|
+| Real-time messaging | room | Broker, fan-out, NDJSON persistence, chat history |
+| Plugins | room | /taskboard, /queue, /help, /stats — single definition generates CLI + slash + WS interfaces |
+| Agent behavior | room-ralph | Prompt building, context monitoring, Claude interaction, restart on exhaustion |
+| UI | Hive | Web dashboard, workspace views, task boards, agent status panels |
+| Authentication | Hive | OAuth, API keys, user accounts — maps to room tokens internally |
+| Billing/metering | Hive | Per-agent cost tracking (cloud API and local model agents), per-team rollups |
+| Agent deployment | Hive | Clone repos, set up workdirs, spawn agents, monitor lifecycle |
+| Token lifecycle | Hive | Calls `room join` to mint tokens, stores them, passes to agents on spawn |
+| Workspace management | Hive | Groups of rooms, team rosters, cross-room views |
 
 ## Design principles
 
-1. **room stays simple.** Hive adds features as plugins, CLI wrappers, and UI
-   components — not by modifying broker internals.
+1. **Room stays generic.** Room is infrastructure — it does not know about Hive,
+   billing, or agent deployment. Hive-specific features are built as plugins or
+   in the Hive server, never by modifying broker internals.
 
-2. **Agents are users.** Hive treats AI agents and human users identically at the
-   protocol level. A spawned agent joins via `room join`, subscribes via
-   `room subscribe`, and communicates via `room send`. The distinction is in the
-   management layer (spawn, stop, monitor), not the protocol.
+2. **Plugins are the extension points.** A single plugin definition generates
+   three interfaces: CLI subcommand (`room <plugin> <action>`), in-room slash
+   command (`/<plugin> <action>`), and WS/REST endpoint. Room dispatches all
+   three to the same handler via `CommandContext`. Hive consumes the WS/REST
+   interface.
 
-3. **Rooms are boundaries.** Each room is an independent coordination context.
-   Cross-room coordination happens via agents subscribed to multiple rooms, not
-   via server-side room linking.
+3. **Agents are users at the protocol level.** Hive treats AI agents and humans
+   identically in the room wire format. An agent joins via token, subscribes to
+   rooms, sends messages, and receives broadcasts. The distinction is in Hive's
+   management layer (spawn, stop, monitor, bill), not in room's protocol.
 
-4. **Progressive disclosure.** A user running `room myroom alice` today should
-   get value immediately. Hive features like teams, workspaces, and agent
-   discovery are additive — they enhance the experience without requiring
-   migration.
+4. **No compile-time dependency on room-cli.** Hive talks to room via WS and
+   REST only. It may depend on `room-protocol` for message types, but never
+   imports broker internals or transport code.
+
+5. **WS is the primary transport.** WebSocket provides persistent bidirectional
+   streaming — Hive connects once and receives messages in real-time. REST is
+   secondary, used for stateless operations (health checks, one-off queries,
+   admin actions from the web UI).
+
+## Transport: room as infrastructure
+
+Hive communicates with its bundled room server over WebSocket:
+
+```
+Hive Server  ──[WS]──►  Room Broker (ws://localhost:<port>/ws/<room_id>)
+             ──[REST]──► Room Broker (http://localhost:<port>/api/...)
+```
+
+The current WS transport handles one room per connection. For Hive managing
+multiple rooms, future work includes a multiplexed WS endpoint at the daemon
+level with `room_id` in the message envelope, eliminating the need for N
+separate connections.
+
+### Plugin responses
+
+Plugins currently emit human-readable system messages. Hive needs
+machine-readable responses. A structured JSON `data` field alongside the
+human-readable `content` will allow Hive to parse task state, queue contents,
+and other plugin data programmatically without scraping chat text.
 
 ## PRDs in this folder
 
 | Document | Status | Summary |
 |---|---|---|
-| [prd-workspace.md](prd-workspace.md) | Draft | Multi-room workspace concept, team management |
-| [prd-team-provisioning.md](prd-team-provisioning.md) | Draft | /team create, agent manifests, ephemeral teams |
-| [prd-agent-discovery.md](prd-agent-discovery.md) | Draft | Expertise indexing, agent reputation, skill matching |
+| [prd-workspace.md](prd-workspace.md) | Draft | Workspace concept: room grouping, team rosters, cross-room views |
+| [prd-team-provisioning.md](prd-team-provisioning.md) | Draft | Agent team manifests, spawn/stop/scale, billing integration |
+| [prd-agent-discovery.md](prd-agent-discovery.md) | Draft | Expertise indexing, capacity tracking, skill matching |
 
-## Dependencies on room features
-
-Hive depends on several room features that are in various stages of readiness:
+## Room features Hive depends on
 
 | Feature | Status | Hive dependency |
 |---|---|---|
-| Multi-room daemon | Shipped (v3) | Required for workspaces |
-| UserRegistry | Shipped (v3) | Required for cross-room identity |
-| /spawn + personalities | In progress (#434, #439) | Required for team provisioning |
-| /taskboard | In progress (#444) | Required for task management |
-| Subscription tiers | Shipped (v3) | Required for multi-room views |
-| Agent status tracking | Shipped (v3) | Required for agent discovery |
+| Multi-room daemon | Shipped (v3) | Hive bundles a daemon instance |
+| UserRegistry | Shipped (v3) | Cross-room identity |
+| WS + REST transport | Shipped (v3) | Primary communication channel |
+| /taskboard plugin | Shipped (v3) | Task lifecycle management |
+| /queue plugin | Shipped (v3) | Backlog management |
+| Subscription tiers | Shipped (v3) | Per-room message filtering |
+| Agent status tracking | Shipped (v3) | Capacity and status views |
+| Token persistence | Shipped (v3) | Tokens survive broker restarts |
 
-## Open questions for joao
+## Hive-readiness gaps in room
 
-1. **Should Hive be a separate binary or part of `room`?** Current assumption:
-   Hive commands are subcommands of `room` (e.g. `room hive workspace create`).
-   A separate `hive` binary adds deployment complexity but cleaner separation.
+These room-side improvements would benefit Hive but are not blockers for
+initial development:
 
-2. **Web UI or CLI-only?** These PRDs assume CLI-first. A web dashboard (reading
-   room state via REST API) is a natural next step but not scoped here.
+| Gap | Description | Priority |
+|---|---|---|
+| WS multiplexing | Single connection with room_id in envelope (daemon-level) | High |
+| Structured plugin responses | JSON `data` field alongside human text | High |
+| Plugin trait decoupling (#454) | Move Plugin trait to room-protocol or room-plugin crate | Medium |
+| read_line size limit (#470) | Bound incoming message size to prevent OOM | Medium |
+| WS bind address (#455-MED-2) | Default to 127.0.0.1 instead of 0.0.0.0 | Low |
 
-3. **Multi-host support?** Room daemon is currently single-host. Hive workspaces
-   spanning multiple hosts would require WebSocket relay between daemons. Is this
-   a near-term goal or future aspiration?
+## Decisions made (2026-03-12)
 
-4. **Billing/metering?** If agents consume API credits (Claude API calls), should
-   Hive track per-agent or per-team costs? This affects the /stats plugin design.
+These questions from the original PRDs have been answered by joao:
+
+1. **Hive is a separate web/native app**, not a CLI tool or room subcommand.
+2. **Web UI, not CLI.** Hive's interface is a web dashboard or native app.
+3. **Hive owns token lifecycle.** Room's existing join/validate flow is
+   sufficient — Hive calls `room join` to mint tokens and manages them in its
+   own database.
+4. **Agent lifecycle is its own domain** within Hive — managing clones,
+   workdirs, spawning agents. Whether this becomes a separate crate is an
+   implementation decision deferred to development phase.
+5. **Billing tracks per-agent costs in detail**, including mixed local model
+   and cloud API agents.
+6. **Multi-host is future aspiration**, not near-term. WS relay between
+   daemons would be needed but is not scoped.
+7. **Single plugin definition generates all interfaces** — CLI + slash + WS.
+   This is a joao directive for room's plugin framework.

--- a/docs/hive/prd-agent-discovery.md
+++ b/docs/hive/prd-agent-discovery.md
@@ -1,10 +1,10 @@
 # PRD: Agent Discovery
 
-> Status: Draft
-> Author: r2d2
+> Status: Draft (revised)
+> Author: r2d2 (original), saphire (revised)
 > Date: 2026-03-12
-> Dependencies: /who (shipped), /stats (shipped), personalities (#439),
->   /taskboard (#444)
+> Dependencies: /who (shipped), /stats (shipped), /taskboard (shipped),
+>   room-ralph (shipped)
 
 ## Problem
 
@@ -12,25 +12,53 @@ In a workspace with 10+ agents across multiple rooms, finding the right agent
 for a task is non-trivial. Questions like "which agent knows about the broker
 code?", "who has capacity right now?", and "which reviewer has the best track
 record on CLI changes?" have no good answer today. The host manually assigns
-work based on memory and gut feel.
+work based on memory.
 
-As the number of agents grows, manual assignment doesn't scale. Agents idle
+As the number of agents grows, manual assignment does not scale. Agents idle
 while others are overloaded. Expertise is invisible — an agent that spent 20
 iterations deep in `broker/mod.rs` has knowledge that is lost when it goes
 offline.
 
 ## Goal
 
-Provide an **agent discovery** system that indexes agent expertise, tracks
-capacity, and helps the host (or coordinator agent) make informed assignment
-decisions.
+Provide an **agent discovery** system within Hive that indexes agent expertise,
+tracks capacity, and helps users make informed assignment decisions through
+Hive's web UI.
 
 ## Non-goals
 
-- Autonomous task assignment (agents don't self-assign — the host or coordinator
-  decides).
+- Autonomous task assignment without human approval (the coordinator or host
+  decides — Hive suggests).
 - Replacing the room coordination protocol.
 - Training or fine-tuning agents based on history.
+
+---
+
+## Architecture
+
+Agent discovery is a Hive-side feature. Room provides the raw data (status,
+messages, taskboard state); Hive indexes, aggregates, and presents it.
+
+```
+Room (data sources)                    Hive (indexing + UI)
+┌───────────────────┐                  ┌──────────────────────┐
+│ /who (online)     │──[WS]──────────► │ Capacity tracker     │
+│ /set_status       │──[WS]──────────► │                      │
+│ /taskboard list   │──[WS/REST]─────► │ Assignment tracker   │
+│ Chat history      │──[REST query]──► │                      │
+└───────────────────┘                  │ Expertise indexer    │
+                                       │   (also reads git)   │
+Git history ──────────────────────────►│                      │
+GitHub API ───────────────────────────►│ Skill matcher        │
+                                       └──────────┬───────────┘
+                                                   │
+                                       ┌───────────▼──────────┐
+                                       │  Hive Web UI         │
+                                       │  - Agent profiles    │
+                                       │  - Capacity view     │
+                                       │  - Suggest agent     │
+                                       └──────────────────────┘
+```
 
 ---
 
@@ -42,10 +70,10 @@ Every agent builds an implicit expertise profile through its work:
 
 - **Files touched**: tracked from git history (`git log --author=<username>`).
 - **Issues completed**: tracked from merged PRs with `Closes #N`.
-- **Domains**: inferred from file paths (e.g. `broker/` → broker internals,
-  `tui/` → terminal UI, `tests/` → testing infrastructure).
+- **Domains**: inferred from file paths (e.g. `broker/` = broker internals,
+  `tui/` = terminal UI, `plugin/` = plugin system).
 
-The expertise index is a per-agent record stored in the workspace state:
+Hive builds and maintains the expertise index in its database:
 
 ```json
 {
@@ -63,49 +91,42 @@ The expertise index is a per-agent record stored in the workspace state:
 
 ### 2. Capacity tracking
 
-Capacity is derived from agent status and current assignments:
+Capacity is derived from room's real-time data, streamed to Hive via WS:
 
-- **Idle**: agent is online but has no active claim or issue.
+- **Idle**: agent is online but has no active claim or taskboard assignment.
 - **Active**: agent has claimed a task via `/taskboard claim` or `/claim`.
 - **Blocked**: agent has set status containing "blocked" or "waiting".
 - **Offline**: agent is not connected to any room.
 
-```bash
-room hive agents --capacity
-```
+The Hive dashboard shows a live capacity view:
 
 ```
- agent      | status     | current task   | domains
- r2d2       | idle       | —              | broker, oneshot, ralph
- saphire    | active     | #444 taskboard | tui, plugin
- bumblebee  | active     | #438 subs      | broker, ws
- ba         | monitoring | sprint coord   | all
+ Agent      │ Status     │ Current task    │ Domains
+ r2d2       │ idle       │ —               │ broker, oneshot, ralph
+ saphire    │ active     │ #444 taskboard  │ tui, plugin
+ bumblebee  │ active     │ #438 subs       │ broker, ws
+ ba         │ monitoring │ sprint coord    │ all
 ```
 
 ### 3. Skill matching
 
-Given a new issue, suggest which agent is best suited:
+Given a new issue, Hive suggests which agent is best suited:
 
-```bash
-room hive suggest-agent --issue 450
-```
-
-The system:
-1. Reads the issue title and body from GitHub (`gh issue view 450`).
+1. Reads the issue title and body from GitHub (via webhook or API).
 2. Extracts keywords and file path hints (e.g. "fix bug in broker/commands.rs").
-3. Matches against the expertise index.
+3. Matches against the expertise index in Hive's database.
 4. Filters by capacity (prefer idle agents over active ones).
-5. Returns a ranked list of suggestions.
+5. Returns a ranked list of suggestions in the web UI.
 
 ```
 Suggested agents for #450 (broker command routing bug):
-  1. r2d2     — 12 files in broker/, 5 merged PRs, idle
+  1. r2d2      — 12 files in broker/, 5 merged PRs, idle
   2. bumblebee — 4 files in broker/, 2 merged PRs, active (#438)
   3. saphire   — 1 file in broker/, 0 merged PRs, active (#444)
 ```
 
-This is a suggestion, not an assignment. The host or coordinator makes the
-final decision.
+This is a suggestion, not an assignment. The user makes the final decision
+through the web UI. Hive then sends the assignment via room message.
 
 ---
 
@@ -113,157 +134,93 @@ final decision.
 
 ### 1. Build the expertise index
 
-```bash
-room hive agents index
-```
+Hive's backend periodically scans git history for all known agent usernames,
+builds the domain map, and stores it in Hive's database. This can also be
+triggered manually from the web UI ("Rebuild Index").
 
-Scans git history for all known agent usernames, builds the domain map, and
-writes to `~/.room/state/expertise.json`. This is an offline operation that
-can be run periodically or triggered after sprints close.
+Incremental updates happen after each merged PR (detected via GitHub webhook).
 
-For incremental updates:
+### 2. View agent profiles
 
-```bash
-room hive agents index --since 2026-03-01
-```
+The web UI shows per-agent profile pages with:
 
-### 2. Query agent expertise
-
-```bash
-room hive agents expertise r2d2
-```
-
-```
-Agent: r2d2
-Total PRs: 12 | Total issues: 12 | Avg time to merge: 45m
-
-Domains:
-  broker/     12 files, 5 PRs (last: 2026-03-12)
-  oneshot/     8 files, 3 PRs (last: 2026-03-10)
-  ralph/       6 files, 4 PRs (last: 2026-03-12)
-  protocol/    2 files, 1 PR  (last: 2026-02-28)
-```
+- Expertise domains and depth (files touched, PRs merged)
+- Current status and assignment
+- Historical activity (PRs per sprint, test contribution)
+- Cost data (API usage, session hours)
 
 ### 3. Find agents by domain
 
-```bash
-room hive agents find --domain tui
-```
+The web UI provides a search/filter interface:
 
-```
-Agents with TUI expertise:
-  saphire    — 15 files, 6 PRs (last: 2026-03-12)
-  bumblebee  — 3 files, 1 PR (last: 2026-03-05)
-```
+- Filter by domain (broker, tui, plugin, etc.)
+- Filter by status (idle, active, blocked)
+- Sort by expertise depth, availability, or cost efficiency
 
 ### 4. Agent reputation (stretch goal)
 
-Track quality metrics per agent over time:
+Quality metrics per agent over time:
 
-- **Merge rate**: PRs merged vs. PRs opened (indicates clean implementation).
-- **Review cycles**: average number of review rounds before merge.
-- **Regression rate**: bugs introduced by merged PRs (tracked by
-  `git bisect` or issue references).
+- **Merge rate**: PRs merged vs. PRs opened.
+- **Review cycles**: average review rounds before merge.
+- **Regression rate**: bugs introduced by merged PRs.
 - **Test contribution**: net change in test count per PR.
 
-```bash
-room hive agents reputation r2d2
-```
-
-```
-Agent: r2d2 (sprint 10-12)
-  Merge rate:      100% (12/12)
-  Avg review cycles: 1.2
-  Regressions:     1 (#411 caused by #408)
-  Test contribution: +42 net tests
-```
-
-This data helps the coordinator decide whether an agent needs supervision
-(pair with a reviewer) or can be trusted with autonomous work.
+Reputation data is visible to workspace admins in the web UI. It helps
+decide whether an agent needs supervision or can work autonomously.
 
 ---
 
 ## Data model
 
-### Expertise index
+### Hive database (not room)
 
-Location: `~/.room/state/expertise.json`
+All agent discovery state lives in Hive's database:
 
-Built from git history. Updated on-demand via `room hive agents index`.
+- **Expertise index**: per-agent domain map, built from git history.
+- **Agent profiles**: expertise + reputation + cost data per agent.
+- **Capacity snapshots**: periodic snapshots for trend analysis.
 
-### Agent profiles
-
-Location: `~/.room/state/agent-profiles/<username>.json`
-
-Per-agent profile including expertise, reputation, and preferences. Written
-by the index command and updated incrementally.
-
-### Capacity snapshot
-
-Not persisted — derived live from:
-- `/who` output (online/offline).
-- Agent status (`/set_status` values).
-- `/taskboard` claims (active assignments).
+Room's data model is unchanged. Room provides raw status/message data;
+Hive aggregates it.
 
 ---
 
-## Dependencies on room features
+## Room features used
 
-| Feature | Status | How agent discovery uses it |
+| Feature | Status | How Hive uses it |
 |---|---|---|
-| /who | Shipped | Online/offline detection |
+| /who | Shipped | Online/offline detection (via WS) |
 | /stats | Shipped | Agent activity metrics |
-| /set_status | Shipped | Capacity inference (idle/active/blocked) |
-| /taskboard (#444) | In progress | Current assignments |
-| Agent status tracking | Shipped | Real-time status in capacity view |
+| /set_status | Shipped | Capacity inference (via WS status stream) |
+| /taskboard | Shipped | Current assignments |
 | UserRegistry | Shipped | Agent identity across rooms |
-| Personalities (#439) | Shipped | Personality metadata in profiles |
-| Git history | External | Expertise index source data |
-| GitHub API (gh) | External | Issue details for skill matching |
+| WS streaming | Shipped | Real-time status updates |
+| REST query | Shipped | Historical message search |
 
 ---
 
-## Implementation considerations
+## External dependencies
 
-### Data freshness
-
-The expertise index is built from git history — it is always stale by the
-duration of the current sprint. For accurate suggestions, run
-`room hive agents index` at the start of each sprint and after each major
-merge batch.
-
-Capacity is live — it reads current `/who` and status data. No staleness
-concern.
-
-### Privacy
-
-Agent expertise data is derived from public git history and room messages. No
-new data is collected — the index is a materialized view of existing information.
-
-### Performance
-
-Git history scanning for ~1000 commits takes <1 second. The expertise index
-is small (KB range). No performance concern for workspaces with <50 agents.
+| Dependency | Purpose |
+|---|---|
+| Git history | Expertise index source data |
+| GitHub API / webhooks | Issue details for skill matching, PR merge events |
 
 ---
 
-## Open questions for joao
+## Resolved questions
 
-1. **Should expertise indexing be automatic?** Current proposal: manual
-   (`room hive agents index`). Alternative: daemon runs periodic indexing in
-   the background. Risk: resource usage on large repos.
+1. **Expertise indexing is automatic.** Hive's backend rebuilds incrementally
+   on PR merge events (GitHub webhook). Full rebuilds can be triggered from
+   the web UI.
 
-2. **Agent reputation — useful or premature?** Reputation metrics (merge rate,
-   regression rate) are valuable for the coordinator but could create perverse
-   incentives if agents optimize for metrics over quality. Should this be
-   host-only data?
+2. **Agent reputation is useful but admin-only.** Visible to workspace admins,
+   not to agents themselves. Avoids perverse incentives.
 
-3. **Cross-workspace expertise.** If an agent works in workspace A and then
-   is assigned to workspace B, should its expertise from A be visible? Current
-   proposal: expertise is global (not workspace-scoped) since it is derived
-   from git history which is repo-scoped.
+3. **Expertise is global, not workspace-scoped.** Expertise comes from git
+   history which is repo-scoped, not workspace-scoped. An agent's expertise
+   from workspace A is visible when assigned to workspace B.
 
-4. **Suggest-agent automation.** Should the coordinator agent be able to call
-   `suggest-agent` programmatically and auto-assign, or should it always be a
-   human decision? The coordination protocol today requires host approval for
-   assignments — auto-assignment would bypass that.
+4. **Suggest-agent is advisory.** Hive suggests; humans decide. Auto-assignment
+   is a future feature that requires explicit opt-in per workspace.

--- a/docs/hive/prd-team-provisioning.md
+++ b/docs/hive/prd-team-provisioning.md
@@ -1,222 +1,231 @@
 # PRD: Team Provisioning
 
-> Status: Draft
-> Author: r2d2
+> Status: Draft (revised)
+> Author: r2d2 (original), saphire (revised)
 > Date: 2026-03-12
-> Dependencies: /spawn + personalities (#434, #439), workspaces (prd-workspace.md)
+> Dependencies: room-ralph (shipped), workspaces (prd-workspace.md)
 
 ## Problem
 
-Spawning a team of agents today is a manual, repetitive process. For a typical
-sprint, the host runs 3-5 `room-ralph` commands with different personalities,
-models, and issue assignments. If the broker restarts, agents die and must be
-re-spawned individually. There is no declarative way to say "I want a team of
-coder + reviewer + coordinator in this workspace" and have it materialize.
+Spawning a team of agents today is a manual process. The host runs multiple
+`room-ralph` commands with different personalities, models, and issue
+assignments. If agents crash, ralph handles restarts — but provisioning the
+initial team and managing its lifecycle (scale up, tear down, re-provision)
+has no unified interface.
+
+As Hive manages larger deployments, the manual approach does not scale.
+Hive needs a programmatic way to define, spawn, monitor, and tear down
+agent teams.
 
 ## Goal
 
-Let users define **team manifests** — declarative descriptions of agent teams
-that can be provisioned with a single command. Teams are ephemeral (spawn, use,
-tear down) but the manifest is reusable.
+Let Hive define **team manifests** — declarative descriptions of agent teams
+that can be provisioned, monitored, and torn down through Hive's web interface
+and API.
 
 ## Non-goals
 
-- Persistent agent processes (agents still die on broker restart — ralph handles
-  reconnection).
-- Agent-to-agent delegation or hierarchy.
-- Resource scheduling across multiple hosts.
+- Modifying room-ralph internals — ralph remains an independent agent execution
+  tool. Hive orchestrates it, not replaces it.
+- Resource scheduling across multiple hosts (future aspiration).
+- Agent-to-agent delegation or hierarchy at the protocol level.
+
+---
+
+## Architecture
+
+Agent lifecycle management is its own domain within Hive. The stack:
+
+```
+Hive Web UI
+    │
+    ▼
+Hive Server (orchestration: decides when/why to spawn)
+    │
+    ▼
+Agent Runner (lifecycle: clone, workdir setup, spawn, monitor, restart)
+    │
+    ▼
+room-ralph (execution: prompt building, context monitoring, claude interaction)
+    │
+    ▼
+room (collaboration: messages, plugins, persistence)
+```
+
+Whether the Agent Runner is a separate crate or a module within Hive is an
+implementation decision deferred to development. The PRD captures
+responsibilities and interfaces, not package structure.
+
+### Responsibilities
+
+| Component | Owns |
+|---|---|
+| Hive Server | Business logic — "PR #42 arrived, spin up a reviewer" |
+| Agent Runner | Infrastructure — clone repo at PR ref, set up workdir, spawn ralph, monitor process, handle restarts |
+| room-ralph | Agent behavior — prompts, tool selection, context monitoring, claude subprocess |
+| room | Collaboration — message routing, plugins, persistence |
 
 ---
 
 ## User flows
 
+All interactions happen through Hive's web UI or API.
+
 ### 1. Define a team manifest
 
-```toml
-# ~/.room/teams/sprint-dev.toml
-[team]
-name = "sprint-dev"
-description = "Standard sprint development team"
+In Hive's web UI, the user creates a team template:
 
-[[agent]]
-personality = "coder"
-username_prefix = "coder"
-model = "opus"
-count = 2
-
-[[agent]]
-personality = "reviewer"
-username_prefix = "reviewer"
-model = "sonnet"
-
-[[agent]]
-personality = "coordinator"
-username_prefix = "ba"
-model = "opus"
+```json
+{
+  "name": "sprint-dev",
+  "description": "Standard sprint development team",
+  "agents": [
+    {
+      "personality": "coder",
+      "username_prefix": "coder",
+      "model": "opus",
+      "count": 2
+    },
+    {
+      "personality": "reviewer",
+      "username_prefix": "reviewer",
+      "model": "sonnet"
+    },
+    {
+      "personality": "coordinator",
+      "username_prefix": "ba",
+      "model": "opus"
+    }
+  ]
+}
 ```
 
-Each `[[agent]]` entry maps to a `/spawn` invocation. The `count` field
-(default 1) allows spawning multiple agents of the same personality.
+Manifests are stored in Hive's database. They are reusable across
+workspaces and sprints.
 
 ### 2. Provision a team
 
-```bash
-room hive team spawn sprint-dev --room triage --issue-prefix 430
-```
+From the workspace view, the user clicks "Spawn Team" and selects a
+manifest. Hive:
 
-This:
-1. Reads `~/.room/teams/sprint-dev.toml`.
-2. For each agent entry, calls `/spawn` (or `room-ralph` directly):
-   - `coder-a1b2` with personality=coder, model=opus, issue=430
-   - `coder-c3d4` with personality=coder, model=opus, issue=431
-   - `reviewer-e5f6` with personality=reviewer, model=sonnet
-   - `ba-g7h8` with personality=coordinator, model=opus
-3. Each agent joins the specified room automatically.
-4. A summary is broadcast to the room.
+1. Reads the manifest from its database.
+2. For each agent entry, the Agent Runner:
+   - Optionally clones the target repo at the specified ref.
+   - Sets up an isolated workdir.
+   - Mints a room token (via `room join`), stored in Hive's database.
+   - Subscribes the agent to the workspace rooms.
+   - Spawns `room-ralph` with the appropriate profile, model, and room token.
+3. Broadcasts a team provisioning summary to the workspace's default room.
 
-### 3. Check team status
+### 3. Monitor team status
 
-```bash
-room hive team status sprint-dev
-```
+The workspace dashboard shows a live agent status panel:
 
 ```
-Team: sprint-dev (room: triage)
- agent       | personality | model  | status           | uptime
- coder-a1b2  | coder       | opus   | implementing #430 | 14m
- coder-c3d4  | coder       | opus   | running tests     | 12m
- reviewer-e5 | reviewer    | sonnet | reviewing PR #443 | 8m
- ba-g7h8     | coordinator | opus   | monitoring sprint | 14m
+Team: sprint-dev (workspace: sprint-12)
+ Agent       │ Personality │ Model  │ Status             │ Uptime
+ coder-a1b2  │ coder       │ opus   │ implementing #430  │ 14m
+ coder-c3d4  │ coder       │ opus   │ running tests      │ 12m
+ reviewer-e5 │ reviewer    │ sonnet │ reviewing PR #443  │ 8m
+ ba-g7h8     │ coordinator │ opus   │ monitoring sprint  │ 14m
 ```
 
-Uses `/agent list` and `/who` data combined with status information.
+Status is derived from room's `/who` output and agent `/set_status` values,
+streamed to Hive via WS.
 
-### 4. Tear down a team
+### 4. Scale a team
 
-```bash
-room hive team stop sprint-dev
-```
+From the dashboard, the user can add or remove agents:
 
-Sends `/agent stop` for every agent in the team. Broadcasts a shutdown
-summary to the room. The manifest is preserved for re-use.
+- **Add**: spawn another agent of a given personality, assigned to a specific
+  issue or task.
+- **Remove**: gracefully stop a specific agent (sends shutdown signal, waits
+  for current work to complete, broadcasts leave event).
 
-### 5. Scale a team
+### 5. Tear down a team
 
-```bash
-room hive team scale sprint-dev --add coder --issue 445
-```
+"Stop Team" sends shutdown signals to all agents, collects final status, and
+broadcasts a summary. The manifest is preserved for re-use. Agent tokens are
+revoked.
 
-Adds one more coder agent to the running team, assigned to issue 445.
+### 6. Automated provisioning (advanced)
 
-```bash
-room hive team scale sprint-dev --remove reviewer-e5f6
-```
+Hive can trigger agent provisioning based on external events:
 
-Stops a specific agent from the team.
+- **PR arrives**: Hive detects a new PR via GitHub webhook, clones the repo
+  at the PR ref, spawns a reviewer agent with the repo as workdir.
+- **Issue created**: Hive detects a new issue, matches it to an available
+  agent via skill matching (see prd-agent-discovery.md), and assigns it.
+- **Schedule**: spawn a CI-watcher agent at the start of each business day,
+  tear it down at end of day.
 
 ---
 
-## Agent manifests (advanced)
+## Billing and metering
 
-For more control than personalities provide, users can define full agent
-manifests that specify custom prompts, tool restrictions, and environment:
+Hive tracks per-agent costs in detail:
 
-```toml
-# ~/.room/teams/security-audit.toml
-[team]
-name = "security-audit"
+| Cost type | Source | Tracking |
+|---|---|---|
+| Cloud API (Claude, etc.) | API provider billing | Per-agent, per-session |
+| Local model | Compute time | Per-agent, per-session |
+| Infrastructure | room server resources | Per-workspace |
 
-[[agent]]
-username_prefix = "auditor"
-profile = "reader"
-model = "opus"
-prompt_file = "~/.room/prompts/security-audit.md"
-disallow_tools = ["Write", "Edit", "Bash(git push *)"]
-add_dirs = ["/path/to/target-repo"]
-max_iter = 10
-```
+Agents may be mixed: a coding agent uses Claude (cloud billing), while a
+summarization agent runs a local model (no API cost, but compute cost). Hive
+must distinguish these and provide per-agent and per-team cost rollups.
 
-This gives full control over the `room-ralph` invocation without needing
-a custom personality definition.
+The billing UI shows:
 
----
-
-## Ephemeral teams
-
-Teams spawned with `--ephemeral` auto-destroy when a condition is met:
-
-```bash
-room hive team spawn sprint-dev --room triage --ephemeral=idle:30m
-```
-
-Options:
-- `--ephemeral=idle:30m` — tear down after 30 minutes of no agent activity.
-- `--ephemeral=task:445` — tear down when issue #445 is closed.
-- `--ephemeral=time:2h` — tear down after 2 hours regardless.
-
-Ephemeral teams are tracked via a metadata file alongside the manifest. A
-background check (in the daemon or a helper process) polls for the condition
-and runs `team stop` when met.
+- Per-agent cost breakdown (API calls, tokens consumed, compute time)
+- Per-team aggregates
+- Per-workspace totals
+- Historical trends
 
 ---
 
 ## Data model
 
-### Team manifest file
+### Hive database (not room)
 
-Location: `~/.room/teams/<name>.toml`
+Team state lives in Hive's database:
 
-### Active team state
+- **Team manifests**: reusable templates (name, agents, personalities, models)
+- **Active team instances**: running agents (username, PID, spawn time, room
+  tokens, assigned issues)
+- **Billing records**: per-agent cost events (API calls, duration, model used)
 
-Location: `~/.room/state/teams/<name>.json`
-
-```json
-{
-  "team": "sprint-dev",
-  "room": "triage",
-  "spawned_at": "2026-03-12T10:00:00Z",
-  "agents": [
-    {"username": "coder-a1b2", "pid": 12345, "personality": "coder", "issue": "430"},
-    {"username": "reviewer-e5f6", "pid": 12400, "personality": "reviewer", "issue": null}
-  ],
-  "ephemeral": null
-}
-```
-
-This file is written on spawn and updated on scale/stop. It is the source of
-truth for `team status` and `team stop`.
+Room's data model is unchanged. Room only knows about connected users and
+messages.
 
 ---
 
-## Dependencies on room features
+## Room features used
 
-| Feature | Status | How team provisioning uses it |
+| Feature | Status | How Hive uses it |
 |---|---|---|
-| /spawn + personalities | In progress (#434, #439) | Core spawn mechanism |
-| /agent list + stop | Planned (#434 phase 1) | Team status and teardown |
-| PID persistence | Planned (#434 phase 3) | Survive broker restarts |
-| Agent status tracking | Shipped | Team status dashboard |
-| Workspaces | Proposed (prd-workspace.md) | Team-workspace association |
+| Token issuance (room join) | Shipped | Mint tokens for spawned agents |
+| room subscribe | Shipped | Auto-subscribe agents to workspace rooms |
+| /who + status | Shipped | Live agent status for dashboard |
+| /taskboard | Shipped | Task assignment tracking |
+| WS streaming | Shipped | Real-time status updates |
+| Token persistence | Shipped | Tokens survive broker restarts |
 
 ---
 
-## Open questions for joao
+## Resolved questions
 
-1. **Issue assignment strategy.** Should `--issue-prefix` auto-increment
-   (430, 431, 432...) or should each agent entry in the manifest specify its
-   own issue? Auto-increment is convenient but fragile (gaps in issue numbers).
+1. **Issue assignment**: Hive manages issue assignment, not the team manifest.
+   Manifests define agent types; Hive's orchestration layer assigns specific
+   issues based on capacity and expertise (see prd-agent-discovery.md).
 
-2. **Team-level resource limits.** Should there be a max total agents across
-   all teams per daemon (e.g. 20)? Or per-team limits in the manifest? Current
-   `/agent` has a per-room limit of 5.
+2. **Resource limits**: Hive enforces per-workspace and per-team agent limits
+   in its own configuration, not in room.
 
-3. **Team restart semantics.** If an agent in a team crashes (context exhaustion,
-   error), ralph already handles restart. But if the whole team is stopped and
-   re-spawned (`team spawn` again), should it resume from progress files or
-   start fresh? Progress files are per-issue, so they'd survive — but the team
-   state file would need reconciliation.
+3. **Restart semantics**: room-ralph handles individual agent restarts
+   (context exhaustion, errors). Hive handles team-level lifecycle (provision,
+   scale, tear down). Progress files bridge the gap — ralph reads them on
+   restart, Hive can manage them via the Agent Runner.
 
-4. **Shared vs. personal manifests.** Like workspaces, team manifests are
-   currently personal (`~/.room/teams/`). Should there be a shared location
-   (e.g. in the repo under `teams/`) so all team members use the same
-   definition?
+4. **Shared manifests**: manifests are stored in Hive's database, accessible
+   to all team members. No per-user local files.

--- a/docs/hive/prd-workspace.md
+++ b/docs/hive/prd-workspace.md
@@ -1,191 +1,156 @@
 # PRD: Hive Workspaces
 
-> Status: Draft
-> Author: r2d2
+> Status: Draft (revised)
+> Author: r2d2 (original), saphire (revised)
 > Date: 2026-03-12
-> Dependencies: daemon multi-room (shipped), UserRegistry (shipped), /taskboard (#444)
+> Dependencies: daemon multi-room (shipped), UserRegistry (shipped), /taskboard (shipped)
 
 ## Problem
 
-Today, managing multiple rooms requires running separate `room` commands per room
-or a daemon with manual `room create` / `room subscribe` invocations. There is no
-concept of a "workspace" — a named collection of rooms with shared configuration,
-team membership, and a unified view of activity across rooms.
-
-For a team running 5-10 rooms (one per feature, one for triage, one for CI
-notifications), the cognitive overhead of subscribing to the right rooms, tracking
-which agent is in which room, and finding messages across rooms is significant.
+Teams running multiple rooms (one per feature, one for triage, one for CI
+notifications) face cognitive overhead: tracking which agent is in which room,
+finding messages across rooms, and managing subscriptions. There is no unified
+"workspace" concept that groups rooms with shared configuration and team
+membership.
 
 ## Goal
 
-Provide a **workspace** abstraction that groups rooms, manages cross-room
-subscriptions, and gives users a single entry point for multi-room workflows.
+Provide a **workspace** abstraction within Hive that groups rooms, manages
+team membership, and gives users a unified view of activity across rooms.
 
 ## Non-goals
 
-- Replacing the daemon — workspaces are a layer on top of daemon rooms.
-- Cross-host workspaces (see open questions).
+- Replacing the room daemon — workspaces are a Hive-level concept layered on
+  daemon rooms.
+- Cross-host workspaces (future aspiration — requires WS relay).
 - Room-level ACLs beyond what room already supports.
 
 ---
 
+## Architecture
+
+Workspaces are a **Hive server concept**, not a room concept. Room has no
+knowledge of workspaces — it only knows about individual rooms and their
+subscribers. Hive maintains workspace state in its own database and
+translates workspace operations into room API calls.
+
+```
+Hive Web UI                    Hive Server                Room Daemon
+┌──────────────┐               ┌──────────────┐           ┌──────────┐
+│ Workspace    │──[HTTP/WS]──► │ Workspace    │──[WS]───► │ Room A   │
+│   Dashboard  │               │   Manager    │──[WS]───► │ Room B   │
+│              │               │              │──[REST]──► │ Room C   │
+└──────────────┘               └──────────────┘           └──────────┘
+```
+
 ## User flows
+
+All interactions happen through Hive's web UI or native app. There are no
+CLI commands — Hive is not a CLI tool.
 
 ### 1. Create a workspace
 
-```bash
-room hive workspace create sprint-12 \
-  --rooms triage,feature-auth,feature-taskboard,ci-notifications \
-  --default-room triage
-```
+The user opens Hive's web dashboard, creates a workspace named "sprint-12",
+and selects which rooms to include. Hive:
 
-This:
-1. Ensures all listed rooms exist in the daemon (creates missing ones).
-2. Stores workspace metadata in `~/.room/workspaces/sprint-12.toml`.
-3. Auto-subscribes the user to all listed rooms.
+1. Ensures all listed rooms exist in the bundled room daemon (creates missing
+   ones via REST `POST /api/<room>/create`).
+2. Stores workspace metadata in Hive's database.
+3. Auto-subscribes the user to all listed rooms via room's subscribe API.
 
-```toml
-# ~/.room/workspaces/sprint-12.toml
-[workspace]
-name = "sprint-12"
-default_room = "triage"
-rooms = ["triage", "feature-auth", "feature-taskboard", "ci-notifications"]
-created_at = "2026-03-12T10:00:00Z"
-```
+### 2. Workspace dashboard
 
-### 2. Join a workspace
-
-```bash
-room hive workspace join sprint-12
-```
-
-Reads the workspace TOML, subscribes the user to all rooms, and opens the TUI
-with the default room selected. The room list in the TUI sidebar shows only
-workspace rooms (not all daemon rooms).
-
-### 3. Multi-room view
-
-```bash
-room hive inbox
-# or within TUI: /inbox
-```
-
-Shows recent messages from all workspace rooms, merged by timestamp:
+The workspace view shows a unified timeline of messages from all workspace
+rooms, merged by timestamp:
 
 ```
-[triage]          ba: sprint 12 scorecard updated
-[feature-auth]    saphire: PR #445 merged
+[triage]           ba: sprint 12 scorecard updated
+[feature-auth]     saphire: PR #445 merged
 [ci-notifications] ci-bot: all checks passed on master
-[triage]          joao: @r2d2 pick up #435
+[triage]           joao: @r2d2 pick up #435
 ```
 
-This is a read-only view. To reply, the user switches to the specific room.
+Implementation: Hive maintains WS connections to each workspace room (or a
+single multiplexed connection once room supports it) and merges the streams
+in real-time.
 
-Implementation: uses `room poll --rooms <list>` under the hood.
+### 3. Room switching
+
+From the workspace view, the user clicks on a room name to enter that room's
+dedicated view. The room view shows full chat history, member list, and
+allows sending messages — all via room's WS transport.
 
 ### 4. Add/remove rooms
 
-```bash
-room hive workspace add-room sprint-12 hotfix-queue
-room hive workspace remove-room sprint-12 ci-notifications
-```
-
-Updates the TOML and adjusts subscriptions.
+The workspace settings panel allows adding or removing rooms. Hive updates
+its database and adjusts room subscriptions accordingly.
 
 ### 5. Archive a workspace
 
-```bash
-room hive workspace archive sprint-12
-```
-
-Unsubscribes from all rooms, moves the TOML to `~/.room/workspaces/archive/`.
-Rooms are not destroyed — they persist in the daemon with their history.
+Archiving a workspace unsubscribes users from all rooms and hides the
+workspace from the active list. Rooms are not destroyed — they persist in
+the daemon with their history.
 
 ---
 
 ## Team management within workspaces
 
-Each workspace can have a **team roster** — named users and agents assigned to it.
-The roster is informational (it does not enforce access control) but drives:
+Each workspace has a **team roster** — named users and agents assigned to it.
 
-- Default agent spawning: `room hive team spawn sprint-12` spawns all agents
-  defined in the team manifest (see prd-team-provisioning.md).
-- Status dashboard: `room hive team status sprint-12` shows the status of every
-  team member across all workspace rooms.
-- Notifications: `room hive team notify sprint-12 "standup in 5"` sends a message
-  to each team member via their subscribed room.
-
-```toml
-# Added to workspace TOML
-[team]
-members = ["joao", "ba", "r2d2", "saphire", "bumblebee"]
-```
+- **Status dashboard**: the workspace view shows each team member's status
+  across all workspace rooms (pulled from room's `/who` and status data via
+  WS).
+- **Agent spawning**: the workspace provides a "spawn team" action that
+  provisions agents according to a team manifest (see prd-team-provisioning.md).
+- **Notifications**: Hive can broadcast a message to all team members via
+  their subscribed rooms.
 
 ---
 
 ## Data model
 
-### Workspace file
+### Hive database (not room)
 
-Location: `~/.room/workspaces/<name>.toml`
+Workspace state lives in Hive's database — not in room's filesystem or
+NDJSON files. This includes:
 
-```toml
-[workspace]
-name = "sprint-12"
-default_room = "triage"
-rooms = ["triage", "feature-auth", "feature-taskboard"]
-created_at = "2026-03-12T10:00:00Z"
+- Workspace name, creation date, archived status
+- List of room IDs in the workspace
+- Team roster (user/agent names, roles)
+- Active workspace per user (last used)
 
-[team]
-members = ["joao", "ba", "r2d2", "saphire"]
-```
-
-### Workspace registry
-
-Location: `~/.room/workspaces/registry.json`
-
-```json
-{
-  "active": "sprint-12",
-  "workspaces": ["sprint-12", "sprint-11"]
-}
-```
-
-The `active` field tracks the last-used workspace for commands that don't specify
-one explicitly.
+Room's data model is unchanged. Room only knows about individual rooms,
+subscribers, and messages.
 
 ---
 
-## Dependencies on room features
+## Room features used
 
-| Feature | Status | How workspace uses it |
+| Feature | Status | How Hive uses it |
 |---|---|---|
 | Daemon multi-room | Shipped | Workspace rooms are daemon rooms |
-| room create / destroy | Shipped | Workspace create ensures rooms exist |
+| room create / destroy | Shipped | Workspace create ensures rooms exist (via REST) |
 | room subscribe | Shipped | Workspace join subscribes to all rooms |
-| room poll --rooms | Shipped | Multi-room inbox view |
+| WS streaming | Shipped | Real-time message feed for workspace view |
+| REST poll/query | Shipped | History and search across workspace rooms |
 | UserRegistry | Shipped | Cross-room identity for team roster |
-| /taskboard (#444) | In progress | Task tracking across workspace rooms |
-| Subscription persistence (#438) | In progress | Survives broker restarts |
+| /taskboard | Shipped | Task tracking across workspace rooms |
+| Subscription persistence | Shipped | Survives broker restarts |
 
 ---
 
-## Open questions for joao
+## Resolved questions
 
-1. **Should workspaces be shared or personal?** Current proposal: personal
-   (each user has their own `~/.room/workspaces/`). Shared workspaces would
-   require storing the TOML in the daemon's data directory and broadcasting
-   changes.
+1. **Workspaces are shared, managed by Hive.** Since Hive is a server, workspace
+   state is centralized in Hive's database — not per-user local TOML files.
+   All team members see the same workspace configuration.
 
-2. **Should workspace rooms auto-create on workspace create?** Current proposal:
-   yes — `workspace create` calls `room create` for any listed room that doesn't
-   exist. Alternative: require rooms to exist first (fail-fast).
+2. **Workspace rooms auto-create.** When a workspace is created, Hive ensures
+   all listed rooms exist in the daemon, creating any that are missing.
 
-3. **TUI integration depth.** Options:
-   - (a) Workspace-aware sidebar (show only workspace rooms, grouped).
-   - (b) Full workspace TUI mode (tabs per room, unified notification).
-   - (c) CLI-only for v1, TUI later.
+3. **Web UI, not TUI.** Hive provides a web dashboard. The room TUI remains
+   independently useful for direct room access but is not part of Hive.
 
-4. **Workspace-scoped taskboard.** Should `/taskboard` commands be workspace-wide
-   (tasks visible across all rooms) or per-room? Per-room is simpler but
-   fragments task tracking.
+4. **Taskboard scope.** Per-room taskboards remain the default (room is
+   generic). Hive's web UI can aggregate taskboard data across workspace rooms
+   by querying each room's `/taskboard list` response.


### PR DESCRIPTION
## Summary

- Rewrites all 4 docs/hive/ PRDs to reflect architecture decisions from team discussion (2026-03-12)
- Hive is now a standalone web/native app using room as infrastructure via WS/REST
- Replaces all `room hive` CLI examples with web UI flows
- Resolves open questions with joao's answers (auth ownership, billing, multi-host scope)

## Key changes

- **README.md**: New architecture diagram, separation of concerns table, hive-readiness gaps, resolved questions section
- **prd-workspace.md**: Workspaces are Hive-server concepts with shared database state, not local TOML files. Web dashboard replaces CLI commands
- **prd-team-provisioning.md**: Agent Runner lifecycle stack (Hive -> Agent Runner -> ralph -> room). Billing/metering section added. Team manifests in Hive database
- **prd-agent-discovery.md**: Expertise indexing and capacity tracking are Hive-side features reading room data via WS. Web UI for agent profiles and skill matching

## Test plan

- [ ] Verify all markdown renders correctly on GitHub
- [ ] Confirm no stale references to `room hive` CLI commands remain
- [ ] Review architecture diagrams for accuracy