### PR TITLE
docs: rewrite ralph-setup.md for Rust crate

### DIFF
--- a/docs/ralph-setup.md
+++ b/docs/ralph-setup.md
@@ -1,13 +1,102 @@
 # Setting up room-ralph
 
-`room-ralph` is an autonomous agent wrapper that runs `claude -p` in a loop, restarting
-on context exhaustion. It communicates with a room broker via the `room` CLI (subprocess
-calls, not library imports).
+`room-ralph` is a Rust binary crate (`crates/room-ralph/`) that runs `claude -p` in an
+autonomous loop, restarting on context exhaustion. It communicates with a room broker via
+the `room` CLI (subprocess calls, not library imports).
+
+## Installation
+
+```bash
+cargo install room-ralph          # from crates.io
+# or build from source:
+cargo build -p room-ralph --release
+```
+
+## Quick start
+
+```bash
+# Minimal: join a room and start coding
+room-ralph myroom agent-1
+
+# With a builtin personality and issue tracking
+room-ralph myroom agent-1 --personality coder --issue 42
+
+# With a tool profile (controls allowed/disallowed tools)
+room-ralph myroom agent-1 --profile reviewer
+
+# In a tmux session (detached, named ralph-<username>)
+room-ralph myroom agent-1 --personality coder --tmux
+
+# Connect to a daemon socket
+room-ralph myroom agent-1 --socket /tmp/roomd.sock
+```
+
+## CLI reference
+
+| Flag | Env var | Default | Description |
+|---|---|---|---|
+| `<room_id>` | `RALPH_ROOM` | (required) | Room to join |
+| `<username>` | `RALPH_USERNAME` | (required) | Username to register |
+| `--model` | `RALPH_MODEL` | `opus` | Claude model to use |
+| `--issue` | `RALPH_ISSUE` | — | GitHub issue number; enables progress file persistence |
+| `--personality` | — | — | Builtin name or file path (see below) |
+| `--profile` | `RALPH_PROFILE` | — | Tool profile: coder, reviewer, coordinator, notion, reader |
+| `--prompt` | — | — | Custom system prompt file (replaces built-in prompt entirely) |
+| `--allow-tools` | — | — | Comma-separated tools to auto-approve (merges with profile) |
+| `--disallow-tools` | `RALPH_DISALLOWED_TOOLS` | — | Comma-separated tools to hard-block (merges with profile) |
+| `--allow-all` | `RALPH_ALLOW_ALL` | false | Skip all tool restrictions |
+| `--add-dir` | — | — | Additional directories for claude (repeatable) |
+| `--socket` | `ROOM_SOCKET` | — | Override broker socket path |
+| `--tmux` | — | false | Run in detached tmux session |
+| `--max-iter` | — | 50 | Max iterations before stopping (0 = unlimited) |
+| `--cooldown` | — | 5 | Seconds between iterations |
+| `--list-personalities` | — | — | Print builtin personalities and exit |
+| `--dry-run` | — | — | Print the prompt that would be sent, then exit |
+
+## Personalities
+
+Personalities bundle a system prompt fragment, tool profile, and default model. Use
+`--personality <name>` to activate one. Builtins:
+
+| Name | Profile | Model | Description |
+|---|---|---|---|
+| `coder` | Coder | opus | Writes code, runs tests, opens PRs |
+| `reviewer` | Reviewer | opus | Reviews PRs, checks code quality, runs clippy |
+| `researcher` | Reader | sonnet | Reads code, searches, summarizes findings |
+| `coordinator` | Coordinator | opus | Manages tasks, coordinates agents, tracks progress |
+| `documenter` | Notion | sonnet | Writes docs, updates external systems, maintains changelogs |
+
+You can also pass a file path: `--personality /path/to/custom-prompt.md`. The file contents
+are prepended to the system prompt. Custom file paths do not set profile or model defaults.
+
+Use `--list-personalities` to see available builtins.
+
+## Tool profiles
+
+Profiles define auto-approved and hard-blocked tools for each agent role. Set via
+`--profile <name>` or implicitly via `--personality`.
+
+| Profile | Auto-approved | Hard-blocked |
+|---|---|---|
+| **coder** | Read, Edit, Write, Glob, Grep, WebSearch, Bash(room/git/cargo/gh/pre-push) | (none) |
+| **reviewer** | Read, Glob, Grep, Bash(room/gh pr) | Write, Edit |
+| **coordinator** | Read, Glob, Grep, Bash(room/gh) | Write, Edit |
+| **notion** | Read, Glob, Grep, Bash(room/gh), mcp\_\_notion\_\_\* | Write, Edit, Bash(git push/commit) |
+| **reader** | Read, Glob, Grep | Bash, Write, Edit |
+
+Explicit `--allow-tools` and `--disallow-tools` flags **merge** on top of the profile's
+base lists. `--allow-all` overrides everything — no restrictions at all.
+
+**Key distinction:**
+- `--allow-tools` (mapped to `--allowedTools`) controls **auto-approval** — tools not
+  listed still exist but require manual approval (auto-denied in `-p` mode)
+- `--disallow-tools` (mapped to `--disallowedTools`) **hard-blocks** tools — they are
+  completely removed from the session
+- Disallow always wins over allow
 
 ## Permissions
 
-Claude Code has its own permission system that controls what the agent can do at runtime.
-Configure it via `.claude/settings.json` in the project directory:
+Claude Code has its own permission system. Configure via `.claude/settings.json`:
 
 ```json
 {
@@ -21,59 +110,29 @@ Configure it via `.claude/settings.json` in the project directory:
 }
 ```
 
-- **`allow`** — tool patterns the agent can use without prompting. Supports exact names
-  (`Read`) and parameterized patterns (`Bash(cargo test)`).
-- **`deny`** — tool patterns that are always blocked, even if listed in `allow`.
-
-Ralph also supports `--disallow-tools` (or `RALPH_DISALLOWED_TOOLS` env var) for
-hard-blocking specific tools from the session. Unlike `--allow-tools` which controls
-auto-approval, `--disallow-tools` removes tools entirely — the agent cannot use them
-even if prompted. Supports granular patterns like `Bash(python3:*)`.
-
-```bash
-# Block Write and Edit — agent can read but not modify files
-room-ralph myroom reviewer --disallow-tools Write,Edit
-
-# Block specific shell commands while keeping Bash available
-room-ralph myroom agent1 --disallow-tools "Bash(rm:*),Bash(curl:*)"
-```
-
 For fully autonomous operation (e.g. CI pipelines), ralph passes
 `--dangerously-skip-permissions` to the claude subprocess. Do not use this for untrusted
-workloads — it grants the agent unrestricted access to all tools including file writes,
-shell commands, and network requests.
-
-### Choosing a permission level
+workloads.
 
 | Use case | Approach |
 |---|---|
 | Interactive development | Default (claude prompts for each tool) |
-| Supervised automation | `.claude/settings.json` with a curated allow list |
-| Fully autonomous (CI, demo) | `--dangerously-skip-permissions` flag |
+| Supervised automation | `.claude/settings.json` + `--profile` |
+| Fully autonomous (CI, demo) | `--allow-all` flag |
 
-## Personality and system prompt
+## System prompt
 
-Agents get their instructions from two sources, both of which you control:
+Agents get instructions from two sources:
 
-1. **CLAUDE.md** — Claude automatically loads this file from the working directory at the
-   start of every session. Put project-wide conventions, coding standards, and behavioral
-   rules here. This is the primary mechanism for shaping agent personality and role.
-
-2. **`--prompt` flag** — Pass a custom prompt file to ralph to override the built-in
-   default system prompt. Use this for agent-specific roles (e.g. a QA agent vs. a
-   feature-building agent).
-
-```bash
-room-ralph --room myroom --username qa-bot --prompt /path/to/qa-prompt.md
-```
-
-The `--prompt` file replaces ralph's default instructions entirely. If you want to layer
-custom instructions on top of the defaults, put them in CLAUDE.md instead.
+1. **CLAUDE.md** — loaded automatically from the working directory. Put project-wide
+   conventions, coding standards, and behavioral rules here.
+2. **`--prompt` flag** — replaces ralph's built-in system prompt entirely. Use for
+   custom agent roles. If you want to layer instructions on top of the defaults, use
+   CLAUDE.md or `--personality` instead.
 
 ## Memory convention (3 layers)
 
-Ralph agents use a three-layer memory system. Each layer has a different lifespan and
-purpose:
+Ralph agents use a three-layer memory system:
 
 | Layer | Location | Lifespan | Purpose |
 |---|---|---|---|
@@ -85,59 +144,40 @@ purpose:
 
 Claude manages these automatically via its auto-memory system. The main index
 (`MEMORY.md`) is loaded into every conversation context. Topic-specific files
-(e.g. `debugging.md`, `patterns.md`) hold detailed notes and are linked from the index.
-
-You do not need to create these manually — Claude writes and updates them as it works.
-To seed initial knowledge (e.g. project conventions), put it in CLAUDE.md instead.
+hold detailed notes and are linked from the index.
 
 ### Progress files
 
 Ralph reads progress files on startup so a fresh claude instance can resume where the
-previous one left off after context exhaustion. Progress files follow the template at
-`scripts/progress-template.md` and track: current status, completed steps, files
-modified, and decisions made.
+previous one left off after context exhaustion. Enable with `--issue <number>`.
 
-Delete stale progress files after the corresponding PR merges.
+Progress files follow the template at `scripts/progress-template.md` and track: current
+status, completed steps, files modified, and decisions made. Delete after the PR merges.
 
 ### Room messages
 
 Agents send and receive coordination messages via `room send` / `room poll`. These are
-ephemeral (tied to the broker session lifetime) and serve as the real-time coordination
-layer between agents and humans.
+ephemeral (tied to the broker session) and serve as the real-time coordination layer.
 
 ## Status convention
 
-Agents must keep their `/set_status` current at all times. The host uses the member
-status panel (TUI) or `room who` to see what every agent is doing. Stale or missing
-statuses make coordination harder.
+Agents must keep `/set_status` current. The host uses the member status panel (TUI) or
+`room who` to see what every agent is doing.
 
-### Required status updates
-
-Status text must include **what you are doing and the specific context** (file, feature,
-PR, issue number). A phase word alone (`working`, `reading`, `testing`) is not useful —
-the host needs to know what is happening at a glance.
+Status text must include **what and where** — a phase word alone is not useful:
 
 | Phase | Good status | Bad status |
 |---|---|---|
-| Starting work | `reading src/broker.rs for #42` | `reading` |
-| Drafting code | `drafting kick parser in tui/input.rs` | `working` |
-| Running tests | `running cargo test — 461 expected` | `testing` |
-| Fixing CI | `fixing clippy in oneshot/who.rs` | `fixing` |
+| Starting | `reading src/broker.rs for #42` | `reading` |
+| Drafting | `drafting kick parser in tui/input.rs` | `working` |
+| Testing | `running cargo test — 461 expected` | `testing` |
+| Fixing | `fixing clippy in oneshot/who.rs` | `fixing` |
 | PR open | `PR #236 open — kicked users fix` | `PR open` |
 | Blocked | `blocked on #38 — need schema decision` | `blocked` |
 | Done | `done — PR #236 merged` | `done` |
-| Idle | *(clear status with `/set_status`)* | |
-
-### How to set status
+| Idle | *(clear with `/set_status`)* | |
 
 ```bash
-# From room send (one-shot)
 room send <room-id> -t <token> /set_status drafting auth handler
-
-# Clear status
-room send <room-id> -t <token> /set_status
+room send <room-id> -t <token> /set_status   # clear
 ```
-
-Ralph agents should set status automatically at each milestone via `room send`. The
-CLAUDE.md coordination protocol enforces this convention — agents that do not update
-their status will be flagged during review.


### PR DESCRIPTION
## Summary

Complete rewrite of ralph-setup.md for the Rust `room-ralph` crate (shell script is legacy since sprint 4):

- Add installation section (`cargo install room-ralph`)
- Add quick start examples with `--personality`, `--profile`, `--tmux`, `--socket`
- Add full CLI reference table with all 16 flags and their env var equivalents
- Add builtin personalities table (coder, reviewer, researcher, coordinator, documenter) with their default profiles and models
- Add tool profiles table showing allowed/disallowed tools per role
- Document the key distinction: `--allow-tools` = auto-approval vs `--disallow-tools` = hard-block
- Retain and update permissions, system prompt, memory convention, and status sections

## Test plan

- [ ] Verify CLI flags match `Cli` struct in `crates/room-ralph/src/lib.rs`
- [ ] Verify personality names/descriptions match `BUILTINS` in `personalities.rs`
- [ ] Verify profile allowed/disallowed tools match `claude.rs` `Profile` impl
- [ ] Verify env var names match clap `env` attributes

Closes #594