### PR TITLE
test(tui): add 29 tests covering member panel, paste, scroll, and tab switching

### DIFF
--- a/crates/room-cli/src/tui/input.rs
+++ b/crates/room-cli/src/tui/input.rs
@@ -636,6 +636,14 @@ pub(super) fn apply_backslash_enter(buf: &mut String, cursor_pos: usize) -> Opti
     }
 }
 
+/// Normalize pasted text: convert `\r\n` to `\n`, then stray `\r` to `\n`.
+///
+/// Called on `Event::Paste` to ensure consistent newline handling regardless
+/// of the clipboard's line-ending convention (Windows, old Mac, Unix).
+pub(super) fn normalize_paste(text: &str) -> String {
+    text.replace("\r\n", "\n").replace('\r', "\n")
+}
+
 /// Parse `/dm <user> <message>` input into a `DmRoom` action.
 ///
 /// Returns `Some(Action::DmRoom { .. })` when the input is a valid `/dm`
@@ -2397,5 +2405,142 @@ mod tests {
             state.mention.active,
             "mention picker should activate for Username params"
         );
+    }
+
+    // ── normalize_paste tests ───────────────────────────────────────────────
+
+    #[test]
+    fn normalize_paste_unix_newlines_unchanged() {
+        assert_eq!(normalize_paste("hello\nworld"), "hello\nworld");
+    }
+
+    #[test]
+    fn normalize_paste_windows_crlf_to_lf() {
+        assert_eq!(normalize_paste("hello\r\nworld"), "hello\nworld");
+    }
+
+    #[test]
+    fn normalize_paste_old_mac_cr_to_lf() {
+        assert_eq!(normalize_paste("hello\rworld"), "hello\nworld");
+    }
+
+    #[test]
+    fn normalize_paste_mixed_endings() {
+        assert_eq!(normalize_paste("a\r\nb\rc\nd"), "a\nb\nc\nd");
+    }
+
+    #[test]
+    fn normalize_paste_no_newlines() {
+        assert_eq!(normalize_paste("plain text"), "plain text");
+    }
+
+    #[test]
+    fn normalize_paste_empty() {
+        assert_eq!(normalize_paste(""), "");
+    }
+
+    #[test]
+    fn normalize_paste_multiple_crlf() {
+        assert_eq!(normalize_paste("a\r\n\r\nb"), "a\n\nb");
+    }
+
+    // ── Ctrl+D behavior (raw-mode TUI) ─────────────────────────────────────
+
+    #[test]
+    fn ctrl_d_does_not_quit() {
+        // In raw-mode TUI, Ctrl+D is not an exit signal (Ctrl+C is used
+        // instead). Ctrl+D falls through to handle_char which inserts 'd'.
+        let mut state = InputState::new();
+        let action = handle_key(
+            make_key_mod(KeyCode::Char('d'), KeyModifiers::CONTROL),
+            &mut state,
+            &[],
+            10,
+            80,
+        );
+        assert!(action.is_none(), "Ctrl+D should not trigger Quit");
+    }
+
+    // ── Tab switching (Ctrl+N / Ctrl+P / Ctrl+1-9) ─────────────────────────
+
+    #[test]
+    fn ctrl_n_returns_next_tab() {
+        let mut state = InputState::new();
+        let action = handle_key(
+            make_key_mod(KeyCode::Char('n'), KeyModifiers::CONTROL),
+            &mut state,
+            &[],
+            10,
+            80,
+        );
+        assert!(matches!(action, Some(Action::NextTab)));
+    }
+
+    #[test]
+    fn ctrl_p_returns_prev_tab() {
+        let mut state = InputState::new();
+        let action = handle_key(
+            make_key_mod(KeyCode::Char('p'), KeyModifiers::CONTROL),
+            &mut state,
+            &[],
+            10,
+            80,
+        );
+        assert!(matches!(action, Some(Action::PrevTab)));
+    }
+
+    #[test]
+    fn ctrl_1_returns_switch_tab_zero() {
+        let mut state = InputState::new();
+        let action = handle_key(
+            make_key_mod(KeyCode::Char('1'), KeyModifiers::CONTROL),
+            &mut state,
+            &[],
+            10,
+            80,
+        );
+        assert!(matches!(action, Some(Action::SwitchTab(0))));
+    }
+
+    #[test]
+    fn ctrl_9_returns_switch_tab_eight() {
+        let mut state = InputState::new();
+        let action = handle_key(
+            make_key_mod(KeyCode::Char('9'), KeyModifiers::CONTROL),
+            &mut state,
+            &[],
+            10,
+            80,
+        );
+        assert!(matches!(action, Some(Action::SwitchTab(8))));
+    }
+
+    // ── PageUp / PageDown scroll ────────────────────────────────────────────
+
+    #[test]
+    fn page_up_increases_scroll_offset() {
+        let mut state = InputState::new();
+        state.scroll_offset = 0;
+        handle_key(make_key(KeyCode::PageUp), &mut state, &[], 10, 80);
+        assert_eq!(state.scroll_offset, 10, "PageUp should add visible_count");
+    }
+
+    #[test]
+    fn page_down_decreases_scroll_offset() {
+        let mut state = InputState::new();
+        state.scroll_offset = 15;
+        handle_key(make_key(KeyCode::PageDown), &mut state, &[], 10, 80);
+        assert_eq!(
+            state.scroll_offset, 5,
+            "PageDown should subtract visible_count"
+        );
+    }
+
+    #[test]
+    fn page_down_saturates_at_zero() {
+        let mut state = InputState::new();
+        state.scroll_offset = 3;
+        handle_key(make_key(KeyCode::PageDown), &mut state, &[], 10, 80);
+        assert_eq!(state.scroll_offset, 0, "PageDown should not go below 0");
     }
 }

--- a/crates/room-cli/src/tui/mod.rs
+++ b/crates/room-cli/src/tui/mod.rs
@@ -31,13 +31,13 @@ use room_protocol::SubscriptionTier;
 
 use crate::message::Message;
 use input::{
-    build_payload, cursor_display_pos, handle_key, parse_kick_broadcast, parse_status_broadcast,
-    parse_subscription_broadcast, seed_online_users_from_who, wrap_input_display, Action,
-    InputState,
+    build_payload, cursor_display_pos, handle_key, normalize_paste, parse_kick_broadcast,
+    parse_status_broadcast, parse_subscription_broadcast, seed_online_users_from_who,
+    wrap_input_display, Action, InputState,
 };
 use render::{
-    assign_color, find_view_start, format_message, render_tab_bar, user_color, welcome_splash,
-    ColorMap, TabInfo,
+    assign_color, build_member_panel_spans, find_view_start, format_message,
+    member_panel_row_width, render_tab_bar, user_color, welcome_splash, ColorMap, TabInfo,
 };
 
 /// Maximum visible content lines in the input box before it stops growing.
@@ -631,31 +631,7 @@ pub async fn run(
                     .map(|u| {
                         let status = user_statuses_ref.get(u).map(|s| s.as_str()).unwrap_or("");
                         let tier = subscription_tiers_ref.get(u).copied();
-                        let mut spans = vec![Span::styled(
-                            format!(" {u}"),
-                            Style::default()
-                                .fg(user_color(u, &color_map))
-                                .add_modifier(Modifier::BOLD),
-                        )];
-                        match tier {
-                            Some(SubscriptionTier::MentionsOnly) => {
-                                spans.push(Span::styled(" @", Style::default().fg(Color::Yellow)));
-                            }
-                            Some(SubscriptionTier::Unsubscribed) => {
-                                spans.push(Span::styled(
-                                    " \u{2717}",
-                                    Style::default().fg(Color::Red),
-                                ));
-                            }
-                            _ => {}
-                        }
-                        if !status.is_empty() {
-                            spans.push(Span::styled(
-                                format!("  {status}"),
-                                Style::default().fg(Color::DarkGray),
-                            ));
-                        }
-                        spans.push(Span::raw(" "));
+                        let spans = build_member_panel_spans(u, status, tier, &color_map);
                         ListItem::new(Line::from(spans))
                     })
                     .collect();
@@ -664,18 +640,8 @@ pub async fn run(
                     .iter()
                     .map(|u| {
                         let status = user_statuses_ref.get(u).map(|s| s.as_str()).unwrap_or("");
-                        let status_len = if status.is_empty() {
-                            0
-                        } else {
-                            status.len() + 2 // "  " + status
-                        };
                         let tier = subscription_tiers_ref.get(u).copied();
-                        let tier_len = match tier {
-                            Some(SubscriptionTier::MentionsOnly)
-                            | Some(SubscriptionTier::Unsubscribed) => 2, // " @" or " ✗"
-                            _ => 0,
-                        };
-                        u.len() + 1 + tier_len + status_len + 1 // " " + name + tier + status + " "
+                        member_panel_row_width(u, status, tier)
                     })
                     .max()
                     .unwrap_or(10);
@@ -882,8 +848,7 @@ pub async fn run(
                     }
                 }
                 Event::Paste(text) => {
-                    // Normalize line endings: \r\n → \n, stray \r → \n.
-                    let clean = text.replace("\r\n", "\n").replace('\r', "\n");
+                    let clean = normalize_paste(&text);
                     input_state.input.insert_str(input_state.cursor_pos, &clean);
                     input_state.cursor_pos += clean.len();
                     input_state.mention.active = false;

--- a/crates/room-cli/src/tui/render.rs
+++ b/crates/room-cli/src/tui/render.rs
@@ -5,6 +5,8 @@ use ratatui::{
     text::{Line, Span, Text},
 };
 
+use room_protocol::SubscriptionTier;
+
 use crate::message::Message;
 
 pub(super) use super::render_bots::welcome_splash;
@@ -498,6 +500,62 @@ pub(super) fn render_tab_bar(tabs: &[TabInfo]) -> Option<Line<'static>> {
     Some(Line::from(spans))
 }
 
+/// Build the styled spans for a single member panel row.
+///
+/// Renders: ` <username>` (bold, colored) + optional tier indicator + optional
+/// status (dimmed) + trailing space. Used by the floating member panel.
+pub(super) fn build_member_panel_spans(
+    username: &str,
+    status: &str,
+    tier: Option<SubscriptionTier>,
+    color_map: &ColorMap,
+) -> Vec<Span<'static>> {
+    let mut spans = vec![Span::styled(
+        format!(" {username}"),
+        Style::default()
+            .fg(user_color(username, color_map))
+            .add_modifier(Modifier::BOLD),
+    )];
+    match tier {
+        Some(SubscriptionTier::MentionsOnly) => {
+            spans.push(Span::styled(" @", Style::default().fg(Color::Yellow)));
+        }
+        Some(SubscriptionTier::Unsubscribed) => {
+            spans.push(Span::styled(" \u{2717}", Style::default().fg(Color::Red)));
+        }
+        _ => {}
+    }
+    if !status.is_empty() {
+        spans.push(Span::styled(
+            format!("  {status}"),
+            Style::default().fg(Color::DarkGray),
+        ));
+    }
+    spans.push(Span::raw(" "));
+    spans
+}
+
+/// Compute the content width of a single member panel row.
+///
+/// Returns the number of characters needed to display the username, tier
+/// indicator, and status for one row. Used to size the floating panel.
+pub(super) fn member_panel_row_width(
+    username: &str,
+    status: &str,
+    tier: Option<SubscriptionTier>,
+) -> usize {
+    let tier_len = match tier {
+        Some(SubscriptionTier::MentionsOnly) | Some(SubscriptionTier::Unsubscribed) => 2,
+        _ => 0,
+    };
+    let status_len = if status.is_empty() {
+        0
+    } else {
+        status.len() + 2 // "  " + status
+    };
+    username.len() + 1 + tier_len + status_len + 1 // " " + name + tier + status + " "
+}
+
 /// Look up a username's color from the map, falling back to the hash-based
 /// palette index if the user has not been assigned a color yet.
 pub(super) fn user_color(username: &str, color_map: &ColorMap) -> Color {
@@ -928,6 +986,143 @@ mod tests {
             .expect("should find alpha span");
         assert_eq!(alpha_span.style.fg, Some(Color::Black));
         assert_eq!(alpha_span.style.bg, Some(Color::Cyan));
+    }
+
+    // ── build_member_panel_spans tests ─────────────────────────────────────
+
+    #[test]
+    fn member_panel_spans_plain_user() {
+        let cm = ColorMap::new();
+        let spans = build_member_panel_spans("alice", "", None, &cm);
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(text, " alice ");
+    }
+
+    #[test]
+    fn member_panel_spans_with_status() {
+        let cm = ColorMap::new();
+        let spans = build_member_panel_spans("alice", "coding", None, &cm);
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(text, " alice  coding ");
+    }
+
+    #[test]
+    fn member_panel_spans_mentions_only_tier() {
+        let cm = ColorMap::new();
+        let spans = build_member_panel_spans("bob", "", Some(SubscriptionTier::MentionsOnly), &cm);
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(text, " bob @ ");
+        // Verify the "@" indicator has yellow color
+        let at_span = spans.iter().find(|s| s.content.contains('@')).unwrap();
+        assert_eq!(at_span.style.fg, Some(Color::Yellow));
+    }
+
+    #[test]
+    fn member_panel_spans_unsubscribed_tier() {
+        let cm = ColorMap::new();
+        let spans =
+            build_member_panel_spans("charlie", "", Some(SubscriptionTier::Unsubscribed), &cm);
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains('\u{2717}'), "should contain cross mark");
+        // Verify the cross mark has red color
+        let cross_span = spans
+            .iter()
+            .find(|s| s.content.contains('\u{2717}'))
+            .unwrap();
+        assert_eq!(cross_span.style.fg, Some(Color::Red));
+    }
+
+    #[test]
+    fn member_panel_spans_full_tier_no_indicator() {
+        let cm = ColorMap::new();
+        let spans = build_member_panel_spans("dave", "", Some(SubscriptionTier::Full), &cm);
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(text, " dave ");
+    }
+
+    #[test]
+    fn member_panel_spans_with_status_and_tier() {
+        let cm = ColorMap::new();
+        let spans = build_member_panel_spans(
+            "eve",
+            "reviewing PR",
+            Some(SubscriptionTier::MentionsOnly),
+            &cm,
+        );
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(text, " eve @  reviewing PR ");
+    }
+
+    #[test]
+    fn member_panel_spans_username_is_bold() {
+        let cm = ColorMap::new();
+        let spans = build_member_panel_spans("alice", "", None, &cm);
+        let name_span = &spans[0];
+        assert!(
+            name_span.style.add_modifier.contains(Modifier::BOLD),
+            "username should be bold"
+        );
+    }
+
+    #[test]
+    fn member_panel_spans_status_is_dimmed() {
+        let cm = ColorMap::new();
+        let spans = build_member_panel_spans("alice", "busy", None, &cm);
+        let status_span = spans.iter().find(|s| s.content.contains("busy")).unwrap();
+        assert_eq!(
+            status_span.style.fg,
+            Some(Color::DarkGray),
+            "status should be DarkGray"
+        );
+    }
+
+    // ── member_panel_row_width tests ────────────────────────────────────────
+
+    #[test]
+    fn row_width_plain_user() {
+        // " alice " = 1 + 5 + 1 = 7
+        assert_eq!(member_panel_row_width("alice", "", None), 7);
+    }
+
+    #[test]
+    fn row_width_with_status() {
+        // " alice  coding " = 1 + 5 + 0 + (2 + 6) + 1 = 15
+        assert_eq!(member_panel_row_width("alice", "coding", None), 15);
+    }
+
+    #[test]
+    fn row_width_with_mentions_only_tier() {
+        // " bob @ " = 1 + 3 + 2 + 0 + 1 = 7
+        assert_eq!(
+            member_panel_row_width("bob", "", Some(SubscriptionTier::MentionsOnly)),
+            7
+        );
+    }
+
+    #[test]
+    fn row_width_with_unsubscribed_tier() {
+        // Same as MentionsOnly: +2 for the indicator
+        assert_eq!(
+            member_panel_row_width("bob", "", Some(SubscriptionTier::Unsubscribed)),
+            7
+        );
+    }
+
+    #[test]
+    fn row_width_full_tier_no_extra() {
+        assert_eq!(
+            member_panel_row_width("bob", "", Some(SubscriptionTier::Full)),
+            member_panel_row_width("bob", "", None),
+        );
+    }
+
+    #[test]
+    fn row_width_with_status_and_tier() {
+        // " eve @  reviewing PR " = 1 + 3 + 2 + (2 + 12) + 1 = 21
+        assert_eq!(
+            member_panel_row_width("eve", "reviewing PR", Some(SubscriptionTier::MentionsOnly)),
+            21
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Manual testing of TUI & Input area for v3.0.0 release. Audited all 323 existing TUI unit tests, identified 6 automated test gaps, and filled them with 29 new tests.

**Extracted 3 inline functions into testable helpers:**
- `build_member_panel_spans` / `member_panel_row_width` in render.rs — member panel item construction was previously inlined in the draw closure
- `normalize_paste` in input.rs — paste CRLF normalization

**New test coverage:**
- Member panel spans: tier indicators (@/cross mark), status dimming, bold username, Full tier no-indicator (8 tests)
- Member panel row width: all tier/status combinations (6 tests)
- Paste normalization: CRLF, CR, LF, mixed endings, empty (7 tests)
- Ctrl+D behavior: documents it falls through to char insert, not quit (correct for raw-mode TUI) (1 test)
- Tab switching: Ctrl+N/P/1/9 actions (4 tests)
- PageUp/PageDown: scroll offset arithmetic, saturation at zero (3 tests)

**Remaining human-only gaps (cannot be automated):**
- Terminal resize visual layout
- Panel positioning / popup overlap
- Multiline paste visual wrap rendering
- Markdown style visual appearance

## Test plan
- [x] `cargo check` passes
- [x] `cargo fmt` — no changes
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — 1227 Rust tests pass (29 new)
