### PR TITLE
test(broker): taskboard oneshot integration tests

### DIFF
--- a/crates/room-cli/CHANGELOG.md
+++ b/crates/room-cli/CHANGELOG.md
@@ -20,6 +20,7 @@ For changes prior to the workspace restructure (v0.1.2 through v1.0.2), see the
 - Integration tests: REST/WS global daemon token fallback and kicked user WS reconnection rejection. (#490, #492)
 - Integration tests: queue plugin oneshot response — add, pop (FIFO), and remove return system echo to oneshot senders. (#494)
 - `/taskboard assign <task-id> <username>` subcommand — poster or host can assign an open task to a specific user. (#502)
+- Integration tests: taskboard oneshot response — post, list, and claim+finish lifecycle return system echo to oneshot senders. (#534)
 - `/info [username]` command — shows room metadata (no args) or user info (status,
   subscription tier, host flag, online status). `/room-info` is now an alias. (#507)
 

--- a/crates/room-cli/tests/broker.rs
+++ b/crates/room-cli/tests/broker.rs
@@ -1474,3 +1474,97 @@ async fn queue_remove_oneshot_returns_response() {
         "response should show the original index: {content}"
     );
 }
+
+// ── Taskboard oneshot tests ─────────────────────────────────────────────────
+//
+// Verify that `/taskboard` subcommands via oneshot (room send) return a
+// response instead of EOF.
+
+/// Build a taskboard command JSON envelope for oneshot sends.
+fn taskboard_cmd_wire(action: &str, args: &[&str]) -> String {
+    let mut params: Vec<serde_json::Value> = vec![serde_json::Value::String(action.to_owned())];
+    for arg in args {
+        params.push(serde_json::Value::String((*arg).to_owned()));
+    }
+    serde_json::json!({"type": "command", "cmd": "taskboard", "params": params}).to_string()
+}
+
+/// Oneshot `/taskboard post` returns a system message echo to the sender.
+#[tokio::test]
+async fn taskboard_post_oneshot_returns_response() {
+    let td = common::TestDaemon::start(&["tb-os-post"]).await;
+    let token = common::daemon_join(&td.socket_path, "tb-os-post", "bot").await;
+
+    let wire = taskboard_cmd_wire("post", &["fix", "the", "flaky", "test"]);
+    let resp = common::daemon_send(&td.socket_path, "tb-os-post", &token, &wire).await;
+
+    assert_eq!(
+        resp["type"], "system",
+        "expected system message, got: {resp}"
+    );
+    let content = resp["content"].as_str().unwrap();
+    assert!(
+        content.contains("tb-001"),
+        "response should contain task ID: {content}"
+    );
+    assert!(
+        content.contains("fix the flaky test"),
+        "response should echo the task description: {content}"
+    );
+}
+
+/// Oneshot `/taskboard list` returns a reply to the sender.
+#[tokio::test]
+async fn taskboard_list_oneshot_returns_response() {
+    let td = common::TestDaemon::start(&["tb-os-list"]).await;
+    let token = common::daemon_join(&td.socket_path, "tb-os-list", "bot").await;
+
+    // Post a task first.
+    let post_wire = taskboard_cmd_wire("post", &["list-test-task"]);
+    common::daemon_send(&td.socket_path, "tb-os-list", &token, &post_wire).await;
+
+    let list_wire = taskboard_cmd_wire("list", &[]);
+    let resp = common::daemon_send(&td.socket_path, "tb-os-list", &token, &list_wire).await;
+
+    assert_eq!(
+        resp["type"], "system",
+        "expected system message, got: {resp}"
+    );
+    let content = resp["content"].as_str().unwrap();
+    assert!(
+        content.contains("tb-001"),
+        "list should show the posted task: {content}"
+    );
+}
+
+/// Oneshot `/taskboard claim` + `/taskboard finish` lifecycle.
+#[tokio::test]
+async fn taskboard_claim_finish_oneshot_returns_response() {
+    let td = common::TestDaemon::start(&["tb-os-fin"]).await;
+    let token = common::daemon_join(&td.socket_path, "tb-os-fin", "bot").await;
+
+    // Post → claim → finish.
+    let post_wire = taskboard_cmd_wire("post", &["finish-test"]);
+    common::daemon_send(&td.socket_path, "tb-os-fin", &token, &post_wire).await;
+
+    let claim_wire = taskboard_cmd_wire("claim", &["tb-001"]);
+    let resp = common::daemon_send(&td.socket_path, "tb-os-fin", &token, &claim_wire).await;
+    assert_eq!(resp["type"], "system", "claim should return system: {resp}");
+    let content = resp["content"].as_str().unwrap();
+    assert!(
+        content.contains("claimed by bot"),
+        "claim response: {content}"
+    );
+
+    let finish_wire = taskboard_cmd_wire("finish", &["tb-001"]);
+    let resp = common::daemon_send(&td.socket_path, "tb-os-fin", &token, &finish_wire).await;
+    assert_eq!(
+        resp["type"], "system",
+        "finish should return system: {resp}"
+    );
+    let content = resp["content"].as_str().unwrap();
+    assert!(
+        content.contains("finished by bot"),
+        "finish response: {content}"
+    );
+}


### PR DESCRIPTION
## Summary

- Add 3 integration tests verifying taskboard oneshot (room send) responses: post, list, claim+finish lifecycle
- Root cause: live daemon binary is `room 3.0.0` while crate is `3.0.1` — stale binary missing sprint 14 plugin changes
- Fix: rebuild (`cargo install --path crates/room-cli`) and restart the daemon

## Test plan

- [x] `cargo check` / `cargo fmt` / `cargo clippy` clean
- [x] 3 new tests pass: `taskboard_post_oneshot_returns_response`, `taskboard_list_oneshot_returns_response`, `taskboard_claim_finish_oneshot_returns_response`
- [ ] Rebuild binary, restart daemon, verify `/taskboard` commands work via `room send`

Closes #534
