### PR TITLE
fix(query): compile regex once at construction, not per message

### DIFF
--- a/crates/room-cli/src/broker/ws/rest.rs
+++ b/crates/room-cli/src/broker/ws/rest.rs
@@ -117,8 +117,19 @@ pub(super) struct CreateRoomRequest {
 // ── Query helpers ───────────────────────────────────────────────────────
 
 /// Build a [`QueryFilter`] from REST query params, scoped to `room_id`.
-pub(super) fn build_query_filter(params: &QueryParams, room_id: &str) -> QueryFilter {
-    QueryFilter {
+///
+/// Returns `Err` with a human-readable message if the `regex` param is invalid.
+pub(super) fn build_query_filter(
+    params: &QueryParams,
+    room_id: &str,
+) -> Result<QueryFilter, String> {
+    let compiled_regex = params
+        .regex
+        .as_deref()
+        .map(|pat| regex::Regex::new(pat).map_err(|e| format!("invalid regex pattern: {e}")))
+        .transpose()?;
+
+    Ok(QueryFilter {
         users: params
             .user
             .as_ref()
@@ -128,14 +139,14 @@ pub(super) fn build_query_filter(params: &QueryParams, room_id: &str) -> QueryFi
         after_seq: params.since.map(|seq| (room_id.to_owned(), seq)),
         before_seq: params.before.map(|seq| (room_id.to_owned(), seq)),
         content_search: params.content.clone(),
-        content_regex: params.regex.clone(),
+        content_regex: compiled_regex,
         mention_user: params.mention.clone(),
         public_only: params.public.unwrap_or(false),
         ascending: params.asc.unwrap_or(false),
         after_ts: params.after_ts.as_deref().and_then(|s| s.parse().ok()),
         before_ts: params.before_ts.as_deref().and_then(|s| s.parse().ok()),
         ..QueryFilter::default()
-    }
+    })
 }
 
 /// Apply a [`QueryFilter`] to a history, enforcing DM privacy.
@@ -355,7 +366,20 @@ pub(super) async fn api_query(
         }
     };
 
-    let filter = build_query_filter(&params, &room_id);
+    let filter = match build_query_filter(&params, &room_id) {
+        Ok(f) => f,
+        Err(msg) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "type": "error",
+                    "code": "invalid_regex",
+                    "message": msg
+                })),
+            )
+                .into_response()
+        }
+    };
 
     // `public=true` alone is not a valid query — require at least one narrowing param.
     if filter.public_only && !has_narrowing_filter(&filter, false) {
@@ -724,7 +748,20 @@ pub(super) async fn daemon_api_query(
         }
     };
 
-    let filter = build_query_filter(&params, &room_id);
+    let filter = match build_query_filter(&params, &room_id) {
+        Ok(f) => f,
+        Err(msg) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "type": "error",
+                    "code": "invalid_regex",
+                    "message": msg
+                })),
+            )
+                .into_response()
+        }
+    };
 
     // `public=true` alone is not a valid query — require at least one narrowing param.
     if filter.public_only && !has_narrowing_filter(&filter, false) {

--- a/crates/room-cli/src/main.rs
+++ b/crates/room-cli/src/main.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use chrono::DateTime;
 use clap::{Parser, Subcommand};
+use regex::Regex;
 use room_cli::{
     broker::daemon::{is_pid_alive, DaemonConfig, DaemonState},
     client::Client,
@@ -479,11 +480,17 @@ async fn main() -> anyhow::Result<()> {
                 new || wait
             };
 
+            let compiled_regex = regex
+                .map(|pat| {
+                    Regex::new(&pat).map_err(|e| anyhow::anyhow!("invalid --regex pattern: {e}"))
+                })
+                .transpose()?;
+
             let filter = QueryFilter {
                 rooms: effective_rooms.clone(),
                 users: user.map(|u| vec![u]).unwrap_or_default(),
                 content_search: search,
-                content_regex: regex,
+                content_regex: compiled_regex,
                 after_seq,
                 before_seq,
                 after_ts,

--- a/crates/room-cli/src/query.rs
+++ b/crates/room-cli/src/query.rs
@@ -23,12 +23,11 @@ pub struct QueryFilter {
     /// Only include messages whose content contains this substring
     /// (case-sensitive).
     pub content_search: Option<String>,
-    /// Only include messages whose content matches this regex pattern.
+    /// Only include messages whose content matches this pre-compiled regex.
     ///
-    /// Stored as `String` to keep the struct `Clone`-able; compiled inside
-    /// [`matches`][Self::matches] on each call. An invalid pattern causes the
-    /// message to be excluded (treated as "no match").
-    pub content_regex: Option<String>,
+    /// Compiled once at construction time. Callers should validate the pattern
+    /// before building the filter (e.g. via [`Regex::new`]).
+    pub content_regex: Option<Regex>,
     /// Only include messages whose sequence number is strictly greater than
     /// this value. Tuple is `(room_id, seq)`. The constraint is skipped for
     /// messages whose `room_id` differs from the filter room.
@@ -88,13 +87,10 @@ impl QueryFilter {
         }
 
         // ── content_regex: regex match ─────────────────────────────────────────
-        if let Some(ref pattern) = self.content_regex {
-            match Regex::new(pattern) {
-                Ok(re) => match msg.content() {
-                    Some(content) if re.is_match(content) => {}
-                    _ => return false,
-                },
-                Err(_) => return false,
+        if let Some(ref re) = self.content_regex {
+            match msg.content() {
+                Some(content) if re.is_match(content) => {}
+                _ => return false,
             }
         }
 
@@ -383,7 +379,7 @@ mod tests {
     #[test]
     fn content_regex_passes_matching_pattern() {
         let f = QueryFilter {
-            content_regex: Some(r"\d+".into()),
+            content_regex: Some(Regex::new(r"\d+").unwrap()),
             ..Default::default()
         };
         assert!(f.matches(&make_message("r", "u", "issue #42 fixed"), "r"));
@@ -392,25 +388,22 @@ mod tests {
     #[test]
     fn content_regex_rejects_non_matching() {
         let f = QueryFilter {
-            content_regex: Some(r"^\d+$".into()),
+            content_regex: Some(Regex::new(r"^\d+$").unwrap()),
             ..Default::default()
         };
         assert!(!f.matches(&make_message("r", "u", "no numbers here"), "r"));
     }
 
     #[test]
-    fn content_regex_invalid_pattern_excludes_message() {
-        let f = QueryFilter {
-            content_regex: Some("[invalid".into()),
-            ..Default::default()
-        };
-        assert!(!f.matches(&make_message("r", "u", "anything"), "r"));
+    fn content_regex_invalid_pattern_rejected_at_compile_time() {
+        // Invalid patterns are now caught at construction time, not inside matches().
+        assert!(Regex::new("[invalid").is_err());
     }
 
     #[test]
     fn content_regex_rejects_no_content() {
         let f = QueryFilter {
-            content_regex: Some(".*".into()),
+            content_regex: Some(Regex::new(".*").unwrap()),
             ..Default::default()
         };
         // Join has no content — should be excluded.
@@ -694,7 +687,7 @@ mod tests {
     #[test]
     fn has_narrowing_filter_content_regex_is_true() {
         let f = QueryFilter {
-            content_regex: Some(r"\d+".into()),
+            content_regex: Some(Regex::new(r"\d+").unwrap()),
             ..Default::default()
         };
         assert!(has_narrowing_filter(&f, false));


### PR DESCRIPTION
## Summary

- `QueryFilter::matches()` called `Regex::new(pattern)` on every message when using `--regex` flag — O(n) compilations per query
- Moved regex compilation to construction time: `content_regex` field type changed from `Option<String>` to `Option<Regex>`
- CLI (`main.rs`): validates regex at parse time, bails with descriptive error on invalid pattern
- REST (`rest.rs`): `build_query_filter` now returns `Result`, invalid regex returns 400 Bad Request with `invalid_regex` error code

**Note:** The security audit (#455) attributed this to `parse_mentions` in room-protocol — that function does not use regex (it uses `match_indices` + manual char parsing). The actual issue was in `QueryFilter::matches()` in room-cli.

## Files changed

- `crates/room-cli/src/query.rs` — field type change, simplified `matches()` body
- `crates/room-cli/src/main.rs` — compile regex before constructing filter
- `crates/room-cli/src/broker/ws/rest.rs` — `build_query_filter` returns `Result`, callers handle error

## Test plan

- [x] Existing regex filter tests updated and pass (pre-compiled `Regex` in test constructors)
- [x] Invalid pattern test verifies `Regex::new` catches errors at compile time
- [x] All 1172+ tests pass (`cargo test`)
- [x] `cargo check && cargo fmt && cargo clippy -- -D warnings` clean

Closes #466