### PR TITLE
fix(docs): correct audit findings across 6 files (#625)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,7 @@ Every message is a JSON object with a `type` field:
 {"type":"join","id":"...","room":"...","user":"alice","ts":"..."}
 {"type":"message","id":"...","room":"...","user":"bob","ts":"...","content":"hello"}
 {"type":"leave","id":"...","room":"...","user":"alice","ts":"..."}
-{"type":"command","id":"...","room":"...","user":"bob","ts":"...","cmd":"claim","params":["task"]}
+{"type":"command","id":"...","room":"...","user":"bob","ts":"...","cmd":"taskboard","params":["claim","tb-001"]}
 {"type":"reply","id":"...","room":"...","user":"bob","ts":"...","reply_to":"<msg-id>","content":"ack"}
 ```
 
@@ -385,11 +385,13 @@ Open → Claimed → Planned → Approved → Finished
 | `/taskboard list` | Anyone | Show all tasks (ID, status, assignee, elapsed, description) |
 | `/taskboard show <task-id>` | Anyone | Show full task detail |
 | `/taskboard claim <task-id>` | Anyone (Open tasks) | Claim a task — starts lease timer |
+| `/taskboard assign <task-id> <username>` | Poster or host | Assign an open task to a specific user |
 | `/taskboard plan <task-id> <plan>` | Assignee only | Submit implementation plan — **required before coding** |
 | `/taskboard approve <task-id>` | Poster or host | Approve a plan — agent may proceed |
 | `/taskboard update <task-id> [notes]` | Assignee only | Renew lease and update notes |
 | `/taskboard release <task-id>` | Assignee or host | Release task back to Open |
 | `/taskboard finish <task-id>` | Assignee only | Mark task as Finished |
+| `/taskboard cancel <task-id> [reason]` | Poster, assignee, or host | Cancel a task with optional reason |
 
 **Mandatory workflow for every task:**
 1. Claim: `/taskboard claim <task-id>`
@@ -761,11 +763,11 @@ All tests must remain green. Add tests for any new behaviour.
 
 ## Baseline test count
 
-**Current baseline: 1371 Rust tests + 107 shell tests**
+**Current baseline: 1373 Rust tests + 107 shell tests**
 
 Rust breakdown:
 - room-protocol: 116 unit tests
-- room-cli: 888 unit + 193 integration (33 auth + 37 broker + 25 daemon + 10 events + 20 oneshot + 11 rest_query + 29 room_lifecycle + 8 scripted + 20 ws + 7 ws_smoke ignored) = 1081 tests
+- room-cli: 888 unit + 195 integration (33 auth + 37 broker + 25 daemon + 10 events + 22 oneshot + 11 rest_query + 29 room_lifecycle + 8 scripted + 20 ws + 7 ws_smoke ignored) = 1083 tests
 - room-ralph: 164 unit + 10 integration = 174 tests
 
 Note: integration tests are split into focused modules under `tests/` (auth, broker, daemon,

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ Write one JSON object per line. Plain text lines are also accepted and treated a
 {"type":"reply","reply_to":"<message-id>","content":"ack"}
 
 // Structured command
-{"type":"command","cmd":"claim","params":["describe what you are claiming"]}
+{"type":"command","cmd":"who","params":[]}
 
 // Plain text (also works)
 hey everyone

--- a/docs/broker-internals.md
+++ b/docs/broker-internals.md
@@ -93,7 +93,7 @@ For each interactive connection, the broker spawns two concurrent tasks:
 Reads lines from the client's socket. For each line:
 
 - Parses it via `parse_client_line` into a `Message` enum variant
-- Routes commands via `route_command`: `set_status`, `who`, `claim`, `unclaim`, `claimed`, and `room-info` are handled as built-in commands; admin commands go to `handle_admin_cmd`; plugin commands are dispatched via `PluginRegistry`; all others pass through to broadcast
+- Routes commands via `route_command`: `set_status`, `who`, `subscribe`, `unsubscribe`, `subscribe_events`, `subscriptions`, `info`/`room-info`, and `help` are handled as built-in commands; admin commands go to `handle_admin_cmd`; plugin commands are dispatched via `PluginRegistry`; all others pass through to broadcast
 - DMs (`Message::DirectMessage`) are delivered only to sender, recipient, and host via `dm_and_persist`
 - Everything else goes to `broadcast_and_persist`
 
@@ -172,13 +172,17 @@ All writes go through `history::append`, which opens the file in append mode. To
 | `status_map` | `Arc<Mutex<HashMap<String, String>>>` | Maps username to status string (ephemeral) |
 | `host_user` | `Arc<Mutex<Option<String>>>` | Username of the first connected client |
 | `token_map` | `Arc<Mutex<HashMap<String, String>>>` | Maps token UUID to username (persisted to `.tokens` file) |
-| `claim_map` | `Arc<Mutex<HashMap<String, ClaimEntry>>>` | Maps username to claim entry (task + timestamp, 30min TTL, lazily swept) |
+| `subscription_map` | `SubscriptionMap` (`Arc<Mutex<HashMap<String, SubscriptionTier>>>`) | Per-user subscription tier (Full, MentionsOnly, Unsubscribed) |
 | `chat_path` | `Arc<PathBuf>` | Path to the NDJSON chat file |
+| `token_map_path` | `Arc<PathBuf>` | Path to persisted token-map file (`.tokens`) |
+| `subscription_map_path` | `Arc<PathBuf>` | Path to persisted subscription-map file (`.subscriptions`) |
 | `room_id` | `Arc<String>` | Room identifier |
 | `shutdown` | `Arc<watch::Sender<bool>>` | Shutdown signal |
 | `seq_counter` | `Arc<AtomicU64>` | Monotonic sequence counter |
 | `plugin_registry` | `Arc<PluginRegistry>` | Compiled-in plugin dispatch (`/help`, `/stats`, `/queue`, `/taskboard`) |
 | `config` | `Option<RoomConfig>` | Room visibility and access control (daemon mode) |
+| `registry` | `OnceLock<Arc<Mutex<UserRegistry>>>` | Daemon-level user registry for cross-room identity (unset in single-room mode) |
+| `event_filter_state` | `OnceLock<(EventFilterMap, Arc<PathBuf>)>` | Per-user event type filter with persistence path (unset = all events pass) |
 
 ## Admin commands
 

--- a/docs/ralph-setup.md
+++ b/docs/ralph-setup.md
@@ -110,9 +110,9 @@ Claude Code has its own permission system. Configure via `.claude/settings.json`
 }
 ```
 
-For fully autonomous operation (e.g. CI pipelines), ralph passes
-`--dangerously-skip-permissions` to the claude subprocess. Do not use this for untrusted
-workloads.
+For fully autonomous operation (e.g. CI pipelines), use the `--allow-all` flag
+(or `RALPH_ALLOW_ALL=true`), which passes auto-approval for all tools to the claude
+subprocess. Do not use this for untrusted workloads.
 
 | Use case | Approach |
 |---|---|

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -59,7 +59,7 @@ crates/room-cli/src/
   tui/render.rs         — unit tests for wrap_words, format_message
   tui/widgets.rs        — unit tests for CommandPalette, MentionPicker
   oneshot/token.rs      — unit tests for token file I/O, cursor read/write
-  oneshot/poll.rs       — unit tests for DM filter, cursor advancement, multiplexed poll
+  oneshot/poll/         — unit tests for DM filter, cursor advancement, tier/event filtering, multiplexed poll
 crates/room-cli/tests/
   common/mod.rs         — shared test helpers (free_port, wait_for_socket, wait_for_tcp)
   auth.rs               — token issuance, validation, join permissions
@@ -193,12 +193,12 @@ async fn my_feature_works() {
 
 ## Test baseline
 
-**Current: 1371 Rust tests + 107 shell tests** (as of v3.1.0)
+**Current: 1373 Rust tests + 107 shell tests** (as of v3.1.0)
 
 | Crate | Unit | Integration | Total |
 |-------|------|-------------|-------|
 | room-protocol | 116 | — | 116 |
-| room-cli | 888 | 193 | 1081 |
+| room-cli | 888 | 195 | 1083 |
 | room-ralph | 164 | 10 | 174 |
 
 Shell tests: 48 (test-context-monitor.sh) + 59 (test-ralph-room.sh) = 107.

--- a/docs/wire-format.md
+++ b/docs/wire-format.md
@@ -191,7 +191,8 @@ The `EventType` enum is `#[non_exhaustive]` — new types may be added in future
 | Field | Sender provides | Broker assigns |
 |---|---|---|
 | `type` | ✓ | — |
-| `content` / `cmd` / `params` / `to` / `reply_to` / `event_type` | ✓ | — |
+| `content` / `cmd` / `params` / `to` / `reply_to` | ✓ | — |
+| `event_type` | — | ✓ (set by emitting plugin) |
 | `id` | — | ✓ (UUID v4) |
 | `room` | — | ✓ |
 | `user` | — | ✓ (from connection identity) |


### PR DESCRIPTION
## Summary

- **wire-format.md**: move `event_type` from sender-provides to broker-assigns (plugins set it server-side)
- **broker-internals.md**: remove stale `claim`/`unclaim`/`claimed` refs from `route_command` description, replace `claim_map` with `subscription_map`, add 4 missing `RoomState` fields (`token_map_path`, `subscription_map_path`, `registry`, `event_filter_state`)
- **CLAUDE.md**: update test baseline 1371→1373, add `assign`/`cancel` to taskboard command table, replace stale `/claim` wire format example
- **README.md**: replace stale `/claim` stdin example with `/who`
- **ralph-setup.md**: replace incorrect `--dangerously-skip-permissions` claim with accurate `--allow-all` documentation
- **testing.md**: update test baseline 1371→1373, fix integration count 193→195, update `oneshot/poll.rs` → `poll/` directory reference

## Test plan

- [x] `cargo check` passes
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — all 1373 tests pass
- [ ] Review each file diff for accuracy against actual codebase state

Closes #625