### PR TITLE
Add 1-agent-per-bug coordination rules to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,13 +328,13 @@ room send myroom -t $TOKEN "opening PR for #42"
   taskboard entry. If you spot something that needs fixing, file an issue — do not silently
   fix it in an unrelated PR.
 - **File bugs, don't self-assign.** When you discover a bug, open a GitHub issue and report
-  it to BA in the room. Do not start fixing it unless it is a direct consequence of your
+  it to ba in the room. Do not start fixing it unless it is a direct consequence of your
   current in-progress task.
-- **One agent per bug.** When multiple agents report the same bug, BA assigns exactly one
+- **One agent per bug.** When multiple agents report the same bug, ba assigns exactly one
   agent to fix it. All other agents stand down and move on to their next task.
-- **Wait for assignment before coding.** Even if a bug is urgent, wait for BA to assign it
-  via the taskboard. Starting work without assignment leads to duplicate effort and merge
-  conflicts.
+- **Wait for assignment before coding.** Unless the bug was introduced by your current
+  in-progress task (see above), wait for ba to assign it via the taskboard. Starting work
+  without assignment leads to duplicate effort and merge conflicts.
 
 ### Wave-based merge strategy
 


### PR DESCRIPTION
Closes #539

Adds four coordination rules to CLAUDE.md under the coordination section:

1. **All work needs a ticket** — no implementation without a GH issue + taskboard entry
2. **File bugs, don't self-assign** — open an issue, report to BA, don't start fixing unless it's from your current task
3. **One agent per bug** — BA assigns exactly one agent for duplicate bugs, others stand down
4. **Wait for assignment before coding** — even urgent bugs wait for taskboard assignment

Files: CLAUDE.md only, 11 insertions.