### PR TITLE
fix(broker): deprecate SEND: handshake in favor of TOKEN:

### DIFF
--- a/crates/room-cli/src/broker/daemon.rs
+++ b/crates/room-cli/src/broker/daemon.rs
@@ -1015,6 +1015,10 @@ async fn dispatch_connection(
     // Dispatch based on the per-room handshake after the ROOM: prefix.
     let username = match parse_client_handshake(&rest) {
         ClientHandshake::Send(u) => {
+            eprintln!(
+                "[broker/daemon] DEPRECATED: SEND:{u} handshake used — \
+                 migrate to TOKEN:<uuid> (SEND: will be removed in a future version)"
+            );
             return handle_oneshot_send(u, reader, write_half, &state).await;
         }
         ClientHandshake::Token(token) => {

--- a/crates/room-cli/src/broker/handshake.rs
+++ b/crates/room-cli/src/broker/handshake.rs
@@ -10,7 +10,7 @@
 //!
 //! | Prefix | Variant | Meaning |
 //! |---|---|---|
-//! | `SEND:<username>` | [`ClientHandshake::Send`] | Legacy unauthenticated one-shot send |
+//! | `SEND:<username>` | [`ClientHandshake::Send`] | **DEPRECATED** — unauthenticated one-shot send (use `TOKEN:` instead) |
 //! | `TOKEN:<uuid>` | [`ClientHandshake::Token`] | Token-authenticated one-shot send |
 //! | `JOIN:<username>` | [`ClientHandshake::Join`] | Register username, receive session token |
 //! | `<username>` | [`ClientHandshake::Interactive`] | Full interactive join |
@@ -29,7 +29,9 @@
 /// Typed result of parsing the first line of a per-room connection.
 #[derive(Debug, PartialEq)]
 pub(crate) enum ClientHandshake {
-    /// `SEND:<username>` — legacy unauthenticated one-shot send.
+    /// `SEND:<username>` — **deprecated** unauthenticated one-shot send.
+    ///
+    /// Will be removed in a future version. Use [`ClientHandshake::Token`] instead.
     Send(String),
     /// `TOKEN:<uuid>` — token-authenticated one-shot send.
     Token(String),

--- a/crates/room-cli/src/broker/mod.rs
+++ b/crates/room-cli/src/broker/mod.rs
@@ -186,6 +186,10 @@ async fn handle_client(
     use handshake::{parse_client_handshake, ClientHandshake};
     let username = match parse_client_handshake(first_line) {
         ClientHandshake::Send(u) => {
+            eprintln!(
+                "[broker] DEPRECATED: SEND:{u} handshake used — \
+                 migrate to TOKEN:<uuid> (SEND: will be removed in a future version)"
+            );
             return handle_oneshot_send(u, reader, write_half, state).await;
         }
         ClientHandshake::Token(token) => {

--- a/crates/room-cli/src/broker/ws/mod.rs
+++ b/crates/room-cli/src/broker/ws/mod.rs
@@ -110,6 +110,10 @@ async fn run_ws_session(
             return ws_oneshot_join(&u, &mut ws_tx, state).await;
         }
         ClientHandshake::Send(u) => {
+            eprintln!(
+                "[broker/ws] DEPRECATED: SEND:{u} handshake used — \
+                 migrate to TOKEN:<uuid> (SEND: will be removed in a future version)"
+            );
             return ws_oneshot_send(u, &mut ws_rx, &mut ws_tx, state).await;
         }
         ClientHandshake::Token(token) => {

--- a/crates/room-cli/src/oneshot/mod.rs
+++ b/crates/room-cli/src/oneshot/mod.rs
@@ -12,11 +12,12 @@ pub use poll::{
 };
 pub use subscribe::cmd_subscribe;
 pub use token::{cmd_join, username_from_token};
+#[allow(deprecated)]
+pub use transport::send_message;
 pub use transport::{create_room, destroy_room};
 pub use transport::{
     ensure_daemon_running, global_join_session, join_session, join_session_target,
-    resolve_socket_target, send_message, send_message_with_token, send_message_with_token_target,
-    SocketTarget,
+    resolve_socket_target, send_message_with_token, send_message_with_token_target, SocketTarget,
 };
 pub use who::cmd_who;
 

--- a/crates/room-cli/src/oneshot/transport.rs
+++ b/crates/room-cli/src/oneshot/transport.rs
@@ -194,6 +194,15 @@ async fn ensure_daemon_running_impl(socket: &Path, exe: &Path) -> anyhow::Result
 
 /// Connect to a running broker and deliver a single message without joining the room.
 /// Returns the broadcast echo (with broker-assigned id/ts) so callers have the message ID.
+///
+/// # Deprecation
+///
+/// Uses the `SEND:<username>` handshake which bypasses token authentication.
+/// Use [`send_message_with_token`] instead — obtain a token via `room join` first.
+#[deprecated(
+    since = "3.1.0",
+    note = "SEND: handshake is unauthenticated; use send_message_with_token instead"
+)]
 pub async fn send_message(
     socket_path: &Path,
     username: &str,

--- a/crates/room-cli/tests/auth.rs
+++ b/crates/room-cli/tests/auth.rs
@@ -279,6 +279,7 @@ async fn admin_clear_tokens_blocks_all_sends() {
 
 /// `/clear` truncates the history file and broadcasts a system message.
 #[tokio::test]
+#[allow(deprecated)]
 async fn admin_clear_history() {
     let broker = TestBroker::start("t_clear_history").await;
     let mut admin = TestClient::connect(&broker.socket_path, "admin").await;

--- a/crates/room-cli/tests/oneshot.rs
+++ b/crates/room-cli/tests/oneshot.rs
@@ -117,6 +117,7 @@ async fn who_responds_only_to_requester() {
 /// `send_message` delivers a message to connected clients without generating
 /// join or leave events for the sender.
 #[tokio::test]
+#[allow(deprecated)]
 async fn send_delivers_message_without_join_leave() {
     let broker = TestBroker::start("t_send_no_join").await;
 
@@ -149,6 +150,7 @@ async fn send_delivers_message_without_join_leave() {
 
 /// `send_message` returns a fully-populated Message with the correct fields.
 #[tokio::test]
+#[allow(deprecated)]
 async fn send_returns_echo_json() {
     let broker = TestBroker::start("t_send_echo").await;
 
@@ -276,6 +278,7 @@ async fn poll_with_no_broker_reads_file_directly() {
 
 /// `send_message` returns an error when no broker socket exists.
 #[tokio::test]
+#[allow(deprecated)]
 async fn send_fails_when_no_broker() {
     let dir = tempfile::tempdir().unwrap();
     let socket_path = dir.path().join("nonexistent.sock");
@@ -292,6 +295,7 @@ async fn send_fails_when_no_broker() {
 /// (Tests broker routing of a `{"type":"dm",...}` envelope over the one-shot SEND path;
 /// see `cmd_send` in `oneshot.rs` for the CLI layer that builds this envelope from `--to`.)
 #[tokio::test]
+#[allow(deprecated)]
 async fn oneshot_send_dm_is_routed_privately() {
     let broker = TestBroker::start("t_oneshot_dm").await;
 
@@ -722,5 +726,58 @@ async fn pull_messages_filters_dms_for_viewer() {
             .iter()
             .any(|m| matches!(m, Message::DirectMessage { content, .. } if content == "secret")),
         "alice should see the DM addressed to her"
+    );
+}
+
+// ── SEND: deprecation tests (#467) ──────────────────────────────────────────
+
+/// The deprecated `SEND:` handshake still delivers messages (backward compat).
+/// This test uses the raw UDS protocol to verify the broker still processes
+/// `SEND:<username>` connections correctly, even though the handshake is
+/// deprecated in favor of `TOKEN:<uuid>`.
+#[tokio::test]
+async fn deprecated_send_handshake_still_works() {
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio::net::UnixStream;
+
+    let broker = TestBroker::start("t_send_deprecated").await;
+
+    // Connect using raw SEND: handshake.
+    let stream = UnixStream::connect(&broker.socket_path).await.unwrap();
+    let (read_half, mut write_half) = stream.into_split();
+
+    write_half.write_all(b"SEND:legacy-bot\n").await.unwrap();
+    write_half
+        .write_all(b"hello from deprecated path\n")
+        .await
+        .unwrap();
+
+    let mut reader = BufReader::new(read_half);
+    let mut line = String::new();
+    reader.read_line(&mut line).await.unwrap();
+
+    let echo: Message = serde_json::from_str(line.trim()).unwrap();
+    assert_eq!(echo.user(), "legacy-bot");
+    assert!(
+        matches!(&echo, Message::Message { content, .. } if content == "hello from deprecated path"),
+        "SEND: handshake should still deliver messages"
+    );
+}
+
+/// The deprecated `send_message` function still works when called with
+/// `#[allow(deprecated)]`. Verifies backward compatibility is preserved.
+#[tokio::test]
+async fn deprecated_send_message_fn_still_delivers() {
+    let broker = TestBroker::start("t_send_fn_deprecated").await;
+
+    #[allow(deprecated)]
+    let msg = room_cli::oneshot::send_message(&broker.socket_path, "old-bot", "still works")
+        .await
+        .unwrap();
+
+    assert_eq!(msg.user(), "old-bot");
+    assert!(
+        matches!(&msg, Message::Message { content, .. } if content == "still works"),
+        "deprecated send_message should still deliver messages"
     );
 }


### PR DESCRIPTION
## Summary

- `SEND:<username>` handshake allows unauthenticated message sending — security audit #455 flagged this as should-fix-soon
- Added `eprintln!` deprecation warnings in all 3 broker paths (UDS, WS, daemon) when SEND: is received
- Marked client-side `send_message` function as `#[deprecated(since = "3.1.0")]` with migration guidance to `send_message_with_token`
- Updated `ClientHandshake::Send` docs in handshake.rs to mark as deprecated
- SEND: still works for backward compatibility — removal planned for a future version
- Added 2 new tests: raw UDS SEND: handshake backward compat, deprecated `send_message` fn backward compat
- Added `#[allow(deprecated)]` to existing tests that use the legacy path

## Files changed

- `broker/mod.rs`, `broker/ws/mod.rs`, `broker/daemon.rs` — deprecation warnings on SEND: match arms
- `broker/handshake.rs` — doc updates marking SEND: as deprecated
- `oneshot/transport.rs` — `#[deprecated]` on `send_message`
- `oneshot/mod.rs` — `#[allow(deprecated)]` on re-export
- `tests/oneshot.rs` — 2 new tests + `#[allow(deprecated)]` on 4 existing tests
- `tests/auth.rs` — `#[allow(deprecated)]` on 1 existing test

## Test plan

- [x] 2 new tests verify SEND: backward compatibility (raw UDS + send_message fn)
- [x] All existing tests pass with `#[allow(deprecated)]`
- [x] `cargo check && cargo fmt && cargo clippy -- -D warnings && cargo test` clean

Closes #467