### PR TITLE
fix(broker): add size limit to read_line to prevent memory exhaustion

### DIFF
--- a/crates/room-cli/src/broker/daemon.rs
+++ b/crates/room-cli/src/broker/daemon.rs
@@ -768,7 +768,7 @@ async fn handle_create(
     system_token_map: &TokenMap,
     user_registry: &Arc<tokio::sync::Mutex<UserRegistry>>,
 ) -> anyhow::Result<()> {
-    use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+    use tokio::io::AsyncWriteExt;
 
     // Validate room ID.
     if let Err(e) = validate_room_id(room_id) {
@@ -797,7 +797,7 @@ async fn handle_create(
 
     // Read config JSON from second line.
     let mut config_line = String::new();
-    reader.read_line(&mut config_line).await?;
+    super::read_line_limited(reader, &mut config_line).await?;
     let config_str = config_line.trim();
 
     let (visibility_str, invite): (String, Vec<String>) = if config_str.is_empty() {
@@ -944,13 +944,13 @@ async fn dispatch_connection(
     system_token_map: &TokenMap,
     user_registry: &Arc<tokio::sync::Mutex<UserRegistry>>,
 ) -> anyhow::Result<()> {
-    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio::io::{AsyncWriteExt, BufReader};
 
     let (read_half, mut write_half) = stream.into_split();
     let mut reader = BufReader::new(read_half);
 
     let mut first = String::new();
-    reader.read_line(&mut first).await?;
+    super::read_line_limited(&mut reader, &mut first).await?;
     let first_line = first.trim();
 
     if first_line.is_empty() {

--- a/crates/room-cli/src/broker/mod.rs
+++ b/crates/room-cli/src/broker/mod.rs
@@ -28,13 +28,56 @@ use fanout::{broadcast_and_persist, dm_and_persist};
 use room_protocol::SubscriptionTier;
 use state::RoomState;
 use tokio::{
-    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+    io::{AsyncBufRead, AsyncBufReadExt, AsyncWriteExt, BufReader},
     net::{
         unix::{OwnedReadHalf, OwnedWriteHalf},
         UnixListener, UnixStream,
     },
     sync::{broadcast, watch, Mutex},
 };
+
+/// Maximum bytes allowed in a single line from a client connection.
+/// Prevents memory exhaustion from malicious clients sending arbitrarily large lines.
+pub const MAX_LINE_BYTES: usize = 64 * 1024; // 64 KB
+
+/// Read a single newline-terminated line, rejecting lines that exceed `MAX_LINE_BYTES`.
+///
+/// Returns `Ok(n)` where `n` is the number of bytes read (0 = EOF).
+/// Returns an error if the accumulated bytes before a newline exceed the limit.
+///
+/// The line (including the trailing `\n`) is appended to `buf`, matching the
+/// behaviour of `AsyncBufReadExt::read_line`.
+pub(crate) async fn read_line_limited<R: AsyncBufRead + Unpin>(
+    reader: &mut R,
+    buf: &mut String,
+) -> anyhow::Result<usize> {
+    let mut total = 0usize;
+    loop {
+        let available = reader.fill_buf().await?;
+        if available.is_empty() {
+            // EOF
+            return Ok(total);
+        }
+        // Look for a newline in the buffered data.
+        let (chunk, found_newline) = match available.iter().position(|&b| b == b'\n') {
+            Some(pos) => (&available[..=pos], true),
+            None => (available, false),
+        };
+        let chunk_len = chunk.len();
+        if total + chunk_len > MAX_LINE_BYTES {
+            anyhow::bail!("line exceeds maximum size of {} bytes", MAX_LINE_BYTES);
+        }
+        // Safety: we validate UTF-8 before appending.
+        let text = std::str::from_utf8(chunk)
+            .map_err(|e| anyhow::anyhow!("invalid UTF-8 in client line: {e}"))?;
+        buf.push_str(text);
+        total += chunk_len;
+        reader.consume(chunk_len);
+        if found_newline {
+            return Ok(total);
+        }
+    }
+}
 
 pub struct Broker {
     room_id: String,
@@ -180,7 +223,7 @@ async fn handle_client(
 
     // First line: username handshake, or one of the one-shot prefixes.
     let mut first = String::new();
-    reader.read_line(&mut first).await?;
+    read_line_limited(&mut reader, &mut first).await?;
     let first_line = first.trim();
 
     use handshake::{parse_client_handshake, ClientHandshake};
@@ -372,7 +415,7 @@ pub(crate) async fn run_interactive_session(
         let mut line = String::new();
         loop {
             line.clear();
-            match reader.read_line(&mut line).await {
+            match read_line_limited(&mut reader, &mut line).await {
                 Ok(0) => break,
                 Ok(_) => {
                     let trimmed = line.trim();
@@ -442,7 +485,20 @@ pub(crate) async fn run_interactive_session(
                         Err(e) => eprintln!("[broker] bad message from {username_in}: {e}"),
                     }
                 }
-                Err(_) => break,
+                Err(e) => {
+                    eprintln!("[broker] read error from {username_in}: {e:#}");
+                    let err = serde_json::json!({
+                        "type": "error",
+                        "code": "line_too_long",
+                        "message": format!("{e}")
+                    });
+                    let _ = write_half_in
+                        .lock()
+                        .await
+                        .write_all(format!("{err}\n").as_bytes())
+                        .await;
+                    break;
+                }
             }
         }
     });
@@ -480,7 +536,7 @@ pub(crate) async fn handle_oneshot_send(
     state: &RoomState,
 ) -> anyhow::Result<()> {
     let mut line = String::new();
-    reader.read_line(&mut line).await?;
+    read_line_limited(&mut reader, &mut line).await?;
     let trimmed = line.trim();
     if trimmed.is_empty() {
         return Ok(());
@@ -781,5 +837,105 @@ mod tests {
         // Verify subscriptions were persisted to the .subscriptions file.
         let loaded = commands::load_subscription_map(&state.subscription_map_path);
         assert_eq!(loaded.get("alice"), Some(&SubscriptionTier::MentionsOnly));
+    }
+
+    // --- read_line_limited tests ---
+
+    #[tokio::test]
+    async fn read_line_limited_reads_normal_line() {
+        let data = b"hello world\n";
+        let cursor = std::io::Cursor::new(data.to_vec());
+        let mut reader = tokio::io::BufReader::new(cursor);
+        let mut buf = String::new();
+        let n = read_line_limited(&mut reader, &mut buf).await.unwrap();
+        assert_eq!(n, 12);
+        assert_eq!(buf, "hello world\n");
+    }
+
+    #[tokio::test]
+    async fn read_line_limited_reads_line_without_trailing_newline() {
+        let data = b"no newline";
+        let cursor = std::io::Cursor::new(data.to_vec());
+        let mut reader = tokio::io::BufReader::new(cursor);
+        let mut buf = String::new();
+        let n = read_line_limited(&mut reader, &mut buf).await.unwrap();
+        assert_eq!(n, 10);
+        assert_eq!(buf, "no newline");
+    }
+
+    #[tokio::test]
+    async fn read_line_limited_returns_zero_on_eof() {
+        let data = b"";
+        let cursor = std::io::Cursor::new(data.to_vec());
+        let mut reader = tokio::io::BufReader::new(cursor);
+        let mut buf = String::new();
+        let n = read_line_limited(&mut reader, &mut buf).await.unwrap();
+        assert_eq!(n, 0);
+        assert!(buf.is_empty());
+    }
+
+    #[tokio::test]
+    async fn read_line_limited_rejects_oversized_line() {
+        // Create a line that exceeds the limit (no newline, so it keeps reading).
+        let data = vec![b'A'; MAX_LINE_BYTES + 1];
+        let cursor = std::io::Cursor::new(data);
+        let mut reader = tokio::io::BufReader::new(cursor);
+        let mut buf = String::new();
+        let result = read_line_limited(&mut reader, &mut buf).await;
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("exceeds maximum size"),
+            "unexpected error: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_line_limited_accepts_line_at_exact_limit() {
+        // Line of exactly MAX_LINE_BYTES (including the newline).
+        let mut data = vec![b'A'; MAX_LINE_BYTES - 1];
+        data.push(b'\n');
+        let cursor = std::io::Cursor::new(data);
+        let mut reader = tokio::io::BufReader::new(cursor);
+        let mut buf = String::new();
+        let n = read_line_limited(&mut reader, &mut buf).await.unwrap();
+        assert_eq!(n, MAX_LINE_BYTES);
+        assert!(buf.ends_with('\n'));
+    }
+
+    #[tokio::test]
+    async fn read_line_limited_reads_multiple_lines() {
+        let data = b"line one\nline two\n";
+        let cursor = std::io::Cursor::new(data.to_vec());
+        let mut reader = tokio::io::BufReader::new(cursor);
+
+        let mut buf = String::new();
+        let n = read_line_limited(&mut reader, &mut buf).await.unwrap();
+        assert_eq!(n, 9);
+        assert_eq!(buf, "line one\n");
+
+        buf.clear();
+        let n = read_line_limited(&mut reader, &mut buf).await.unwrap();
+        assert_eq!(n, 9);
+        assert_eq!(buf, "line two\n");
+
+        buf.clear();
+        let n = read_line_limited(&mut reader, &mut buf).await.unwrap();
+        assert_eq!(n, 0);
+    }
+
+    #[tokio::test]
+    async fn read_line_limited_rejects_invalid_utf8() {
+        let data: Vec<u8> = vec![0xFF, 0xFE, b'\n'];
+        let cursor = std::io::Cursor::new(data);
+        let mut reader = tokio::io::BufReader::new(cursor);
+        let mut buf = String::new();
+        let result = read_line_limited(&mut reader, &mut buf).await;
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("invalid UTF-8"),
+            "unexpected error: {err_msg}"
+        );
     }
 }

--- a/crates/room-cli/tests/broker.rs
+++ b/crates/room-cli/tests/broker.rs
@@ -12,7 +12,7 @@ use room_cli::{
     history,
     message::{self, Message},
 };
-use tokio::io::AsyncBufReadExt;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 use tokio::net::UnixStream;
 
 #[tokio::test]
@@ -953,4 +953,104 @@ async fn dm_history_replay_includes_dms_for_host() {
         dave_saw_dm.is_err() || !dave_saw_dm.unwrap(),
         "dave (non-participant, non-host) must not receive the DM in history replay"
     );
+}
+
+// --- read_line_limited integration tests ---
+
+/// Sending a handshake line that exceeds MAX_LINE_BYTES causes the broker to
+/// drop the connection without allocating unbounded memory.
+#[tokio::test]
+async fn oversized_handshake_line_is_rejected() {
+    let broker = TestBroker::start("t_oversized_hs").await;
+
+    let stream = UnixStream::connect(&broker.socket_path).await.unwrap();
+    let (_, mut writer) = stream.into_split();
+
+    // Send a username line that exceeds the limit (no newline — forces the
+    // broker's read_line_limited to accumulate until it hits the cap).
+    let payload = vec![b'A'; room_cli::broker::MAX_LINE_BYTES + 1];
+    let _ = writer.write_all(&payload).await;
+    // Also send a newline so that a non-limited reader would complete.
+    let _ = writer.write_all(b"\n").await;
+
+    // Give the broker time to process and drop the connection.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Verify the broker is still alive by connecting a normal client.
+    let mut alice = TestClient::connect(&broker.socket_path, "alice").await;
+    let msg = alice
+        .recv_until(|m| matches!(m, Message::Join { user, .. } if user == "alice"))
+        .await;
+    assert_eq!(msg.user(), "alice");
+}
+
+/// An interactive client that sends an oversized message line after handshake
+/// receives an error and is disconnected, while the broker continues serving.
+#[tokio::test]
+async fn oversized_message_line_disconnects_client() {
+    let broker = TestBroker::start("t_oversized_msg").await;
+
+    let mut alice = TestClient::connect(&broker.socket_path, "alice").await;
+    alice
+        .recv_until(|m| matches!(m, Message::Join { user, .. } if user == "alice"))
+        .await;
+
+    // Send an oversized message (no newline first, then newline).
+    let mut payload = vec![b'x'; room_cli::broker::MAX_LINE_BYTES + 1];
+    payload.push(b'\n');
+    let _ = alice.writer.write_all(&payload).await;
+
+    // The broker should send an error response and close the connection.
+    // Try reading — we should either get the error JSON or EOF.
+    let mut line = String::new();
+    let result =
+        tokio::time::timeout(Duration::from_secs(2), alice.reader.read_line(&mut line)).await;
+    match result {
+        Ok(Ok(0)) => {} // EOF — broker closed connection
+        Ok(Ok(_)) => {
+            // Got a response — should be an error envelope.
+            let parsed: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+            assert_eq!(parsed["code"], "line_too_long");
+        }
+        Ok(Err(_)) => {} // I/O error — also acceptable (connection reset)
+        Err(_) => panic!("timed out waiting for broker response after oversized line"),
+    }
+
+    // Verify broker is still alive.
+    let mut bob = TestClient::connect(&broker.socket_path, "bob").await;
+    bob.recv_until(|m| matches!(m, Message::Join { user, .. } if user == "bob"))
+        .await;
+}
+
+/// A normal message just under the size limit is accepted.
+#[tokio::test]
+async fn message_at_size_limit_is_accepted() {
+    let broker = TestBroker::start("t_at_limit").await;
+
+    let mut alice = TestClient::connect(&broker.socket_path, "alice").await;
+    alice
+        .recv_until(|m| matches!(m, Message::Join { user, .. } if user == "alice"))
+        .await;
+
+    let mut bob = TestClient::connect(&broker.socket_path, "bob").await;
+    bob.recv_until(|m| matches!(m, Message::Join { user, .. } if user == "bob"))
+        .await;
+    // drain bob's join from alice's perspective
+    alice
+        .recv_until(|m| matches!(m, Message::Join { user, .. } if user == "bob"))
+        .await;
+
+    // Send a message that fits within the limit.
+    // Account for the JSON envelope overhead (~200 bytes for message wrapper).
+    let content_size = room_cli::broker::MAX_LINE_BYTES - 300;
+    let big_content: String = std::iter::repeat('Z').take(content_size).collect();
+    alice.send_text(&big_content).await;
+
+    // Bob should receive it.
+    let msg = bob
+        .recv_until(
+            |m| matches!(m, Message::Message { content, .. } if content.len() > content_size / 2),
+        )
+        .await;
+    assert_eq!(msg.user(), "alice");
 }


### PR DESCRIPTION
## Summary

- Add `read_line_limited()` helper that enforces a 64 KB per-line cap on all broker-side socket reads
- Replace 5 `read_line` call sites in `broker/mod.rs` and `broker/daemon.rs` with the limited version
- Oversized lines return a `line_too_long` error envelope and disconnect the client
- Prevents memory exhaustion from malicious clients sending arbitrarily large lines without newlines

**Protected call sites:**
- `handle_client` handshake (first line)
- `handle_client` interactive inbound loop
- `handle_oneshot_send` message line
- `dispatch_connection` daemon handshake
- `handle_create` config line

Client-side reads (from trusted broker) are unchanged.

## Test plan

- [x] Unit: normal line, EOF, exact-limit line, oversized line rejection, invalid UTF-8, multi-line reads (7 new unit tests)
- [x] Integration: oversized handshake rejected + broker survives, oversized message disconnects client + broker survives, message at size limit accepted (3 new integration tests)
- [x] All existing tests pass (1182 Rust tests, 0 failures)
- [x] `cargo check && cargo fmt && cargo clippy -- -D warnings && cargo test` all green

Closes #470
