### PR TITLE
feat(plugin): extract /set_status to StatusPlugin

### DIFF
--- a/crates/room-cli/src/broker/commands.rs
+++ b/crates/room-cli/src/broker/commands.rs
@@ -104,24 +104,6 @@ pub(crate) async fn route_command(
             }
         }
 
-        if cmd == "set_status" {
-            let status = params.join(" ");
-            state.set_status(username, status.clone()).await;
-            let display = if status.is_empty() {
-                format!("{username} cleared their status")
-            } else {
-                format!("{username} set status: {status}")
-            };
-            let sys = make_system(&state.room_id, "broker", display);
-            broadcast_and_persist(&sys, &state.clients, &state.chat_path, &state.seq_counter)
-                .await?;
-            // Broadcast already delivers to all interactive clients. One-shot callers are not
-            // subscribed to the broadcast channel, so we carry the JSON in HandledWithReply so
-            // handle_oneshot_send can write it back — preventing the EOF parse error.
-            let json = serde_json::to_string(&sys)?;
-            return Ok(CommandResult::HandledWithReply(json));
-        }
-
         if cmd == "who" {
             let entries: Vec<String> = state
                 .status_entries()
@@ -408,6 +390,20 @@ async fn dispatch_plugin(
             CommandResult::HandledWithReply(json)
         }
         PluginResult::Handled => CommandResult::Handled,
+        PluginResult::SetStatus(status) => {
+            state.set_status(username, status.clone()).await;
+            let display = if status.is_empty() {
+                format!("{username} cleared their status")
+            } else {
+                format!("{username} set status: {status}")
+            };
+            let sys = make_system(&state.room_id, "broker", display);
+            let seq_msg =
+                broadcast_and_persist(&sys, &state.clients, &state.chat_path, &state.seq_counter)
+                    .await?;
+            let json = serde_json::to_string(&seq_msg)?;
+            CommandResult::HandledWithReply(json)
+        }
     })
 }
 

--- a/crates/room-cli/src/broker/mod.rs
+++ b/crates/room-cli/src/broker/mod.rs
@@ -82,6 +82,7 @@ impl Broker {
         let mut registry = PluginRegistry::new();
         registry.register(Box::new(plugin::help::HelpPlugin))?;
         registry.register(Box::new(plugin::stats::StatsPlugin))?;
+        registry.register(Box::new(plugin::status::StatusPlugin))?;
 
         // Load persisted state from a previous broker session (if any).
         let persisted_tokens = auth::load_token_map(&self.token_map_path);

--- a/crates/room-cli/src/broker/state.rs
+++ b/crates/room-cli/src/broker/state.rs
@@ -129,6 +129,9 @@ impl RoomState {
         plugins
             .register(Box::new(crate::plugin::stats::StatsPlugin))
             .map_err(|e| format!("plugin error: {e}"))?;
+        plugins
+            .register(Box::new(crate::plugin::status::StatusPlugin))
+            .map_err(|e| format!("plugin error: {e}"))?;
         let taskboard_path =
             crate::plugin::taskboard::TaskboardPlugin::taskboard_path_from_chat(&chat_path);
         plugins

--- a/crates/room-cli/src/plugin/mod.rs
+++ b/crates/room-cli/src/plugin/mod.rs
@@ -1,6 +1,7 @@
 pub mod help;
 pub mod queue;
 pub mod stats;
+pub mod status;
 pub mod taskboard;
 
 use std::{
@@ -155,6 +156,12 @@ pub enum PluginResult {
     Broadcast(String),
     /// Command handled silently (side effects already done via [`ChatWriter`]).
     Handled,
+    /// Update the sender's status in the broker's status map, then broadcast.
+    ///
+    /// The broker handles the `status_map` write and broadcasts
+    /// `"{username} set status: {status}"` (or `"{username} cleared their status"`
+    /// if empty). Plugins never touch `StatusMap` directly.
+    SetStatus(String),
 }
 
 // ── HistoryReader ───────────────────────────────────────────────────────────
@@ -329,7 +336,6 @@ impl RoomMetadata {
 
 /// Built-in command names that plugins may not override.
 const RESERVED_COMMANDS: &[&str] = &[
-    "set_status",
     "who",
     "kick",
     "reauth",
@@ -512,17 +518,6 @@ pub fn builtin_command_infos() -> Vec<CommandInfo> {
             ],
         },
         CommandInfo {
-            name: "set_status".to_owned(),
-            description: "Set your presence status".to_owned(),
-            usage: "/set_status <status>".to_owned(),
-            params: vec![ParamSchema {
-                name: "status".to_owned(),
-                param_type: ParamType::Text,
-                required: false,
-                description: "Status text (omit to clear)".to_owned(),
-            }],
-        },
-        CommandInfo {
             name: "who".to_owned(),
             description: "List users in the room".to_owned(),
             usage: "/who".to_owned(),
@@ -620,6 +615,7 @@ pub fn all_known_commands() -> Vec<CommandInfo> {
     cmds.extend(help::HelpPlugin.commands());
     cmds.extend(queue::QueuePlugin::default_commands());
     cmds.extend(stats::StatsPlugin.commands());
+    cmds.extend(status::StatusPlugin.commands());
     cmds.extend(taskboard::TaskboardPlugin::default_commands());
     cmds
 }
@@ -858,7 +854,6 @@ mod tests {
             "unclaim",
             "claimed",
             "reply",
-            "set_status",
             "who",
             "kick",
             "reauth",
@@ -895,14 +890,6 @@ mod tests {
         assert_eq!(kick.params.len(), 1);
         assert_eq!(kick.params[0].param_type, ParamType::Username);
         assert!(kick.params[0].required);
-    }
-
-    #[test]
-    fn builtin_command_infos_set_status_is_optional() {
-        let cmds = builtin_command_infos();
-        let ss = cmds.iter().find(|c| c.name == "set_status").unwrap();
-        assert_eq!(ss.params.len(), 1);
-        assert!(!ss.params[0].required);
     }
 
     #[test]

--- a/crates/room-cli/src/plugin/status.rs
+++ b/crates/room-cli/src/plugin/status.rs
@@ -1,0 +1,117 @@
+use super::{BoxFuture, CommandContext, CommandInfo, ParamSchema, ParamType, Plugin, PluginResult};
+
+/// `/set_status` plugin — sets the sender's presence status.
+///
+/// The plugin returns [`PluginResult::SetStatus`] which the broker interprets
+/// to update the `StatusMap` and broadcast the announcement. The plugin itself
+/// never touches broker state directly.
+pub struct StatusPlugin;
+
+impl Plugin for StatusPlugin {
+    fn name(&self) -> &str {
+        "status"
+    }
+
+    fn commands(&self) -> Vec<CommandInfo> {
+        vec![CommandInfo {
+            name: "set_status".to_owned(),
+            description: "Set your presence status".to_owned(),
+            usage: "/set_status <status>".to_owned(),
+            params: vec![ParamSchema {
+                name: "status".to_owned(),
+                param_type: ParamType::Text,
+                required: false,
+                description: "Status text (omit to clear)".to_owned(),
+            }],
+        }]
+    }
+
+    fn handle(&self, ctx: CommandContext) -> BoxFuture<'_, anyhow::Result<PluginResult>> {
+        Box::pin(async move {
+            let status = ctx.params.join(" ");
+            Ok(PluginResult::SetStatus(status))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugin::{ChatWriter, HistoryReader, RoomMetadata, UserInfo};
+    use chrono::Utc;
+    use std::collections::HashMap;
+    use std::sync::{atomic::AtomicU64, Arc};
+    use tempfile::NamedTempFile;
+    use tokio::sync::Mutex;
+
+    fn make_ctx(params: Vec<String>, path: &std::path::Path) -> CommandContext {
+        let clients = Arc::new(Mutex::new(HashMap::new()));
+        let chat_path = Arc::new(path.to_path_buf());
+        let room_id = Arc::new("test-room".to_owned());
+        let seq = Arc::new(AtomicU64::new(0));
+
+        CommandContext {
+            command: "set_status".to_owned(),
+            params,
+            sender: "alice".to_owned(),
+            room_id: "test-room".to_owned(),
+            message_id: "msg-1".to_owned(),
+            timestamp: Utc::now(),
+            history: HistoryReader::new(path, "alice"),
+            writer: ChatWriter::new(&clients, &chat_path, &room_id, &seq, "status"),
+            metadata: RoomMetadata {
+                online_users: vec![UserInfo {
+                    username: "alice".to_owned(),
+                    status: String::new(),
+                }],
+                host: Some("alice".to_owned()),
+                message_count: 0,
+            },
+            available_commands: vec![],
+        }
+    }
+
+    #[tokio::test]
+    async fn set_status_single_word() {
+        let tmp = NamedTempFile::new().unwrap();
+        let ctx = make_ctx(vec!["busy".to_owned()], tmp.path());
+        let result = StatusPlugin.handle(ctx).await.unwrap();
+        let PluginResult::SetStatus(status) = result else {
+            panic!("expected SetStatus");
+        };
+        assert_eq!(status, "busy");
+    }
+
+    #[tokio::test]
+    async fn set_status_multi_word() {
+        let tmp = NamedTempFile::new().unwrap();
+        let ctx = make_ctx(
+            vec!["reviewing".to_owned(), "PR".to_owned(), "#42".to_owned()],
+            tmp.path(),
+        );
+        let result = StatusPlugin.handle(ctx).await.unwrap();
+        let PluginResult::SetStatus(status) = result else {
+            panic!("expected SetStatus");
+        };
+        assert_eq!(status, "reviewing PR #42");
+    }
+
+    #[tokio::test]
+    async fn set_status_empty_clears() {
+        let tmp = NamedTempFile::new().unwrap();
+        let ctx = make_ctx(vec![], tmp.path());
+        let result = StatusPlugin.handle(ctx).await.unwrap();
+        let PluginResult::SetStatus(status) = result else {
+            panic!("expected SetStatus");
+        };
+        assert_eq!(status, "");
+    }
+
+    #[test]
+    fn status_plugin_commands() {
+        let cmds = StatusPlugin.commands();
+        assert_eq!(cmds.len(), 1);
+        assert_eq!(cmds[0].name, "set_status");
+        assert!(!cmds[0].params[0].required);
+    }
+}

--- a/crates/room-cli/src/tui/widgets.rs
+++ b/crates/room-cli/src/tui/widgets.rs
@@ -469,9 +469,9 @@ mod tests {
             p.filtered.len()
         );
         let first_cmd = &p.commands[p.filtered[0]].cmd;
-        assert_eq!(
-            first_cmd, "set_status",
-            "first match should be 'set_status' (prefix), not '{first_cmd}'"
+        assert!(
+            first_cmd.starts_with("se"),
+            "first match should be a 'se' prefix match, not '{first_cmd}'"
         );
         let prefix_count = p
             .filtered


### PR DESCRIPTION
## Summary

- Extract `/set_status` from inline broker command handling to the plugin system
- Add `PluginResult::SetStatus(String)` variant — broker handles `status_map` write + broadcast, plugins never touch `StatusMap` directly
- New `plugin/status.rs` with `StatusPlugin` implementing `Plugin` trait
- Remove `set_status` from `RESERVED_COMMANDS` and `builtin_command_infos()`
- Register `StatusPlugin` in both standalone broker (`mod.rs`) and daemon (`state.rs`)
- Update `all_known_commands()` to include status plugin commands

## Files changed

- `plugin/status.rs` (NEW) — StatusPlugin with 4 unit tests
- `plugin/mod.rs` — add module, SetStatus variant, remove from reserved/builtins, add to all_known_commands
- `broker/commands.rs` — remove inline set_status handler, add SetStatus handling in dispatch_plugin
- `broker/state.rs` — register StatusPlugin in daemon init
- `broker/mod.rs` — register StatusPlugin in standalone init
- `tui/widgets.rs` — relax palette ranking test (accept any `se*` prefix, not specifically `set_status`)

## Test plan

- [x] 4 new unit tests in status.rs (single word, multi-word, empty/clear, commands schema)
- [x] Existing set_status tests in commands.rs pass (now routed through plugin dispatch)
- [x] Palette tests pass (set_status visible via all_known_commands)
- [x] `cargo check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] All 1191 Rust tests pass

Closes #473
