### PR TITLE
fix(ci): switch changelog skip from commit marker to PR label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
           fetch-depth: 0
       - name: Check changelog entry
         run: bash scripts/check-changelog.sh origin/${{ github.base_ref }}
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ github.token }}
 
   scripts:
     name: Shell Scripts

--- a/scripts/check-changelog.sh
+++ b/scripts/check-changelog.sh
@@ -4,8 +4,11 @@
 # Verifies that the PR branch adds at least one line to an [Unreleased]
 # section in any CHANGELOG.md file compared to the base branch.
 #
-# Bypass: include "[skip changelog]" in a commit message on the PR branch.
+# Bypass: add the "skip-changelog" label to the PR on GitHub.
 # Use for docs-only, CI-only, or chore changes that don't need a log entry.
+#
+# In CI, set PR_NUMBER env var so the script can query labels via `gh`.
+# Locally, set SKIP_CHANGELOG=1 to bypass.
 #
 # Usage:
 #   bash scripts/check-changelog.sh [base-ref]
@@ -16,11 +19,20 @@ set -euo pipefail
 BASE_REF="${1:-origin/master}"
 
 # ---------------------------------------------------------------------------
-# Skip check if any commit in the PR carries [skip changelog]
+# Skip check if the PR has the "skip-changelog" label (CI) or SKIP_CHANGELOG
+# env var is set (local override)
 # ---------------------------------------------------------------------------
-if git log "$BASE_REF"..HEAD --format=%s | grep -qi '\[skip changelog\]'; then
-    echo "Changelog check skipped via [skip changelog] marker."
+if [ "${SKIP_CHANGELOG:-}" = "1" ]; then
+    echo "Changelog check skipped via SKIP_CHANGELOG env var."
     exit 0
+fi
+
+if [ -n "${PR_NUMBER:-}" ]; then
+    if gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' 2>/dev/null \
+        | grep -qi '^skip-changelog$'; then
+        echo "Changelog check skipped via skip-changelog label on PR #$PR_NUMBER."
+        exit 0
+    fi
 fi
 
 # ---------------------------------------------------------------------------
@@ -44,7 +56,7 @@ if [ -z "$ADDED_LINES" ]; then
     echo "Format: one bullet point per PR under the appropriate heading"
     echo "(Added, Changed, Fixed, Removed) in [Unreleased]."
     echo ""
-    echo "To skip: add [skip changelog] to any commit message on this branch."
+    echo "To skip: add the 'skip-changelog' label to the PR on GitHub."
     exit 1
 fi
 

--- a/scripts/test-check-changelog.sh
+++ b/scripts/test-check-changelog.sh
@@ -103,21 +103,21 @@ git add crates/room-cli/CHANGELOG.md
 git commit -q -m "add per-crate changelog entry"
 assert_exit "per-crate CHANGELOG changed exits 0" 0 bash "$CHECK_SCRIPT" origin/master
 
-# ── Test: [skip changelog] in commit message → exit 0 ────────────────
+# ── Test: SKIP_CHANGELOG env var → exit 0 ────────────────────────────
 
 setup_repo
 echo "some code" > src.rs
 git add src.rs
-git commit -q -m "docs: update readme [skip changelog]"
-assert_exit "[skip changelog] marker exits 0" 0 bash "$CHECK_SCRIPT" origin/master
+git commit -q -m "docs: update readme"
+assert_exit "SKIP_CHANGELOG=1 exits 0" 0 env SKIP_CHANGELOG=1 bash "$CHECK_SCRIPT" origin/master
 
-# ── Test: [skip changelog] case insensitive ──────────────────────────
+# ── Test: SKIP_CHANGELOG unset → normal check applies ────────────────
 
 setup_repo
 echo "some code" > src.rs
 git add src.rs
-git commit -q -m "ci: update workflow [Skip Changelog]"
-assert_exit "[Skip Changelog] case insensitive exits 0" 0 bash "$CHECK_SCRIPT" origin/master
+git commit -q -m "code without changelog"
+assert_exit "SKIP_CHANGELOG unset still checks changelog" 1 bash "$CHECK_SCRIPT" origin/master
 
 # ── Test: multiple commits, one has changelog → exit 0 ───────────────
 


### PR DESCRIPTION
## Summary
- Replace `[skip changelog]` commit message marker with `skip-changelog` PR label
- CI workflow now passes `PR_NUMBER` and `GH_TOKEN` to the script for label lookup via `gh pr view`
- Local override via `SKIP_CHANGELOG=1` env var for testing
- Created `skip-changelog` GitHub label (blue, with description)

## Context
Sprint 14 retro action item: commit-message-based skip was fragile — a PR with 5 commits where 1 has the marker bypasses the check for all. Labels are unambiguous (one per PR), visible in the PR list, and can be added/removed by reviewers.

## Files changed
- `scripts/check-changelog.sh` — replaced commit marker check with label + env var check
- `scripts/test-check-changelog.sh` — replaced marker tests with `SKIP_CHANGELOG` tests (7/7 pass)
- `.github/workflows/ci.yml` — pass `PR_NUMBER` and `GH_TOKEN` to changelog step

## Test plan
- [x] `bash scripts/test-check-changelog.sh` — 7/7 pass
- [x] `shellcheck --exclude=SC1091 scripts/check-changelog.sh` — clean
- [ ] CI: verify label-based skip works on a PR with `skip-changelog` label

Closes #540