### PR TITLE
fix(main): inject user token into CREATE config for interactive room start

### DIFF
--- a/crates/room-cli/src/main.rs
+++ b/crates/room-cli/src/main.rs
@@ -760,14 +760,25 @@ async fn run_join(
     room_cli::oneshot::transport::ensure_daemon_running().await?;
     let daemon_socket = paths::effective_socket_path(None);
 
+    // Read the user's token so we can authenticate the CREATE request.
+    // The token file is written by `room join <username>` or by Client::ensure_token.
+    let token_val = {
+        let path = paths::global_token_path(&username);
+        std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|data| serde_json::from_str::<serde_json::Value>(data.trim()).ok())
+            .and_then(|v| v["token"].as_str().map(|s| s.to_owned()))
+    };
+    let config_json = match token_val {
+        Some(tok) => room_cli::oneshot::transport::inject_token_into_config(
+            r#"{"visibility":"public"}"#,
+            &tok,
+        ),
+        None => r#"{"visibility":"public"}"#.to_owned(),
+    };
+
     // Create the room on the daemon (ignore "already exists").
-    match room_cli::oneshot::transport::create_room(
-        &daemon_socket,
-        &room_id,
-        r#"{"visibility":"public"}"#,
-    )
-    .await
-    {
+    match room_cli::oneshot::transport::create_room(&daemon_socket, &room_id, &config_json).await {
         Ok(_) => eprintln!("[room] created room '{room_id}' on daemon"),
         Err(e) => {
             let msg = e.to_string();


### PR DESCRIPTION
## Summary
- Fix `room <room_id> <username>` failing with "CREATE requires a valid token in the config JSON" after PR #485 added token auth to daemon CREATE/DESTROY
- `run_join` now reads the user's global token file and injects it into the CREATE config via `inject_token_into_config`

## Root cause
PR #485 added token validation to the daemon CREATE handler but did not update the interactive room-start path in `main.rs::run_join`, which called `create_room` with bare `{"visibility":"public"}` JSON (no token field).

## Test plan
- [x] All 1206 tests pass
- [x] Manual: `room <room_id> <username>` succeeds after fix (installed and verified locally)
