### PR TITLE
fix(daemon): require token auth for UDS CREATE/DESTROY commands

### DIFF
--- a/crates/room-cli/src/broker/daemon.rs
+++ b/crates/room-cli/src/broker/daemon.rs
@@ -703,14 +703,18 @@ pub(crate) async fn create_room_entry(
 ///
 /// Protocol:
 /// 1. Client sends `DESTROY:<room_id>\n`
-/// 2. Daemon responds with `{"type":"room_destroyed","room":"<id>"}\n` or an error.
+/// 2. Client sends `<token>\n` on the next line.
+/// 3. Daemon validates the token, then responds with
+///    `{"type":"room_destroyed","room":"<id>"}\n` or an error.
 ///
 /// Connected clients receive EOF when the room's shutdown signal fires.
 /// Chat files are preserved on disk.
 async fn handle_destroy(
     room_id: &str,
+    reader: &mut tokio::io::BufReader<tokio::net::unix::OwnedReadHalf>,
     write_half: &mut tokio::net::unix::OwnedWriteHalf,
     rooms: &RoomMap,
+    user_registry: &Arc<tokio::sync::Mutex<UserRegistry>>,
 ) -> anyhow::Result<()> {
     use tokio::io::AsyncWriteExt;
 
@@ -722,6 +726,35 @@ async fn handle_destroy(
         });
         write_half.write_all(format!("{err}\n").as_bytes()).await?;
         return Ok(());
+    }
+
+    // Read the token from the second line.
+    let mut token_line = String::new();
+    super::read_line_limited(reader, &mut token_line).await?;
+    let token = token_line.trim();
+
+    if token.is_empty() {
+        let err = serde_json::json!({
+            "type": "error",
+            "code": "missing_token",
+            "message": "DESTROY requires a valid token on the second line"
+        });
+        write_half.write_all(format!("{err}\n").as_bytes()).await?;
+        return Ok(());
+    }
+
+    // Validate against UserRegistry.
+    {
+        let reg = user_registry.lock().await;
+        if reg.validate_token(token).is_none() {
+            let err = serde_json::json!({
+                "type": "error",
+                "code": "invalid_token",
+                "message": "token is not valid"
+            });
+            write_half.write_all(format!("{err}\n").as_bytes()).await?;
+            return Ok(());
+        }
     }
 
     // Remove the room and signal shutdown.
@@ -800,32 +833,60 @@ async fn handle_create(
     super::read_line_limited(reader, &mut config_line).await?;
     let config_str = config_line.trim();
 
-    let (visibility_str, invite): (String, Vec<String>) = if config_str.is_empty() {
-        ("public".into(), vec![])
-    } else {
-        let v: serde_json::Value = match serde_json::from_str(config_str) {
-            Ok(v) => v,
-            Err(e) => {
-                let err = serde_json::json!({
-                    "type": "error",
-                    "code": "invalid_config",
-                    "message": format!("invalid config JSON: {e}")
-                });
-                write_half.write_all(format!("{err}\n").as_bytes()).await?;
-                return Ok(());
-            }
+    let (visibility_str, invite, token): (String, Vec<String>, Option<String>) =
+        if config_str.is_empty() {
+            ("public".into(), vec![], None)
+        } else {
+            let v: serde_json::Value = match serde_json::from_str(config_str) {
+                Ok(v) => v,
+                Err(e) => {
+                    let err = serde_json::json!({
+                        "type": "error",
+                        "code": "invalid_config",
+                        "message": format!("invalid config JSON: {e}")
+                    });
+                    write_half.write_all(format!("{err}\n").as_bytes()).await?;
+                    return Ok(());
+                }
+            };
+            let vis = v["visibility"].as_str().unwrap_or("public").to_owned();
+            let inv = v["invite"]
+                .as_array()
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(|s| s.to_owned()))
+                        .collect()
+                })
+                .unwrap_or_default();
+            let tok = v["token"].as_str().map(|s| s.to_owned());
+            (vis, inv, tok)
         };
-        let vis = v["visibility"].as_str().unwrap_or("public").to_owned();
-        let inv = v["invite"]
-            .as_array()
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|v| v.as_str().map(|s| s.to_owned()))
-                    .collect()
-            })
-            .unwrap_or_default();
-        (vis, inv)
+
+    // Validate the token.
+    let token_str = match token.as_deref() {
+        Some(t) if !t.is_empty() => t,
+        _ => {
+            let err = serde_json::json!({
+                "type": "error",
+                "code": "missing_token",
+                "message": "CREATE requires a valid token in the config JSON"
+            });
+            write_half.write_all(format!("{err}\n").as_bytes()).await?;
+            return Ok(());
+        }
     };
+    {
+        let reg = user_registry.lock().await;
+        if reg.validate_token(token_str).is_none() {
+            let err = serde_json::json!({
+                "type": "error",
+                "code": "invalid_token",
+                "message": "token is not valid"
+            });
+            write_half.write_all(format!("{err}\n").as_bytes()).await?;
+            return Ok(());
+        }
+    }
 
     // Build RoomConfig from the parsed visibility + invite list.
     let room_config = match visibility_str.as_str() {
@@ -962,7 +1023,8 @@ async fn dispatch_connection(
     };
     let (room_id, rest) = match parse_daemon_prefix(first_line) {
         DaemonPrefix::Destroy(room_id) => {
-            return handle_destroy(&room_id, &mut write_half, rooms).await;
+            return handle_destroy(&room_id, &mut reader, &mut write_half, rooms, user_registry)
+                .await;
         }
         DaemonPrefix::Create(room_id) => {
             return handle_create(

--- a/crates/room-cli/src/main.rs
+++ b/crates/room-cli/src/main.rs
@@ -232,6 +232,9 @@ enum Cmd {
     Create {
         /// Room ID to create
         room_id: String,
+        /// Session token from `room join` (required)
+        #[arg(short = 't', long)]
+        token: String,
         /// Override the daemon socket path (default: auto-discover)
         #[arg(long)]
         socket: Option<PathBuf>,
@@ -250,6 +253,9 @@ enum Cmd {
     Destroy {
         /// Room ID to destroy
         room_id: String,
+        /// Session token from `room join` (required)
+        #[arg(short = 't', long)]
+        token: String,
         /// Override the daemon socket path (default: auto-discover)
         #[arg(long)]
         socket: Option<PathBuf>,
@@ -639,14 +645,19 @@ async fn main() -> anyhow::Result<()> {
         }
         Some(Cmd::Create {
             room_id,
+            token,
             socket,
             visibility,
             invite,
         }) => {
-            oneshot::cmd_create(&room_id, socket.as_deref(), &visibility, &invite).await?;
+            oneshot::cmd_create(&room_id, socket.as_deref(), &visibility, &invite, &token).await?;
         }
-        Some(Cmd::Destroy { room_id, socket }) => {
-            oneshot::cmd_destroy(&room_id, socket.as_deref()).await?;
+        Some(Cmd::Destroy {
+            room_id,
+            token,
+            socket,
+        }) => {
+            oneshot::cmd_destroy(&room_id, socket.as_deref(), &token).await?;
         }
         Some(Cmd::List) => {
             oneshot::cmd_list().await?;

--- a/crates/room-cli/src/oneshot/mod.rs
+++ b/crates/room-cli/src/oneshot/mod.rs
@@ -117,11 +117,14 @@ pub async fn cmd_dm(
 /// returns a `room_created` envelope.
 ///
 /// `socket` overrides the default daemon socket path (auto-discovered if `None`).
+/// `token` is required for authentication — the daemon validates it against the
+/// global UserRegistry.
 pub async fn cmd_create(
     room_id: &str,
     socket: Option<&std::path::Path>,
     visibility: &str,
     invite: &[String],
+    token: &str,
 ) -> anyhow::Result<()> {
     let daemon_socket = socket
         .map(|p| p.to_owned())
@@ -137,6 +140,7 @@ pub async fn cmd_create(
     let config = serde_json::json!({
         "visibility": visibility,
         "invite": invite,
+        "token": token,
     });
 
     let result = transport::create_room(&daemon_socket, room_id, &config.to_string()).await?;
@@ -147,11 +151,17 @@ pub async fn cmd_create(
 /// One-shot destroy subcommand: connect to daemon, destroy a room, print result.
 ///
 /// Sends a `DESTROY:<room_id>` request to the daemon socket. The daemon
-/// signals shutdown to connected clients, removes the room from its map,
-/// and preserves the chat file on disk.
+/// validates the token, signals shutdown to connected clients, removes the
+/// room from its map, and preserves the chat file on disk.
 ///
 /// `socket` overrides the default daemon socket path (auto-discovered if `None`).
-pub async fn cmd_destroy(room_id: &str, socket: Option<&std::path::Path>) -> anyhow::Result<()> {
+/// `token` is required for authentication — the daemon validates it against the
+/// global UserRegistry.
+pub async fn cmd_destroy(
+    room_id: &str,
+    socket: Option<&std::path::Path>,
+    token: &str,
+) -> anyhow::Result<()> {
     let daemon_socket = socket
         .map(|p| p.to_owned())
         .unwrap_or_else(crate::paths::room_socket_path);
@@ -163,7 +173,7 @@ pub async fn cmd_destroy(room_id: &str, socket: Option<&std::path::Path>) -> any
         );
     }
 
-    let result = transport::destroy_room(&daemon_socket, room_id).await?;
+    let result = transport::destroy_room(&daemon_socket, room_id, token).await?;
     println!("{}", serde_json::to_string(&result)?);
     Ok(())
 }

--- a/crates/room-cli/src/oneshot/transport.rs
+++ b/crates/room-cli/src/oneshot/transport.rs
@@ -368,8 +368,12 @@ pub async fn global_join_session(
 
 /// Connect to a daemon socket and create a new room via `CREATE:<room_id>`.
 ///
-/// Sends the room ID on the first line and the config JSON on the second.
-/// Returns the daemon's response JSON on success (`{"type":"room_created",...}`).
+/// Sends the room ID on the first line and the config JSON (with `token` field)
+/// on the second. Returns the daemon's response JSON on success
+/// (`{"type":"room_created",...}`).
+///
+/// The `config_json` should include a `"token"` field for authentication.
+/// Use [`inject_token_into_config`] to add it if not already present.
 pub async fn create_room(
     socket_path: &Path,
     room_id: &str,
@@ -399,14 +403,21 @@ pub async fn create_room(
 
 /// Connect to a daemon socket and destroy a room via `DESTROY:<room_id>`.
 ///
-/// Returns the daemon's response JSON on success (`{"type":"room_destroyed",...}`).
-pub async fn destroy_room(socket_path: &Path, room_id: &str) -> anyhow::Result<serde_json::Value> {
+/// Sends the room ID on the first line and the authentication token on the
+/// second. Returns the daemon's response JSON on success
+/// (`{"type":"room_destroyed",...}`).
+pub async fn destroy_room(
+    socket_path: &Path,
+    room_id: &str,
+    token: &str,
+) -> anyhow::Result<serde_json::Value> {
     let stream = UnixStream::connect(socket_path).await.map_err(|e| {
         anyhow::anyhow!("cannot connect to daemon at {}: {e}", socket_path.display())
     })?;
     let (r, mut w) = stream.into_split();
     w.write_all(format!("DESTROY:{room_id}\n").as_bytes())
         .await?;
+    w.write_all(format!("{token}\n").as_bytes()).await?;
 
     let mut reader = BufReader::new(r);
     let mut line = String::new();
@@ -420,6 +431,24 @@ pub async fn destroy_room(socket_path: &Path, room_id: &str) -> anyhow::Result<s
         anyhow::bail!("{message}");
     }
     Ok(v)
+}
+
+/// Inject a `"token"` field into a JSON config string.
+///
+/// If the config is valid JSON, merges the token into the object.
+/// If the config is empty or not an object, wraps the token in a minimal config.
+pub fn inject_token_into_config(config_json: &str, token: &str) -> String {
+    if let Ok(mut v) = serde_json::from_str::<serde_json::Value>(config_json) {
+        if let Some(obj) = v.as_object_mut() {
+            obj.insert(
+                "token".to_owned(),
+                serde_json::Value::String(token.to_owned()),
+            );
+            return serde_json::to_string(&v).unwrap_or_default();
+        }
+    }
+    // Fallback: wrap in a new object.
+    serde_json::json!({"token": token}).to_string()
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/crates/room-cli/src/tui/mod.rs
+++ b/crates/room-cli/src/tui/mod.rs
@@ -128,6 +128,16 @@ impl RoomTab {
     }
 }
 
+/// Read the global token for `username` from the token file on disk.
+///
+/// Returns `None` if the file doesn't exist or can't be parsed.
+fn read_user_token(username: &str) -> Option<String> {
+    let path = crate::paths::global_token_path(username);
+    let data = std::fs::read_to_string(&path).ok()?;
+    let v: serde_json::Value = serde_json::from_str(data.trim()).ok()?;
+    v["token"].as_str().map(|s| s.to_owned())
+}
+
 /// Create or reuse a DM room and return a connected `RoomTab`.
 ///
 /// 1. Sends `CREATE:<dm_room_id>` to the daemon socket. If the room already
@@ -145,9 +155,12 @@ async fn open_dm_tab(
     use tokio::net::UnixStream;
 
     // Step 1: Create the DM room (idempotent — ignore "already exists").
+    // Read the user's token from the token file for authentication.
+    let token = read_user_token(username).unwrap_or_default();
     let config = room_protocol::RoomConfig::dm(username, target_user);
     let config_json = serde_json::to_string(&config)?;
-    match crate::oneshot::transport::create_room(socket_path, dm_room_id, &config_json).await {
+    let authed_config = crate::oneshot::transport::inject_token_into_config(&config_json, &token);
+    match crate::oneshot::transport::create_room(socket_path, dm_room_id, &authed_config).await {
         Ok(_) => {}
         Err(e) if e.to_string().contains("already exists") => {}
         Err(e) => return Err(e),

--- a/crates/room-cli/tests/common/mod.rs
+++ b/crates/room-cli/tests/common/mod.rs
@@ -365,17 +365,21 @@ pub async fn daemon_send(
 }
 
 /// Send a CREATE:<room_id> request to the daemon socket, returns the response JSON.
+///
+/// The `token` is injected into the config JSON for authentication.
 pub async fn daemon_create(
     socket_path: &PathBuf,
     room_id: &str,
     config_json: &str,
+    token: &str,
 ) -> serde_json::Value {
+    let authed_config = room_cli::oneshot::transport::inject_token_into_config(config_json, token);
     let stream = UnixStream::connect(socket_path).await.unwrap();
     let (r, mut w) = stream.into_split();
     w.write_all(format!("CREATE:{room_id}\n").as_bytes())
         .await
         .unwrap();
-    w.write_all(format!("{config_json}\n").as_bytes())
+    w.write_all(format!("{authed_config}\n").as_bytes())
         .await
         .unwrap();
 
@@ -386,12 +390,19 @@ pub async fn daemon_create(
 }
 
 /// Send a DESTROY:<room_id> request to the daemon socket, returns the response JSON.
-pub async fn daemon_destroy(socket_path: &PathBuf, room_id: &str) -> serde_json::Value {
+///
+/// The `token` is sent on the second line for authentication.
+pub async fn daemon_destroy(
+    socket_path: &PathBuf,
+    room_id: &str,
+    token: &str,
+) -> serde_json::Value {
     let stream = UnixStream::connect(socket_path).await.unwrap();
     let (r, mut w) = stream.into_split();
     w.write_all(format!("DESTROY:{room_id}\n").as_bytes())
         .await
         .unwrap();
+    w.write_all(format!("{token}\n").as_bytes()).await.unwrap();
 
     let mut reader = BufReader::new(r);
     let mut line = String::new();

--- a/crates/room-cli/tests/daemon.rs
+++ b/crates/room-cli/tests/daemon.rs
@@ -334,15 +334,18 @@ async fn ws_dm_room_non_participant_join_rejected() {
 #[tokio::test]
 async fn daemon_concurrent_room_creation_deduplicates() {
     let td = TestDaemon::start(&[]).await;
+    let token = daemon_global_join(&td.socket_path, "admin").await;
     let socket1 = td.socket_path.clone();
     let socket2 = td.socket_path.clone();
+    let tok1 = token.clone();
+    let tok2 = token.clone();
 
     // Fire two concurrent CREATE requests for the same room ID.
     let t1 = tokio::spawn(async move {
-        daemon_create(&socket1, "race-room", r#"{"visibility":"public"}"#).await
+        daemon_create(&socket1, "race-room", r#"{"visibility":"public"}"#, &tok1).await
     });
     let t2 = tokio::spawn(async move {
-        daemon_create(&socket2, "race-room", r#"{"visibility":"public"}"#).await
+        daemon_create(&socket2, "race-room", r#"{"visibility":"public"}"#, &tok2).await
     });
 
     let (r1, r2) = tokio::join!(t1, t2);

--- a/crates/room-cli/tests/room_lifecycle.rs
+++ b/crates/room-cli/tests/room_lifecycle.rs
@@ -8,7 +8,8 @@ mod common;
 use std::time::Duration;
 
 use common::{
-    daemon_connect, daemon_create, daemon_destroy, daemon_join, daemon_send, rest_join, TestDaemon,
+    daemon_connect, daemon_create, daemon_destroy, daemon_global_join, daemon_join, daemon_send,
+    rest_join, TestDaemon,
 };
 use room_protocol::RoomConfig;
 use std::path::PathBuf;
@@ -21,11 +22,15 @@ async fn create_room_via_uds_then_join_and_send() {
     // Start a daemon with no pre-created rooms.
     let td = TestDaemon::start(&[]).await;
 
+    // Get a global token for authentication.
+    let admin_token = daemon_global_join(&td.socket_path, "admin").await;
+
     // Create a room dynamically.
     let resp = daemon_create(
         &td.socket_path,
         "dynamic-room",
         r#"{"visibility":"public"}"#,
+        &admin_token,
     )
     .await;
     assert_eq!(resp["type"], "room_created");
@@ -45,12 +50,14 @@ async fn create_room_via_uds_then_join_and_send() {
 #[tokio::test]
 async fn create_room_duplicate_returns_error() {
     let td = TestDaemon::start(&["existing-room"]).await;
+    let token = daemon_global_join(&td.socket_path, "admin").await;
 
     // Try to create a room that already exists.
     let resp = daemon_create(
         &td.socket_path,
         "existing-room",
         r#"{"visibility":"public"}"#,
+        &token,
     )
     .await;
     assert_eq!(resp["type"], "error");
@@ -60,14 +67,21 @@ async fn create_room_duplicate_returns_error() {
 #[tokio::test]
 async fn create_room_invalid_id_returns_error() {
     let td = TestDaemon::start(&[]).await;
+    let token = daemon_global_join(&td.socket_path, "admin").await;
 
     // Room ID with path traversal.
-    let resp = daemon_create(&td.socket_path, "../escape", r#"{"visibility":"public"}"#).await;
+    let resp = daemon_create(
+        &td.socket_path,
+        "../escape",
+        r#"{"visibility":"public"}"#,
+        &token,
+    )
+    .await;
     assert_eq!(resp["type"], "error");
     assert_eq!(resp["code"], "invalid_room_id");
 
     // Empty room ID.
-    let resp2 = daemon_create(&td.socket_path, "", r#"{"visibility":"public"}"#).await;
+    let resp2 = daemon_create(&td.socket_path, "", r#"{"visibility":"public"}"#, &token).await;
     assert_eq!(resp2["type"], "error");
     assert_eq!(resp2["code"], "invalid_room_id");
 }
@@ -75,12 +89,14 @@ async fn create_room_invalid_id_returns_error() {
 #[tokio::test]
 async fn create_dm_room_via_uds() {
     let td = TestDaemon::start(&[]).await;
+    let token = daemon_global_join(&td.socket_path, "admin").await;
 
     // Create a DM room with exactly 2 users.
     let resp = daemon_create(
         &td.socket_path,
         "dm-alice-bob",
         r#"{"visibility":"dm","invite":["alice","bob"]}"#,
+        &token,
     )
     .await;
     assert_eq!(resp["type"], "room_created");
@@ -105,12 +121,14 @@ async fn create_dm_room_via_uds() {
 #[tokio::test]
 async fn create_dm_room_wrong_invite_count_returns_error() {
     let td = TestDaemon::start(&[]).await;
+    let token = daemon_global_join(&td.socket_path, "admin").await;
 
     // DM with only 1 user — should fail.
     let resp = daemon_create(
         &td.socket_path,
         "dm-solo",
         r#"{"visibility":"dm","invite":["alice"]}"#,
+        &token,
     )
     .await;
     assert_eq!(resp["type"], "error");
@@ -121,6 +139,7 @@ async fn create_dm_room_wrong_invite_count_returns_error() {
         &td.socket_path,
         "dm-three",
         r#"{"visibility":"dm","invite":["alice","bob","carol"]}"#,
+        &token,
     )
     .await;
     assert_eq!(resp2["type"], "error");
@@ -128,10 +147,10 @@ async fn create_dm_room_wrong_invite_count_returns_error() {
 }
 
 #[tokio::test]
-async fn create_room_default_config() {
+async fn create_room_default_config_without_token_rejected() {
     let td = TestDaemon::start(&[]).await;
 
-    // Empty config line — should default to public.
+    // Empty config line (no token) — should be rejected.
     let stream = UnixStream::connect(&td.socket_path).await.unwrap();
     let (r, mut w) = stream.into_split();
     w.write_all(b"CREATE:default-room\n\n").await.unwrap();
@@ -140,19 +159,23 @@ async fn create_room_default_config() {
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
     let v: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
-    assert_eq!(v["type"], "room_created");
-    assert_eq!(v["room"], "default-room");
-
-    // Should be joinable (public).
-    let token = daemon_join(&td.socket_path, "default-room", "user1").await;
-    assert!(!token.is_empty());
+    assert_eq!(v["type"], "error");
+    assert_eq!(v["code"], "missing_token");
 }
 
 #[tokio::test]
 async fn create_room_invalid_json_returns_error() {
     let td = TestDaemon::start(&[]).await;
 
-    let resp = daemon_create(&td.socket_path, "bad-config", "not valid json").await;
+    // Send invalid JSON directly — no token injection possible.
+    let stream = UnixStream::connect(&td.socket_path).await.unwrap();
+    let (r, mut w) = stream.into_split();
+    w.write_all(b"CREATE:bad-config\n").await.unwrap();
+    w.write_all(b"not valid json\n").await.unwrap();
+    let mut reader = BufReader::new(r);
+    let mut line = String::new();
+    reader.read_line(&mut line).await.unwrap();
+    let resp: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
     assert_eq!(resp["type"], "error");
     assert_eq!(resp["code"], "invalid_config");
 }
@@ -160,8 +183,15 @@ async fn create_room_invalid_json_returns_error() {
 #[tokio::test]
 async fn create_room_unknown_visibility_returns_error() {
     let td = TestDaemon::start(&[]).await;
+    let token = daemon_global_join(&td.socket_path, "admin").await;
 
-    let resp = daemon_create(&td.socket_path, "weird-room", r#"{"visibility":"secret"}"#).await;
+    let resp = daemon_create(
+        &td.socket_path,
+        "weird-room",
+        r#"{"visibility":"secret"}"#,
+        &token,
+    )
+    .await;
     assert_eq!(resp["type"], "error");
     assert_eq!(resp["code"], "invalid_config");
 }
@@ -172,12 +202,12 @@ async fn create_room_unknown_visibility_returns_error() {
 async fn destroy_room_removes_from_daemon() {
     let td = TestDaemon::start(&["doomed-room"]).await;
 
-    // Room exists — join works.
+    // Room exists — join works. Also gives us a token for destroy.
     let token = daemon_join(&td.socket_path, "doomed-room", "alice").await;
     assert!(!token.is_empty());
 
     // Destroy it.
-    let resp = daemon_destroy(&td.socket_path, "doomed-room").await;
+    let resp = daemon_destroy(&td.socket_path, "doomed-room", &token).await;
     assert_eq!(resp["type"], "room_destroyed");
     assert_eq!(resp["room"], "doomed-room");
 
@@ -196,8 +226,9 @@ async fn destroy_room_removes_from_daemon() {
 #[tokio::test]
 async fn destroy_nonexistent_room_returns_error() {
     let td = TestDaemon::start(&[]).await;
+    let token = daemon_global_join(&td.socket_path, "admin").await;
 
-    let resp = daemon_destroy(&td.socket_path, "ghost-room").await;
+    let resp = daemon_destroy(&td.socket_path, "ghost-room", &token).await;
     assert_eq!(resp["type"], "error");
     assert_eq!(resp["code"], "room_not_found");
 }
@@ -215,7 +246,7 @@ async fn destroy_room_preserves_chat_file() {
     assert!(chat_path.exists(), "chat file should exist before destroy");
 
     // Destroy the room.
-    let resp = daemon_destroy(&td.socket_path, "chat-room").await;
+    let resp = daemon_destroy(&td.socket_path, "chat-room", &token).await;
     assert_eq!(resp["type"], "room_destroyed");
 
     // Chat file should still exist.
@@ -233,8 +264,9 @@ async fn destroy_room_preserves_chat_file() {
 #[tokio::test]
 async fn destroy_empty_room_id_returns_error() {
     let td = TestDaemon::start(&[]).await;
+    let token = daemon_global_join(&td.socket_path, "admin").await;
 
-    let resp = daemon_destroy(&td.socket_path, "").await;
+    let resp = daemon_destroy(&td.socket_path, "", &token).await;
     assert_eq!(resp["type"], "error");
     assert_eq!(resp["code"], "invalid_room_id");
 }
@@ -242,10 +274,16 @@ async fn destroy_empty_room_id_returns_error() {
 #[tokio::test]
 async fn create_then_destroy_then_recreate() {
     let td = TestDaemon::start(&[]).await;
+    let admin_token = daemon_global_join(&td.socket_path, "admin").await;
 
     // Create a room.
-    let create_resp =
-        daemon_create(&td.socket_path, "ephemeral", r#"{"visibility":"public"}"#).await;
+    let create_resp = daemon_create(
+        &td.socket_path,
+        "ephemeral",
+        r#"{"visibility":"public"}"#,
+        &admin_token,
+    )
+    .await;
     assert_eq!(create_resp["type"], "room_created");
 
     // Use it.
@@ -253,12 +291,17 @@ async fn create_then_destroy_then_recreate() {
     assert!(!token.is_empty());
 
     // Destroy it.
-    let destroy_resp = daemon_destroy(&td.socket_path, "ephemeral").await;
+    let destroy_resp = daemon_destroy(&td.socket_path, "ephemeral", &admin_token).await;
     assert_eq!(destroy_resp["type"], "room_destroyed");
 
     // Recreate it.
-    let recreate_resp =
-        daemon_create(&td.socket_path, "ephemeral", r#"{"visibility":"public"}"#).await;
+    let recreate_resp = daemon_create(
+        &td.socket_path,
+        "ephemeral",
+        r#"{"visibility":"public"}"#,
+        &admin_token,
+    )
+    .await;
     assert_eq!(recreate_resp["type"], "room_created");
 
     // Can join again (token is system-level, should still work).
@@ -460,8 +503,11 @@ async fn destroy_room_disconnects_uds_interactive_client() {
     // Drain the join broadcast and any history replay.
     tokio::time::sleep(Duration::from_millis(100)).await;
 
+    // Get a token for destroy auth.
+    let admin_token = daemon_global_join(&td.socket_path, "admin-469").await;
+
     // Destroy the room while the client is connected.
-    let resp = daemon_destroy(&td.socket_path, "live-room").await;
+    let resp = daemon_destroy(&td.socket_path, "live-room", &admin_token).await;
     assert_eq!(resp["type"], "room_destroyed");
 
     // The interactive client should receive EOF (0 bytes read) within a
@@ -513,8 +559,8 @@ async fn destroy_room_rejects_subsequent_token_send() {
     let msg = daemon_send(&td.socket_path, "send-room", &token, "before").await;
     assert_eq!(msg["type"], "message");
 
-    // Destroy the room.
-    let resp = daemon_destroy(&td.socket_path, "send-room").await;
+    // Destroy the room (reuse alice's token for auth).
+    let resp = daemon_destroy(&td.socket_path, "send-room", &token).await;
     assert_eq!(resp["type"], "room_destroyed");
 
     // Subsequent send should fail — room no longer exists.
@@ -548,8 +594,11 @@ async fn destroy_room_disconnects_multiple_uds_clients() {
     // Let join broadcasts settle.
     tokio::time::sleep(Duration::from_millis(200)).await;
 
+    // Get a token for destroy auth.
+    let admin_token = daemon_global_join(&td.socket_path, "admin-multi").await;
+
     // Destroy the room.
-    let resp = daemon_destroy(&td.socket_path, "multi-client-room").await;
+    let resp = daemon_destroy(&td.socket_path, "multi-client-room", &admin_token).await;
     assert_eq!(resp["type"], "room_destroyed");
 
     // All three clients should eventually get EOF or a read error.
@@ -577,4 +626,102 @@ async fn destroy_room_disconnects_multiple_uds_clients() {
         expect_disconnect(&mut r2, "client-2"),
         expect_disconnect(&mut r3, "client-3"),
     );
+}
+
+// ── Auth rejection tests (#469) ─────────────────────────────────────────────
+
+#[tokio::test]
+async fn create_room_without_token_returns_missing_token() {
+    let td = TestDaemon::start(&[]).await;
+
+    // Send CREATE without a token in the config.
+    let stream = UnixStream::connect(&td.socket_path).await.unwrap();
+    let (r, mut w) = stream.into_split();
+    w.write_all(b"CREATE:noauth-room\n{\"visibility\":\"public\"}\n")
+        .await
+        .unwrap();
+
+    let mut reader = BufReader::new(r);
+    let mut line = String::new();
+    reader.read_line(&mut line).await.unwrap();
+    let v: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+    assert_eq!(v["type"], "error");
+    assert_eq!(v["code"], "missing_token");
+}
+
+#[tokio::test]
+async fn create_room_with_invalid_token_returns_invalid_token() {
+    let td = TestDaemon::start(&[]).await;
+
+    // Send CREATE with a bogus token.
+    let stream = UnixStream::connect(&td.socket_path).await.unwrap();
+    let (r, mut w) = stream.into_split();
+    w.write_all(
+        b"CREATE:bad-token-room\n{\"visibility\":\"public\",\"token\":\"not-a-real-token\"}\n",
+    )
+    .await
+    .unwrap();
+
+    let mut reader = BufReader::new(r);
+    let mut line = String::new();
+    reader.read_line(&mut line).await.unwrap();
+    let v: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+    assert_eq!(v["type"], "error");
+    assert_eq!(v["code"], "invalid_token");
+}
+
+#[tokio::test]
+async fn destroy_room_without_token_returns_missing_token() {
+    let td = TestDaemon::start(&["auth-target"]).await;
+
+    // Send DESTROY with an empty second line (no token).
+    let stream = UnixStream::connect(&td.socket_path).await.unwrap();
+    let (r, mut w) = stream.into_split();
+    w.write_all(b"DESTROY:auth-target\n\n").await.unwrap();
+
+    let mut reader = BufReader::new(r);
+    let mut line = String::new();
+    reader.read_line(&mut line).await.unwrap();
+    let v: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+    assert_eq!(v["type"], "error");
+    assert_eq!(v["code"], "missing_token");
+}
+
+#[tokio::test]
+async fn destroy_room_with_invalid_token_returns_invalid_token() {
+    let td = TestDaemon::start(&["auth-target2"]).await;
+
+    // Send DESTROY with a bogus token.
+    let stream = UnixStream::connect(&td.socket_path).await.unwrap();
+    let (r, mut w) = stream.into_split();
+    w.write_all(b"DESTROY:auth-target2\nnot-a-real-token\n")
+        .await
+        .unwrap();
+
+    let mut reader = BufReader::new(r);
+    let mut line = String::new();
+    reader.read_line(&mut line).await.unwrap();
+    let v: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+    assert_eq!(v["type"], "error");
+    assert_eq!(v["code"], "invalid_token");
+}
+
+#[tokio::test]
+async fn create_and_destroy_with_valid_token_succeed() {
+    let td = TestDaemon::start(&[]).await;
+    let token = daemon_global_join(&td.socket_path, "auth-user").await;
+
+    // Create should succeed with valid token.
+    let create_resp = daemon_create(
+        &td.socket_path,
+        "auth-room",
+        r#"{"visibility":"public"}"#,
+        &token,
+    )
+    .await;
+    assert_eq!(create_resp["type"], "room_created");
+
+    // Destroy should succeed with valid token.
+    let destroy_resp = daemon_destroy(&td.socket_path, "auth-room", &token).await;
+    assert_eq!(destroy_resp["type"], "room_destroyed");
 }

--- a/crates/room-cli/tests/ws_smoke.rs
+++ b/crates/room-cli/tests/ws_smoke.rs
@@ -451,11 +451,37 @@ async fn smoke_isolated_daemon_prints_socket_json_and_is_reachable() {
 
     // Connect to the isolated daemon and create a room — verifies the socket is functional.
     use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+
+    // First: get a token via global JOIN.
+    let mut join_stream = tokio::net::UnixStream::connect(&sock)
+        .await
+        .expect("failed to connect for JOIN");
+    join_stream
+        .write_all(b"JOIN:smoke-admin\n")
+        .await
+        .expect("failed to write JOIN command");
+    let mut join_reader = tokio::io::BufReader::new(&mut join_stream);
+    let mut join_resp = String::new();
+    timeout(
+        Duration::from_secs(5),
+        join_reader.read_line(&mut join_resp),
+    )
+    .await
+    .expect("timed out reading JOIN response")
+    .expect("I/O error reading JOIN response");
+    let join_json: serde_json::Value =
+        serde_json::from_str(join_resp.trim()).expect("JOIN response not valid JSON");
+    let admin_token = join_json["token"]
+        .as_str()
+        .expect("JOIN response missing token field");
+
+    // Second: create a room with the token.
     let mut stream = tokio::net::UnixStream::connect(&sock)
         .await
         .expect("failed to connect to isolated daemon socket");
+    let create_config = format!("{{\"visibility\":\"public\",\"token\":\"{admin_token}\"}}");
     stream
-        .write_all(b"CREATE:test-isolated\n{\"visibility\":\"public\"}\n")
+        .write_all(format!("CREATE:test-isolated\n{create_config}\n").as_bytes())
         .await
         .expect("failed to write CREATE command");
     let mut reader2 = tokio::io::BufReader::new(&mut stream);


### PR DESCRIPTION
## Summary

- **UDS CREATE/DESTROY were unauthenticated** — any local process with socket access could create or destroy rooms. REST CREATE already had token auth.
- **CREATE**: token is now required in the config JSON (`"token"` field), validated against the UserRegistry before room creation.
- **DESTROY**: token is sent on a second line after the room ID, validated against the UserRegistry before destruction.
- **CLI**: `room create` and `room destroy` now require `--token/-t` flag.
- **TUI**: DM room creation reads the user's token from the token file and injects it into the CREATE config.

## Test plan

- [x] `create_room_without_token_returns_missing_token` — missing token rejected
- [x] `create_room_with_invalid_token_returns_invalid_token` — bogus token rejected
- [x] `destroy_room_without_token_returns_missing_token` — missing token rejected
- [x] `destroy_room_with_invalid_token_returns_invalid_token` — bogus token rejected
- [x] `create_and_destroy_with_valid_token_succeed` — valid token accepted for both
- [x] `create_room_default_config_without_token_rejected` — empty config (no token) rejected
- [x] All 1183 tests pass
- [x] Full `cargo check && cargo fmt --check && cargo clippy -- -D warnings && cargo test` passes

Closes #469
