### PR TITLE
docs: fix socket and file paths in quick-start and broker-internals

### DIFF
--- a/docs/broker-internals.md
+++ b/docs/broker-internals.md
@@ -6,13 +6,17 @@ A technical reference for contributors and advanced users.
 
 The broker is a single async Tokio process that:
 
-1. Listens on a Unix domain socket (`/tmp/room-<id>.sock`)
+1. Listens on a Unix domain socket (`<runtime_dir>/room-<id>.sock`)
 2. Accepts client connections and runs a per-client handler task
 3. Fans out messages to all connected clients via a `tokio::broadcast` channel
 4. Appends every event to an NDJSON chat file
 
+> **Runtime directory:** `<runtime_dir>` is platform-native — macOS uses `$TMPDIR`
+> (per-user, e.g. `/var/folders/...`), Linux uses `$XDG_RUNTIME_DIR/room/` or `/tmp/`
+> as a fallback. See `paths::room_runtime_dir()`.
+
 ```
-/tmp/room-<id>.sock  ←──────────────────────────────────┐
+<runtime_dir>/room-<id>.sock  ←─────────────────────────┐
                                                          │
 room myroom alice  ──[connect]──► Broker                 │
                                     │                    │
@@ -148,7 +152,7 @@ The main accept loop also holds a watch receiver and exits when `changed()` fire
 
 ## NDJSON persistence
 
-The chat file (default: `/tmp/<room-id>.chat`) is an NDJSON file — one JSON object per line. The broker is the **sole writer**; clients must never write to it directly.
+The chat file (default: `~/.room/data/<room-id>.chat`) is an NDJSON file — one JSON object per line. The broker is the **sole writer**; clients must never write to it directly.
 
 All writes go through `history::append`, which opens the file in append mode. Tokio's `tokio::fs` wrappers are not used here — see below.
 
@@ -188,6 +192,6 @@ const ADMIN_CMD_NAMES: &[&str] = &["kick", "reauth", "clear-tokens", "exit", "cl
 |---|---|
 | `kick <user>` | Removes all tokens for `<user>`, inserts a `KICKED:<user>` sentinel so the username stays reserved. Removes from `StatusMap`. |
 | `reauth <user>` | Removes all tokens for `<user>` (including the kicked sentinel) and deletes the on-disk token file. The user can `room join` again. |
-| `clear-tokens` | Clears the full `TokenMap` and removes all `room-<id>-*.token` files from `/tmp`. |
+| `clear-tokens` | Clears the full `TokenMap` and removes all token files from `~/.room/state/`. |
 | `exit` | Broadcasts a shutdown notice, then calls `shutdown.send(true)`. |
 | `clear` | Truncates the chat history file via `std::fs::write(path, "")`. |

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -35,7 +35,7 @@ room myroom bob
 
 You are now `bob`, connected to the same room. Type a message and press `Enter` to send. It appears in both windows.
 
-> **How it works:** the first `room myroom alice` call looks for `/tmp/room-myroom.sock`. Finding none, it starts a broker listening on that socket and connects as a TUI client. `room myroom bob` finds the socket and connects directly.
+> **How it works:** the first `room myroom alice` call looks for `room-myroom.sock` in the platform-native runtime directory (macOS: `$TMPDIR`, Linux: `$XDG_RUNTIME_DIR/room/` or `/tmp/`). Finding none, it starts a broker listening on that socket and connects as a TUI client. `room myroom bob` finds the socket and connects directly.
 
 ## Key bindings
 


### PR DESCRIPTION
## Summary
- Replace hardcoded `/tmp/` socket paths with platform-native runtime directory references
- Add runtime directory explanation note to broker-internals.md
- Fix chat file default path (`~/.room/data/<room-id>.chat`, not `/tmp/`)
- Fix clear-tokens path reference (`~/.room/state/`, not `/tmp/`)

## Context
From #546 docs audit (P0 issue 9). Both docs hardcoded socket paths as `/tmp/room-<id>.sock`. Actual path is platform-native via `paths::room_runtime_dir()`.

## Note
broker-internals.md also has stale `/claim` references (line 92, 171) — not fixed here as those are scoped to other tickets (#589, #592).

## Test plan
- [x] Docs-only change, no code modified

Closes #593