### PR TITLE
feat(broker): add version field to /api/health endpoint

### DIFF
--- a/crates/room-cli/src/broker/ws/rest.rs
+++ b/crates/room-cli/src/broker/ws/rest.rs
@@ -411,7 +411,8 @@ pub(super) async fn api_health(State(state): State<WsAppState>) -> impl IntoResp
     Json(serde_json::json!({
         "status": "ok",
         "room": rs.room_id(),
-        "users": users
+        "users": users,
+        "version": env!("CARGO_PKG_VERSION"),
     }))
 }
 
@@ -597,6 +598,7 @@ pub(super) async fn daemon_api_health(State(state): State<DaemonWsState>) -> imp
     Json(serde_json::json!({
         "status": "ok",
         "rooms": room_info,
+        "version": env!("CARGO_PKG_VERSION"),
     }))
 }
 

--- a/crates/room-cli/tests/ws.rs
+++ b/crates/room-cli/tests/ws.rs
@@ -223,6 +223,7 @@ async fn rest_health_returns_ok() {
     let body: serde_json::Value = resp.json().await.unwrap();
     assert_eq!(body["status"], "ok");
     assert_eq!(body["room"], "ws_health");
+    assert_eq!(body["version"], env!("CARGO_PKG_VERSION"));
 }
 
 #[tokio::test]

--- a/crates/room-cli/tests/ws_smoke.rs
+++ b/crates/room-cli/tests/ws_smoke.rs
@@ -122,6 +122,7 @@ async fn smoke_rest_health() {
     let body: serde_json::Value = resp.json().await.unwrap();
     assert_eq!(body["status"], "ok");
     assert_eq!(body["room"], "smoke_health");
+    assert_eq!(body["version"], env!("CARGO_PKG_VERSION"));
 
     child.kill().await.ok();
 }


### PR DESCRIPTION
## Summary
- Add `version` field (from `CARGO_PKG_VERSION`) to both single-room and daemon `/api/health` JSON responses
- Existing health tests updated to assert the version field is present and correct

## Context
Sprint 14 retro action item: the taskboard oneshot EOF bug consumed 2+ hours of debugging because the live binary was 3.0.0 while crate code was 3.0.1. A version field in health would have diagnosed this in seconds.

## Files changed
- `crates/room-cli/src/broker/ws/rest.rs` — both `api_health` and `daemon_api_health` handlers
- `crates/room-cli/tests/ws.rs` — version assertion in `rest_health_returns_ok`
- `crates/room-cli/tests/ws_smoke.rs` — version assertion in `smoke_rest_health`

## Test plan
- [x] `cargo test` passes (1371 tests, 0 failures)
- [x] `cargo clippy -- -D warnings` clean
- [ ] Manual: `curl localhost:<port>/api/health` shows version field

Closes #541