### PR TITLE
docs(prd): address review nits on agent PRDs

### DIFF
--- a/docs/prd/agent/prd-agent-health.md
+++ b/docs/prd/agent/prd-agent-health.md
@@ -155,6 +155,41 @@ Implementation approach:
 - Missing expected steps trigger a warning, not a block.
 - The host can `/agent health <username>` to see the full workflow tracking state.
 
+#### Keyword Matching Algorithm
+
+Each workflow step defines a `keywords` list. When an agent sends a `/set_status` update,
+the health system lowercases the status text and checks each unmatched step's keywords
+using substring matching. The first step whose keyword matches is marked as observed.
+
+Default keyword sets for the built-in `coder` personality:
+
+| Workflow step | Keywords |
+|---|---|
+| `read target files` | `reading`, `read`, `examining`, `looking at`, `reviewing src` |
+| `announce plan in room` | `plan`, `proposing`, `announcing`, `approach` |
+| `wait for approval` | `waiting`, `blocked on approval`, `hold` |
+| `implement` | `implement`, `drafting`, `writing`, `coding`, `fixing`, `adding` |
+| `run tests` | `test`, `cargo test`, `running test`, `checking` |
+| `open PR` | `pr`, `pull request`, `opening pr`, `gh pr` |
+| `announce completion` | `done`, `complete`, `merged`, `finished` |
+
+Matching rules:
+- **Substring, case-insensitive**: `"running cargo test for #42"` matches `cargo test`.
+- **First match wins**: If a status matches multiple steps, the earliest unmatched step
+  in the workflow order is marked.
+- **Order-independent observation**: Steps can be observed out of order (the agent may
+  skip ahead), but the skip is flagged as a warning.
+- **No re-matching**: Once a step is marked observed, subsequent statuses do not re-trigger
+  it. This prevents a status like `"reading test output"` from re-marking the `read` step
+  after `test` has already been observed.
+- **Custom overrides**: Personality TOML files can override keyword sets per step:
+
+```toml
+[workflow.keywords]
+"read target files" = ["reading", "scanning", "inspecting"]
+"run tests" = ["pytest", "running suite", "test pass"]
+```
+
 ### Lifecycle-Specific Rules
 
 #### Persistent agents

--- a/docs/prd/agent/prd-agent-plugin.md
+++ b/docs/prd/agent/prd-agent-plugin.md
@@ -255,8 +255,11 @@ consumers (Hive, scripts, other agents). This pattern applies to all plugin resp
 - Hive calls `room join` and `room subscribe` directly via WS/REST.
 - Hive spawns ralph processes through its own agent runner (which may handle repo
   cloning, workdir setup, and monitoring).
-- `/agent list` still works — it shows agents the plugin spawned. Hive-spawned agents
-  appear as regular users in the member panel.
+- **`/agent list` only shows plugin-spawned agents.** Hive-spawned agents are not
+  tracked in the plugin's `SpawnedAgent` map because Hive provisions them independently
+  (its own token minting, workdir setup, process management). They still appear as
+  regular users in the member panel and `/who` output — they just aren't visible to
+  `/agent list`, `/agent stop`, or `/agent health`.
 - `/agent` should document this boundary: "when Hive is absent, this plugin is the
   agent control plane. When Hive is present, Hive manages agent lifecycle."
 
@@ -310,13 +313,13 @@ Files:
 Tests:
 - Unit: palette filters personality names on keystroke
 
-## Open Questions
+## Decided Questions
 
-1. **Should `/agent stop` be graceful-only?** Current proposal: SIGTERM then SIGKILL
-   after 5s. Alternative: SIGTERM only, let ralph handle shutdown. Risk: stuck claude
-   subprocess keeps ralph alive indefinitely.
+1. **`/agent stop` uses SIGTERM then SIGKILL.** SIGTERM with a 5-second grace period,
+   then SIGKILL. SIGTERM-only is insufficient — a stuck claude subprocess can keep
+   ralph alive indefinitely, and the host needs a guaranteed way to reclaim resources.
 
-2. **Progress file location**: `/tmp/room-progress-<issue>.md` (current convention,
-   dies on reboot) vs `~/.room/state/progress/<username>-<issue>.md` (persistent).
-   Decision from discussion: use persistent location. Progress must survive both
-   context exhaustion AND host reboot.
+2. **Progress files use persistent storage.** Location:
+   `~/.room/state/progress/<username>-<issue>.md`. Progress must survive both context
+   exhaustion and host reboot. The ephemeral workdir (`/tmp/room-agent-<username>/`)
+   is for scratch files only.


### PR DESCRIPTION
## Summary

Follow-up to #476 (merged). Addresses ba's review nits:

- **Resolved open questions**: Replaced "Open Questions" section with "Decided Questions" in prd-agent-plugin.md — stop semantics (SIGTERM then SIGKILL) and progress file location (~/.room/state/progress/) are now documented as decisions, not open items.
- **Workflow keyword matching specificity**: Added detailed keyword matching algorithm to prd-agent-health.md — default keyword sets per workflow step, substring matching rules, order-independent observation, no re-matching, and custom TOML override syntax.
- **Hive boundary clarification**: Clarified in prd-agent-plugin.md that `/agent list` only shows plugin-spawned agents. Hive-spawned agents appear in `/who` and the member panel but are invisible to `/agent list`, `/agent stop`, and `/agent health`.

## Test plan

- [ ] Docs-only change, no code affected
- [ ] Verify markdown renders correctly on GitHub
