### PR TITLE
fix(broker): join all params for multi-word /set_status

### DIFF
--- a/crates/room-cli/src/broker/commands.rs
+++ b/crates/room-cli/src/broker/commands.rs
@@ -105,7 +105,7 @@ pub(crate) async fn route_command(
         }
 
         if cmd == "set_status" {
-            let status = params.first().cloned().unwrap_or_default();
+            let status = params.join(" ");
             state.set_status(username, status.clone()).await;
             let display = if status.is_empty() {
                 format!("{username} cleared their status")
@@ -538,6 +538,35 @@ mod tests {
                 .get("alice")
                 .map(String::as_str),
             Some("")
+        );
+    }
+
+    #[tokio::test]
+    async fn route_command_set_status_multi_word_joins_all_params() {
+        let tmp = NamedTempFile::new().unwrap();
+        let state = make_state(tmp.path().to_path_buf());
+        let msg = make_command(
+            "test-room",
+            "alice",
+            "set_status",
+            vec!["reviewing".to_owned(), "PR".to_owned(), "#42".to_owned()],
+        );
+        let result = route_command(msg, "alice", &state).await.unwrap();
+        let CommandResult::HandledWithReply(json) = result else {
+            panic!("expected HandledWithReply");
+        };
+        assert!(
+            json.contains("reviewing PR #42"),
+            "broadcast must contain full multi-word status, got: {json}"
+        );
+        assert_eq!(
+            state
+                .status_map
+                .lock()
+                .await
+                .get("alice")
+                .map(String::as_str),
+            Some("reviewing PR #42")
         );
     }
 


### PR DESCRIPTION
## Summary

- Fix `/set_status` truncating multi-word status text to first word only
- Root cause: `commands.rs:108` used `params.first()` instead of joining all params
- Both `build_wire_payload` functions (oneshot + TUI) split on whitespace, producing multiple params for multi-word input — the broker must join them back
- TUI `parse_status_broadcast` already handles multi-word via `split_once`, so no TUI changes needed

## Test plan

- [x] Added regression test: `route_command_set_status_multi_word_joins_all_params` — verifies "reviewing PR #42" stored and broadcast correctly
- [x] Existing single-word and empty-status tests still pass
- [x] `cargo check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] All 1183 Rust tests pass (1182 + 1 new)

Closes #472
