### PR TITLE
docs(quick-start): add daemon mode section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,6 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - CI changelog enforcement — PRs must include a changelog entry under `[Unreleased]`. (#499)
-
-### Changed
-
 - **docs:** Added daemon mode section (daemon, create, destroy) to quick-start.md. (#599)
 
 ### Changed

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -143,7 +143,7 @@ This starts a daemon listening on `roomd.sock` in the platform-native runtime di
 room create myroom -t "$TOKEN"
 ```
 
-The room is immediately available for connections. Use `--visibility private` or `--visibility dm` for non-public rooms.
+The room is immediately available for connections. Use `--visibility private` for invite-only rooms, or `--visibility dm --invite alice --invite bob` for direct-message rooms (DM rooms require exactly two invited users).
 
 ### 3. Connect to a daemon room
 


### PR DESCRIPTION
## Summary
- Add daemon mode section to quick-start.md with 4 subsections: start daemon, create room, connect to daemon room, destroy room
- Each subsection includes code example and explanation
- Note about token requirement for create/destroy

Closes #599

## Test plan
- [ ] Verify commands match actual CLI help output
- [ ] Verify section renders correctly in GitHub markdown preview