### PR TITLE
fix(auth): reject KICKED sentinel tokens, persist admin token changes

### DIFF
--- a/crates/room-cli/src/broker/admin.rs
+++ b/crates/room-cli/src/broker/admin.rs
@@ -5,7 +5,7 @@
 
 use crate::message::make_system;
 
-use super::{fanout::broadcast_and_persist, state::RoomState};
+use super::{auth::save_token_map, fanout::broadcast_and_persist, state::RoomState};
 
 /// Admin command names — routed through `handle_admin_cmd` when received as
 /// a `Message::Command` with one of these cmd values.
@@ -58,6 +58,9 @@ pub(crate) async fn handle_admin_cmd(
             // kicking multiple users does not overwrite each other's sentinel entries.
             map.retain(|_, u| u != &target);
             map.insert(format!("KICKED:{target}"), target.clone());
+            if let Err(e) = save_token_map(&map, &state.token_map_path) {
+                eprintln!("[admin] kick token persist failed: {e}");
+            }
             drop(map);
             // In daemon mode, also revoke from the UserRegistry so the kicked user
             // cannot rejoin via issue_token_via_registry (which checks has_token_for_user).
@@ -79,6 +82,9 @@ pub(crate) async fn handle_admin_cmd(
             let target = arg.to_owned();
             let mut map = token_map.lock().await;
             map.retain(|_, u| u != &target);
+            if let Err(e) = save_token_map(&map, &state.token_map_path) {
+                eprintln!("[admin] reauth token persist failed: {e}");
+            }
             drop(map);
             // In daemon mode, also revoke from the UserRegistry so the reauthed user
             // can obtain a fresh token via issue_token_via_registry.
@@ -88,9 +94,10 @@ pub(crate) async fn handle_admin_cmd(
                 }
             }
             // Remove the on-disk token file so the user can join afresh.
+            let state_dir = crate::paths::room_state_dir();
             let prefix = format!("room-{room_id}-");
             let suffix = format!("-{target}.token");
-            if let Ok(entries) = std::fs::read_dir("/tmp") {
+            if let Ok(entries) = std::fs::read_dir(&state_dir) {
                 for entry in entries.flatten() {
                     let name = entry.file_name();
                     let s = name.to_string_lossy();
@@ -104,10 +111,16 @@ pub(crate) async fn handle_admin_cmd(
             let _ = broadcast_and_persist(&msg, clients, chat_path, seq_counter).await;
         }
         "clear-tokens" => {
-            token_map.lock().await.clear();
+            let mut map = token_map.lock().await;
+            map.clear();
+            if let Err(e) = save_token_map(&map, &state.token_map_path) {
+                eprintln!("[admin] clear-tokens persist failed: {e}");
+            }
+            drop(map);
             // Remove all on-disk token files for this room.
+            let state_dir = crate::paths::room_state_dir();
             let prefix = format!("room-{room_id}-");
-            if let Ok(entries) = std::fs::read_dir("/tmp") {
+            if let Ok(entries) = std::fs::read_dir(&state_dir) {
                 for entry in entries.flatten() {
                     let name = entry.file_name();
                     let s = name.to_string_lossy();
@@ -331,6 +344,114 @@ mod tests {
         assert!(
             !reg.has_token_for_user("bob"),
             "kick must remove all registry tokens for bob"
+        );
+    }
+
+    // ── token persistence after admin commands (#464) ──────────────────────
+
+    #[tokio::test]
+    async fn kick_persists_token_map_to_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let chat_path = dir.path().join("test.chat");
+        std::fs::write(&chat_path, "").unwrap();
+        let state = make_state(chat_path);
+        *state.host_user.lock().await = Some("alice".to_owned());
+        state
+            .token_map
+            .lock()
+            .await
+            .insert("tok-bob".to_owned(), "bob".to_owned());
+
+        handle_admin_cmd("kick bob", "alice", &state).await;
+
+        // Load from disk — KICKED sentinel must be persisted
+        let loaded = crate::broker::auth::load_token_map(&state.token_map_path);
+        assert!(
+            loaded.contains_key("KICKED:bob"),
+            "KICKED sentinel must be persisted to disk"
+        );
+        assert!(
+            !loaded.contains_key("tok-bob"),
+            "original token must not be on disk after kick"
+        );
+    }
+
+    #[tokio::test]
+    async fn reauth_persists_token_map_to_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let chat_path = dir.path().join("test.chat");
+        std::fs::write(&chat_path, "").unwrap();
+        let state = make_state(chat_path);
+        *state.host_user.lock().await = Some("alice".to_owned());
+        {
+            let mut map = state.token_map.lock().await;
+            map.insert("tok-bob".to_owned(), "bob".to_owned());
+            map.insert("KICKED:bob".to_owned(), "bob".to_owned());
+        }
+
+        handle_admin_cmd("reauth bob", "alice", &state).await;
+
+        let loaded = crate::broker::auth::load_token_map(&state.token_map_path);
+        assert!(
+            !loaded.values().any(|u| u == "bob"),
+            "bob must be fully removed from disk after reauth"
+        );
+    }
+
+    #[tokio::test]
+    async fn clear_tokens_persists_empty_map_to_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let chat_path = dir.path().join("test.chat");
+        std::fs::write(&chat_path, "").unwrap();
+        let state = make_state(chat_path);
+        *state.host_user.lock().await = Some("alice".to_owned());
+        {
+            let mut map = state.token_map.lock().await;
+            map.insert("t1".to_owned(), "alice".to_owned());
+            map.insert("t2".to_owned(), "bob".to_owned());
+        }
+
+        handle_admin_cmd("clear-tokens", "alice", &state).await;
+
+        let loaded = crate::broker::auth::load_token_map(&state.token_map_path);
+        assert!(
+            loaded.is_empty(),
+            "token map on disk must be empty after clear-tokens"
+        );
+    }
+
+    #[tokio::test]
+    async fn kicked_token_rejected_after_simulated_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        let chat_path = dir.path().join("test.chat");
+        std::fs::write(&chat_path, "").unwrap();
+        let state = make_state(chat_path.clone());
+        *state.host_user.lock().await = Some("alice".to_owned());
+        state
+            .token_map
+            .lock()
+            .await
+            .insert("tok-bob".to_owned(), "bob".to_owned());
+
+        handle_admin_cmd("kick bob", "alice", &state).await;
+
+        // Simulate broker restart: load token map from disk into fresh state
+        let loaded = crate::broker::auth::load_token_map(&state.token_map_path);
+        let new_map: super::super::state::TokenMap = Arc::new(Mutex::new(loaded));
+
+        // The original token must be invalid
+        assert!(
+            crate::broker::auth::validate_token("tok-bob", &new_map)
+                .await
+                .is_none(),
+            "original token must be invalid after restart"
+        );
+        // The KICKED sentinel must not authenticate
+        assert!(
+            crate::broker::auth::validate_token("KICKED:bob", &new_map)
+                .await
+                .is_none(),
+            "KICKED sentinel must not authenticate after restart"
         );
     }
 

--- a/crates/room-cli/src/broker/auth.rs
+++ b/crates/room-cli/src/broker/auth.rs
@@ -13,7 +13,7 @@ use super::state::{SubscriptionMap, TokenMap};
 // ── Token persistence ────────────────────────────────────────────────────────
 
 /// Write a token map to disk as JSON.
-fn save_token_map(map: &HashMap<String, String>, path: &Path) -> Result<(), String> {
+pub(crate) fn save_token_map(map: &HashMap<String, String>, path: &Path) -> Result<(), String> {
     let json = serde_json::to_string_pretty(&map).map_err(|e| format!("serialize tokens: {e}"))?;
     std::fs::write(path, json).map_err(|e| format!("write {}: {e}", path.display()))
 }
@@ -122,8 +122,12 @@ pub(crate) async fn issue_token(
 ///
 /// Returns `None` if the token is not found (invalid or expired).
 /// A `KICKED:<username>` sentinel is treated as invalid so kicked users
-/// cannot authenticate.
+/// cannot authenticate — the sentinel key starts with `KICKED:` and must
+/// never be accepted as a valid token.
 pub(crate) async fn validate_token(token: &str, token_map: &TokenMap) -> Option<String> {
+    if token.starts_with("KICKED:") {
+        return None;
+    }
     token_map.lock().await.get(token).cloned()
 }
 
@@ -334,6 +338,20 @@ mod tests {
     async fn validate_token_unknown_returns_none() {
         let map = make_token_map();
         assert!(validate_token("not-a-real-token", &map).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn validate_token_kicked_sentinel_key_rejected() {
+        let map = make_token_map();
+        // Simulate kick: insert KICKED:alice sentinel
+        map.lock()
+            .await
+            .insert("KICKED:alice".to_owned(), "alice".to_owned());
+        // Using the sentinel key as a token must be rejected
+        assert!(
+            validate_token("KICKED:alice", &map).await.is_none(),
+            "KICKED: sentinel key must not authenticate"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Three security fixes from the audit (PR #455):

- **#463 KICKED sentinel bypass**: `validate_token` did a plain hashmap lookup without checking if the token string was a `KICKED:<username>` sentinel key. An attacker could authenticate by passing `KICKED:alice` as a token. Fixed by rejecting any token starting with `KICKED:`.
- **#464 Admin token persistence**: `/kick`, `/reauth`, and `/clear-tokens` modified the in-memory token map but never called `save_token_map`. Kicked users could rejoin after a broker restart because the kicked state was lost. Fixed by persisting after every admin mutation.
- **#465 Hardcoded /tmp path**: `/reauth` and `/clear-tokens` scanned `/tmp` for token files instead of using `paths::room_state_dir()`. Fixed to use the correct state directory.

## Test plan

- [x] `validate_token_kicked_sentinel_key_rejected` — KICKED: prefix rejected
- [x] `kick_persists_token_map_to_disk` — kick writes KICKED sentinel to disk
- [x] `reauth_persists_token_map_to_disk` — reauth removes user from disk
- [x] `clear_tokens_persists_empty_map_to_disk` — clear-tokens writes empty map
- [x] `kicked_token_rejected_after_simulated_restart` — full restart simulation: kick, reload from disk, verify both original token and KICKED sentinel are rejected
- [x] All 49 auth+admin unit tests pass
- [x] Full `scripts/pre-push.sh` passes (check + fmt + clippy + test)

Closes #463, Closes #464, Closes #465
