### PR TITLE
feat(taskboard): add /taskboard assign subcommand

### DIFF
--- a/crates/room-cli/CHANGELOG.md
+++ b/crates/room-cli/CHANGELOG.md
@@ -14,6 +14,7 @@ For changes prior to the workspace restructure (v0.1.2 through v1.0.2), see the
 
 - Integration tests: REST/WS global daemon token fallback and kicked user WS reconnection rejection. (#490, #492)
 - Integration tests: queue plugin oneshot response — add, pop (FIFO), and remove return system echo to oneshot senders. (#494)
+- `/taskboard assign <task-id> <username>` subcommand — poster or host can assign an open task to a specific user. (#502)
 
 ### Fixed
 

--- a/crates/room-cli/src/plugin/taskboard/mod.rs
+++ b/crates/room-cli/src/plugin/taskboard/mod.rs
@@ -52,7 +52,7 @@ impl TaskboardPlugin {
         vec![CommandInfo {
             name: "taskboard".to_owned(),
             description:
-                "Manage task lifecycle — post, list, show, claim, plan, approve, update, release, finish"
+                "Manage task lifecycle — post, list, show, claim, assign, plan, approve, update, release, finish"
                     .to_owned(),
             usage: "/taskboard <action> [args...]".to_owned(),
             params: vec![
@@ -63,6 +63,7 @@ impl TaskboardPlugin {
                         "list".to_owned(),
                         "show".to_owned(),
                         "claim".to_owned(),
+                        "assign".to_owned(),
                         "plan".to_owned(),
                         "approve".to_owned(),
                         "update".to_owned(),
@@ -402,6 +403,58 @@ impl TaskboardPlugin {
         )
     }
 
+    fn handle_assign(&self, ctx: &CommandContext) -> (String, bool) {
+        let task_id = match ctx.params.get(1) {
+            Some(id) => id,
+            None => {
+                return (
+                    "usage: /taskboard assign <task-id> <username>".to_owned(),
+                    false,
+                )
+            }
+        };
+        let target_user = match ctx.params.get(2) {
+            Some(u) => u,
+            None => {
+                return (
+                    "usage: /taskboard assign <task-id> <username>".to_owned(),
+                    false,
+                )
+            }
+        };
+        self.sweep_expired();
+        let mut board = self.board.lock().unwrap();
+        let lt = match board.iter_mut().find(|lt| lt.task.id == *task_id) {
+            Some(lt) => lt,
+            None => return (format!("task {task_id} not found"), false),
+        };
+        if lt.task.status != TaskStatus::Open {
+            return (
+                format!(
+                    "task {task_id} is {} (must be open to assign)",
+                    lt.task.status
+                ),
+                false,
+            );
+        }
+        // Only poster or host can assign.
+        let is_poster = lt.task.posted_by == ctx.sender;
+        let is_host = ctx.metadata.host.as_deref() == Some(&ctx.sender);
+        if !is_poster && !is_host {
+            return ("only the task poster or host can assign".to_owned(), false);
+        }
+        lt.task.status = TaskStatus::Claimed;
+        lt.task.assigned_to = Some(target_user.clone());
+        lt.task.claimed_at = Some(chrono::Utc::now());
+        lt.renew_lease();
+        let tasks: Vec<Task> = board.iter().map(|lt| lt.task.clone()).collect();
+        let _ = task::save_tasks(&self.storage_path, &tasks);
+        (
+            format!("task {task_id} assigned to {target_user} by {}", ctx.sender),
+            true,
+        )
+    }
+
     fn handle_show(&self, ctx: &CommandContext) -> String {
         let task_id = match ctx.params.get(1) {
             Some(id) => id,
@@ -489,14 +542,15 @@ impl Plugin for TaskboardPlugin {
                 "post" => self.handle_post(&ctx),
                 "list" => (self.handle_list(), false),
                 "claim" => self.handle_claim(&ctx),
+                "assign" => self.handle_assign(&ctx),
                 "plan" => self.handle_plan(&ctx),
                 "approve" => self.handle_approve(&ctx),
                 "show" => (self.handle_show(&ctx), false),
                 "update" => self.handle_update(&ctx),
                 "release" => self.handle_release(&ctx),
                 "finish" => self.handle_finish(&ctx),
-                "" => ("usage: /taskboard <post|list|show|claim|plan|approve|update|release|finish> [args...]".to_owned(), false),
-                other => (format!("unknown action: {other}. use: post, list, show, claim, plan, approve, update, release, finish"), false),
+                "" => ("usage: /taskboard <post|list|show|claim|assign|plan|approve|update|release|finish> [args...]".to_owned(), false),
+                other => (format!("unknown action: {other}. use: post, list, show, claim, assign, plan, approve, update, release, finish"), false),
             };
             if broadcast {
                 Ok(PluginResult::Broadcast(result))
@@ -533,7 +587,8 @@ mod tests {
         if let ParamType::Choice(ref choices) = cmds[0].params[0].param_type {
             assert!(choices.contains(&"post".to_owned()));
             assert!(choices.contains(&"approve".to_owned()));
-            assert_eq!(choices.len(), 9);
+            assert!(choices.contains(&"assign".to_owned()));
+            assert_eq!(choices.len(), 10);
         } else {
             panic!("expected Choice param type");
         }
@@ -835,6 +890,109 @@ mod tests {
         assert_eq!(default.len(), instance.len());
         assert_eq!(default[0].name, instance[0].name);
         assert_eq!(default[0].params.len(), instance[0].params.len());
+    }
+
+    #[test]
+    fn handle_assign_happy_path() {
+        let (plugin, _tmp) = make_plugin();
+        plugin.handle_post(&test_ctx("ba", &["post", "implement feature"]));
+        let (result, broadcast) = plugin.handle_assign(&test_ctx_with_host(
+            "ba",
+            &["assign", "tb-001", "agent"],
+            None,
+        ));
+        assert!(result.contains("assigned to agent"));
+        assert!(result.contains("by ba"));
+        assert!(broadcast);
+        let board = plugin.board.lock().unwrap();
+        assert_eq!(board[0].task.status, TaskStatus::Claimed);
+        assert_eq!(board[0].task.assigned_to.as_deref(), Some("agent"));
+    }
+
+    #[test]
+    fn handle_assign_by_host() {
+        let (plugin, _tmp) = make_plugin();
+        plugin.handle_post(&test_ctx("ba", &["post", "task"]));
+        // Host (joao) can assign even though ba posted it.
+        let (result, broadcast) = plugin.handle_assign(&test_ctx_with_host(
+            "joao",
+            &["assign", "tb-001", "saphire"],
+            Some("joao"),
+        ));
+        assert!(result.contains("assigned to saphire"));
+        assert!(result.contains("by joao"));
+        assert!(broadcast);
+    }
+
+    #[test]
+    fn handle_assign_rejected_non_poster_non_host() {
+        let (plugin, _tmp) = make_plugin();
+        plugin.handle_post(&test_ctx("ba", &["post", "task"]));
+        let (result, broadcast) = plugin.handle_assign(&test_ctx_with_host(
+            "random",
+            &["assign", "tb-001", "agent"],
+            Some("joao"),
+        ));
+        assert!(result.contains("only the task poster or host"));
+        assert!(!broadcast);
+    }
+
+    #[test]
+    fn handle_assign_wrong_status() {
+        let (plugin, _tmp) = make_plugin();
+        plugin.handle_post(&test_ctx("ba", &["post", "task"]));
+        plugin.handle_claim(&test_ctx("agent", &["claim", "tb-001"]));
+        // Task is already claimed — assign should fail.
+        let (result, broadcast) =
+            plugin.handle_assign(&test_ctx("ba", &["assign", "tb-001", "other"]));
+        assert!(result.contains("must be open to assign"));
+        assert!(!broadcast);
+    }
+
+    #[test]
+    fn handle_assign_not_found() {
+        let (plugin, _tmp) = make_plugin();
+        let (result, broadcast) =
+            plugin.handle_assign(&test_ctx("ba", &["assign", "tb-999", "agent"]));
+        assert!(result.contains("not found"));
+        assert!(!broadcast);
+    }
+
+    #[test]
+    fn handle_assign_missing_args() {
+        let (plugin, _tmp) = make_plugin();
+        // No task ID.
+        let (result, broadcast) = plugin.handle_assign(&test_ctx("ba", &["assign"]));
+        assert!(result.contains("usage"));
+        assert!(!broadcast);
+        // No username.
+        let (result, broadcast) = plugin.handle_assign(&test_ctx("ba", &["assign", "tb-001"]));
+        assert!(result.contains("usage"));
+        assert!(!broadcast);
+    }
+
+    #[test]
+    fn handle_assign_then_plan_and_finish() {
+        let (plugin, _tmp) = make_plugin();
+        plugin.handle_post(&test_ctx("ba", &["post", "implement #502"]));
+        // Assign to agent.
+        plugin.handle_assign(&test_ctx("ba", &["assign", "tb-001", "agent"]));
+        // Agent can submit plan on assigned task.
+        let (result, broadcast) = plugin.handle_plan(&test_ctx(
+            "agent",
+            &["plan", "tb-001", "add handler and tests"],
+        ));
+        assert!(result.contains("plan submitted"));
+        assert!(broadcast);
+        // Approve and finish.
+        plugin.handle_approve(&test_ctx_with_host(
+            "ba",
+            &["approve", "tb-001"],
+            Some("ba"),
+        ));
+        let (result, broadcast) = plugin.handle_finish(&test_ctx("agent", &["finish", "tb-001"]));
+        assert!(result.contains("finished"));
+        assert!(broadcast);
     }
 
     // ── Test helpers ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add `/taskboard assign <task-id> <username>` subcommand for poster/host to assign open tasks to specific users
- Sets task to Claimed status with assigned_to, claimed_at, and lease renewal — same as self-claim but initiated by an authorized user
- Uses same authorization model as `/taskboard approve` (poster or host only)

## Changes

- `plugin/taskboard/mod.rs`: `handle_assign()` method, "assign" added to `default_commands()` choices, `handle()` dispatch, and usage strings
- `CHANGELOG.md`: added entry under [Unreleased]
- 7 new unit tests: happy path, host-can-assign, auth rejection, wrong status, not-found, missing args, assign-plan-finish lifecycle

## Test plan

- [x] `cargo check` — no errors
- [x] `cargo fmt` — clean
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo test` — all tests pass (46 taskboard unit + 3 integration)
- [ ] Manual test: `/taskboard assign <id> <user>` in live broker

Closes #502
