### PR TITLE
refactor(broker): consolidate OnceLock fields into AuthState/FilterState sub-structs (#545)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and split `route_command()` into dedicated handler functions. (#557)
 - **refactor:** Consolidated duplicate markdown parsers in `tui/render.rs` into a single
   parameterized `render_inline_markdown` function, eliminating `render_bold_inner`. (#560)
+- **refactor:** Consolidated `OnceLock` fields in `RoomState` into `AuthState` and `FilterState`
+  sub-structs, reducing struct field count from 15 to 11. (#545)
 
 - Restructured into a cargo workspace with four crates: `room-protocol` (wire types),
   `room-cli` (broker + TUI + oneshot), `room-ralph` (agent wrapper), `agentroom`

--- a/crates/room-cli/src/broker/admin.rs
+++ b/crates/room-cli/src/broker/admin.rs
@@ -38,7 +38,7 @@ pub(crate) async fn handle_admin_cmd(
 
     let room_id = state.room_id.as_str();
     let clients = &state.clients;
-    let token_map = &state.token_map;
+    let token_map = &state.auth.token_map;
     let chat_path = &state.chat_path;
     let shutdown = &state.shutdown;
     let seq_counter = &state.seq_counter;
@@ -58,13 +58,13 @@ pub(crate) async fn handle_admin_cmd(
             // kicking multiple users does not overwrite each other's sentinel entries.
             map.retain(|_, u| u != &target);
             map.insert(format!("KICKED:{target}"), target.clone());
-            if let Err(e) = save_token_map(&map, &state.token_map_path) {
+            if let Err(e) = save_token_map(&map, &state.auth.token_map_path) {
                 eprintln!("[admin] kick token persist failed: {e}");
             }
             drop(map);
             // In daemon mode, also revoke from the UserRegistry so the kicked user
             // cannot rejoin via issue_token_via_registry (which checks has_token_for_user).
-            if let Some(reg) = state.registry.get() {
+            if let Some(reg) = state.auth.registry.get() {
                 if let Err(e) = reg.lock().await.revoke_user_tokens(&target) {
                     eprintln!("[admin] registry revoke failed for {target}: {e}");
                 }
@@ -82,13 +82,13 @@ pub(crate) async fn handle_admin_cmd(
             let target = arg.strip_prefix('@').unwrap_or(arg).to_owned();
             let mut map = token_map.lock().await;
             map.retain(|_, u| u != &target);
-            if let Err(e) = save_token_map(&map, &state.token_map_path) {
+            if let Err(e) = save_token_map(&map, &state.auth.token_map_path) {
                 eprintln!("[admin] reauth token persist failed: {e}");
             }
             drop(map);
             // In daemon mode, also revoke from the UserRegistry so the reauthed user
             // can obtain a fresh token via issue_token_via_registry.
-            if let Some(reg) = state.registry.get() {
+            if let Some(reg) = state.auth.registry.get() {
                 if let Err(e) = reg.lock().await.revoke_user_tokens(&target) {
                     eprintln!("[admin] registry revoke failed for {target}: {e}");
                 }
@@ -113,7 +113,7 @@ pub(crate) async fn handle_admin_cmd(
         "clear-tokens" => {
             let mut map = token_map.lock().await;
             map.clear();
-            if let Err(e) = save_token_map(&map, &state.token_map_path) {
+            if let Err(e) = save_token_map(&map, &state.auth.token_map_path) {
                 eprintln!("[admin] clear-tokens persist failed: {e}");
             }
             drop(map);
@@ -189,13 +189,13 @@ mod tests {
         let state = make_state(tmp.path().to_path_buf());
         *state.host_user.lock().await = Some("alice".to_owned());
         {
-            let mut guard = state.token_map.lock().await;
+            let mut guard = state.auth.token_map.lock().await;
             guard.insert("uuid-bob".to_owned(), "bob".to_owned());
             guard.insert("KICKED:bob".to_owned(), "bob".to_owned());
         }
         let err = handle_admin_cmd("reauth bob", "alice", &state).await;
         assert!(err.is_none(), "reauth should succeed");
-        let guard = state.token_map.lock().await;
+        let guard = state.auth.token_map.lock().await;
         assert!(
             !guard.values().any(|u| u == "bob"),
             "all bob entries must be removed after reauth"
@@ -208,14 +208,14 @@ mod tests {
         let state = make_state(tmp.path().to_path_buf());
         *state.host_user.lock().await = Some("alice".to_owned());
         {
-            let mut guard = state.token_map.lock().await;
+            let mut guard = state.auth.token_map.lock().await;
             guard.insert("t1".to_owned(), "alice".to_owned());
             guard.insert("t2".to_owned(), "bob".to_owned());
         }
         let err = handle_admin_cmd("clear-tokens", "alice", &state).await;
         assert!(err.is_none(), "clear-tokens should succeed");
         assert!(
-            state.token_map.lock().await.is_empty(),
+            state.auth.token_map.lock().await.is_empty(),
             "token map must be empty after clear-tokens"
         );
     }
@@ -256,13 +256,14 @@ mod tests {
         let state = make_state(tmp.path().to_path_buf());
         *state.host_user.lock().await = Some("alice".to_owned());
         state
+            .auth
             .token_map
             .lock()
             .await
             .insert("tok-bob".to_owned(), "bob".to_owned());
         let err = handle_admin_cmd("kick bob", "alice", &state).await;
         assert!(err.is_none(), "kick should succeed");
-        let map = state.token_map.lock().await;
+        let map = state.auth.token_map.lock().await;
         assert!(
             !map.contains_key("tok-bob"),
             "bob's token should be removed"
@@ -327,6 +328,7 @@ mod tests {
         let state = make_state_with_registry(tmp.path().to_path_buf(), registry.clone());
         *state.host_user.lock().await = Some("alice".to_owned());
         state
+            .auth
             .token_map
             .lock()
             .await
@@ -357,6 +359,7 @@ mod tests {
         let state = make_state(chat_path);
         *state.host_user.lock().await = Some("alice".to_owned());
         state
+            .auth
             .token_map
             .lock()
             .await
@@ -365,7 +368,7 @@ mod tests {
         handle_admin_cmd("kick bob", "alice", &state).await;
 
         // Load from disk — KICKED sentinel must be persisted
-        let loaded = crate::broker::auth::load_token_map(&state.token_map_path);
+        let loaded = crate::broker::auth::load_token_map(&state.auth.token_map_path);
         assert!(
             loaded.contains_key("KICKED:bob"),
             "KICKED sentinel must be persisted to disk"
@@ -384,14 +387,14 @@ mod tests {
         let state = make_state(chat_path);
         *state.host_user.lock().await = Some("alice".to_owned());
         {
-            let mut map = state.token_map.lock().await;
+            let mut map = state.auth.token_map.lock().await;
             map.insert("tok-bob".to_owned(), "bob".to_owned());
             map.insert("KICKED:bob".to_owned(), "bob".to_owned());
         }
 
         handle_admin_cmd("reauth bob", "alice", &state).await;
 
-        let loaded = crate::broker::auth::load_token_map(&state.token_map_path);
+        let loaded = crate::broker::auth::load_token_map(&state.auth.token_map_path);
         assert!(
             !loaded.values().any(|u| u == "bob"),
             "bob must be fully removed from disk after reauth"
@@ -406,14 +409,14 @@ mod tests {
         let state = make_state(chat_path);
         *state.host_user.lock().await = Some("alice".to_owned());
         {
-            let mut map = state.token_map.lock().await;
+            let mut map = state.auth.token_map.lock().await;
             map.insert("t1".to_owned(), "alice".to_owned());
             map.insert("t2".to_owned(), "bob".to_owned());
         }
 
         handle_admin_cmd("clear-tokens", "alice", &state).await;
 
-        let loaded = crate::broker::auth::load_token_map(&state.token_map_path);
+        let loaded = crate::broker::auth::load_token_map(&state.auth.token_map_path);
         assert!(
             loaded.is_empty(),
             "token map on disk must be empty after clear-tokens"
@@ -428,6 +431,7 @@ mod tests {
         let state = make_state(chat_path.clone());
         *state.host_user.lock().await = Some("alice".to_owned());
         state
+            .auth
             .token_map
             .lock()
             .await
@@ -436,7 +440,7 @@ mod tests {
         handle_admin_cmd("kick bob", "alice", &state).await;
 
         // Simulate broker restart: load token map from disk into fresh state
-        let loaded = crate::broker::auth::load_token_map(&state.token_map_path);
+        let loaded = crate::broker::auth::load_token_map(&state.auth.token_map_path);
         let new_map: super::super::state::TokenMap = Arc::new(Mutex::new(loaded));
 
         // The original token must be invalid
@@ -463,6 +467,7 @@ mod tests {
         let state = make_state(tmp.path().to_path_buf());
         *state.host_user.lock().await = Some("alice".to_owned());
         state
+            .auth
             .token_map
             .lock()
             .await
@@ -470,7 +475,7 @@ mod tests {
         // User types `/kick @bob` — the @ must be stripped.
         let err = handle_admin_cmd("kick @bob", "alice", &state).await;
         assert!(err.is_none(), "kick @bob should succeed");
-        let map = state.token_map.lock().await;
+        let map = state.auth.token_map.lock().await;
         assert!(
             !map.contains_key("tok-bob"),
             "bob's token should be removed even with @ prefix"
@@ -487,14 +492,14 @@ mod tests {
         let state = make_state(tmp.path().to_path_buf());
         *state.host_user.lock().await = Some("alice".to_owned());
         {
-            let mut guard = state.token_map.lock().await;
+            let mut guard = state.auth.token_map.lock().await;
             guard.insert("uuid-bob".to_owned(), "bob".to_owned());
             guard.insert("KICKED:bob".to_owned(), "bob".to_owned());
         }
         // User types `/reauth @bob` — the @ must be stripped.
         let err = handle_admin_cmd("reauth @bob", "alice", &state).await;
         assert!(err.is_none(), "reauth @bob should succeed");
-        let guard = state.token_map.lock().await;
+        let guard = state.auth.token_map.lock().await;
         assert!(
             !guard.values().any(|u| u == "bob"),
             "all bob entries must be removed even with @ prefix"
@@ -507,6 +512,7 @@ mod tests {
         let state = make_state(tmp.path().to_path_buf());
         *state.host_user.lock().await = Some("alice".to_owned());
         state
+            .auth
             .token_map
             .lock()
             .await
@@ -514,7 +520,13 @@ mod tests {
         let err = handle_admin_cmd("kick carol", "alice", &state).await;
         assert!(err.is_none(), "kick carol should succeed");
         assert!(
-            state.token_map.lock().await.get("KICKED:carol").is_some(),
+            state
+                .auth
+                .token_map
+                .lock()
+                .await
+                .get("KICKED:carol")
+                .is_some(),
             "kick without @ must still work"
         );
     }
@@ -537,6 +549,7 @@ mod tests {
         let state = make_state_with_registry(tmp.path().to_path_buf(), registry.clone());
         *state.host_user.lock().await = Some("alice".to_owned());
         state
+            .auth
             .token_map
             .lock()
             .await

--- a/crates/room-cli/src/broker/commands.rs
+++ b/crates/room-cli/src/broker/commands.rs
@@ -473,7 +473,13 @@ async fn handle_user_info(target: &str, state: &RoomState) -> String {
     let status_text = status_map.get(target).cloned().unwrap_or_default();
     drop(status_map);
 
-    let sub_tier = state.subscription_map.lock().await.get(target).copied();
+    let sub_tier = state
+        .filters
+        .subscription_map
+        .lock()
+        .await
+        .get(target)
+        .copied();
 
     let is_host = state.host_user.lock().await.as_deref() == Some(target);
 
@@ -781,6 +787,7 @@ mod tests {
         let state = make_state(tmp.path().to_path_buf());
         *state.host_user.lock().await = Some("alice".to_owned());
         state
+            .auth
             .token_map
             .lock()
             .await
@@ -788,7 +795,7 @@ mod tests {
         let msg = make_command("test-room", "alice", "kick", vec!["bob".to_owned()]);
         let result = route_command(msg, "alice", &state).await.unwrap();
         assert!(matches!(result, CommandResult::Handled));
-        let guard = state.token_map.lock().await;
+        let guard = state.auth.token_map.lock().await;
         assert!(
             !guard.contains_key("some-uuid"),
             "original token must be revoked"
@@ -1269,7 +1276,13 @@ mod tests {
         assert!(json.contains("subscribed"));
         assert!(json.contains("full"));
         assert_eq!(
-            *state.subscription_map.lock().await.get("alice").unwrap(),
+            *state
+                .filters
+                .subscription_map
+                .lock()
+                .await
+                .get("alice")
+                .unwrap(),
             SubscriptionTier::Full
         );
     }
@@ -1290,7 +1303,13 @@ mod tests {
         };
         assert!(json.contains("subscribed"));
         assert_eq!(
-            *state.subscription_map.lock().await.get("bob").unwrap(),
+            *state
+                .filters
+                .subscription_map
+                .lock()
+                .await
+                .get("bob")
+                .unwrap(),
             SubscriptionTier::MentionsOnly
         );
     }
@@ -1307,7 +1326,13 @@ mod tests {
         assert!(json.contains("subscribed"));
         assert!(json.contains("full"));
         assert_eq!(
-            *state.subscription_map.lock().await.get("alice").unwrap(),
+            *state
+                .filters
+                .subscription_map
+                .lock()
+                .await
+                .get("alice")
+                .unwrap(),
             SubscriptionTier::Full
         );
     }
@@ -1328,7 +1353,13 @@ mod tests {
         };
         assert!(json.contains("mentions_only"));
         assert_eq!(
-            *state.subscription_map.lock().await.get("bob").unwrap(),
+            *state
+                .filters
+                .subscription_map
+                .lock()
+                .await
+                .get("bob")
+                .unwrap(),
             SubscriptionTier::MentionsOnly
         );
     }
@@ -1347,7 +1378,13 @@ mod tests {
         );
         route_command(msg2, "alice", &state).await.unwrap();
         assert_eq!(
-            *state.subscription_map.lock().await.get("alice").unwrap(),
+            *state
+                .filters
+                .subscription_map
+                .lock()
+                .await
+                .get("alice")
+                .unwrap(),
             SubscriptionTier::MentionsOnly,
             "second subscribe should overwrite the first"
         );
@@ -1368,7 +1405,13 @@ mod tests {
         };
         assert!(json.contains("unsubscribed"));
         assert_eq!(
-            *state.subscription_map.lock().await.get("alice").unwrap(),
+            *state
+                .filters
+                .subscription_map
+                .lock()
+                .await
+                .get("alice")
+                .unwrap(),
             SubscriptionTier::Unsubscribed
         );
     }
@@ -1382,7 +1425,13 @@ mod tests {
         // Should still work — sets to Unsubscribed even without prior entry
         assert!(matches!(result, CommandResult::HandledWithReply(_)));
         assert_eq!(
-            *state.subscription_map.lock().await.get("alice").unwrap(),
+            *state
+                .filters
+                .subscription_map
+                .lock()
+                .await
+                .get("alice")
+                .unwrap(),
             SubscriptionTier::Unsubscribed
         );
     }
@@ -1403,7 +1452,7 @@ mod tests {
         let tmp = NamedTempFile::new().unwrap();
         let state = make_state(tmp.path().to_path_buf());
         {
-            let mut map = state.subscription_map.lock().await;
+            let mut map = state.filters.subscription_map.lock().await;
             map.insert("zara".to_owned(), SubscriptionTier::Full);
             map.insert("alice".to_owned(), SubscriptionTier::MentionsOnly);
         }
@@ -1433,7 +1482,13 @@ mod tests {
         };
         assert!(json.contains("must be one of"));
         // Should not have stored anything
-        assert!(state.subscription_map.lock().await.get("alice").is_none());
+        assert!(state
+            .filters
+            .subscription_map
+            .lock()
+            .await
+            .get("alice")
+            .is_none());
     }
 
     #[tokio::test]
@@ -1473,7 +1528,13 @@ mod tests {
             "DM participant should be allowed to subscribe"
         );
         assert_eq!(
-            state.subscription_map.lock().await.get("alice").copied(),
+            state
+                .filters
+                .subscription_map
+                .lock()
+                .await
+                .get("alice")
+                .copied(),
             Some(SubscriptionTier::Full),
         );
     }
@@ -1493,7 +1554,13 @@ mod tests {
             "should contain permission denied, got: {json}"
         );
         assert!(
-            state.subscription_map.lock().await.get("eve").is_none(),
+            state
+                .filters
+                .subscription_map
+                .lock()
+                .await
+                .get("eve")
+                .is_none(),
             "non-participant must not get a subscription entry"
         );
     }
@@ -1516,6 +1583,7 @@ mod tests {
         };
         assert!(json.contains("permission denied"));
         assert!(state
+            .filters
             .subscription_map
             .lock()
             .await
@@ -1596,7 +1664,7 @@ mod tests {
         let msg = make_command("test-room", "alice", "subscribe", vec![]);
         route_command(msg, "alice", &state).await.unwrap();
 
-        let loaded = load_subscription_map(&state.subscription_map_path);
+        let loaded = load_subscription_map(&state.filters.subscription_map_path);
         assert_eq!(loaded.get("alice"), Some(&SubscriptionTier::Full));
     }
 
@@ -1611,7 +1679,7 @@ mod tests {
         let msg = make_command("test-room", "alice", "unsubscribe", vec![]);
         route_command(msg, "alice", &state).await.unwrap();
 
-        let loaded = load_subscription_map(&state.subscription_map_path);
+        let loaded = load_subscription_map(&state.filters.subscription_map_path);
         assert_eq!(loaded.get("alice"), Some(&SubscriptionTier::Unsubscribed));
     }
 
@@ -1630,7 +1698,7 @@ mod tests {
         );
         route_command(msg, "bob", &state).await.unwrap();
 
-        let loaded = load_subscription_map(&state.subscription_map_path);
+        let loaded = load_subscription_map(&state.filters.subscription_map_path);
         assert_eq!(loaded.len(), 2);
         assert_eq!(loaded.get("alice"), Some(&SubscriptionTier::Full));
         assert_eq!(loaded.get("bob"), Some(&SubscriptionTier::MentionsOnly));
@@ -1645,22 +1713,28 @@ mod tests {
         route_command(msg, "alice", &state).await.unwrap();
 
         // Simulate restart: new state, load from disk.
-        let loaded = load_subscription_map(&state.subscription_map_path);
+        let loaded = load_subscription_map(&state.filters.subscription_map_path);
         assert_eq!(loaded.get("alice"), Some(&SubscriptionTier::Full));
 
         // Verify it can be populated into a new RoomState.
         let state2 = RoomState::new(
             state.room_id.as_ref().clone(),
             state.chat_path.as_ref().clone(),
-            state.token_map_path.as_ref().clone(),
-            state.subscription_map_path.as_ref().clone(),
+            state.auth.token_map_path.as_ref().clone(),
+            state.filters.subscription_map_path.as_ref().clone(),
             Arc::new(Mutex::new(HashMap::new())),
             Arc::new(Mutex::new(loaded)),
             None,
         )
         .unwrap();
         assert_eq!(
-            *state2.subscription_map.lock().await.get("alice").unwrap(),
+            *state2
+                .filters
+                .subscription_map
+                .lock()
+                .await
+                .get("alice")
+                .unwrap(),
             SubscriptionTier::Full
         );
     }
@@ -1680,7 +1754,7 @@ mod tests {
         );
         route_command(msg, "alice", &state).await.unwrap();
 
-        let loaded = load_subscription_map(&state.subscription_map_path);
+        let loaded = load_subscription_map(&state.filters.subscription_map_path);
         assert_eq!(loaded.get("alice"), Some(&SubscriptionTier::MentionsOnly));
     }
 

--- a/crates/room-cli/src/broker/daemon/dispatcher.rs
+++ b/crates/room-cli/src/broker/daemon/dispatcher.rs
@@ -109,14 +109,14 @@ pub(super) async fn dispatch_connection(
         }
         ClientHandshake::Token(token) => {
             // Try room-level token map first, then fall back to global UserRegistry.
-            let resolved = match crate::broker::auth::validate_token(&token, &state.token_map).await
-            {
-                Some(u) => Some(u),
-                None => {
-                    let reg = user_registry.lock().await;
-                    reg.validate_token(&token).map(|u| u.to_owned())
-                }
-            };
+            let resolved =
+                match crate::broker::auth::validate_token(&token, &state.auth.token_map).await {
+                    Some(u) => Some(u),
+                    None => {
+                        let reg = user_registry.lock().await;
+                        reg.validate_token(&token).map(|u| u.to_owned())
+                    }
+                };
             return match resolved {
                 Some(u) => crate::broker::handle_oneshot_send(u, reader, write_half, &state).await,
                 None => {
@@ -133,8 +133,8 @@ pub(super) async fn dispatch_connection(
                 u,
                 write_half,
                 user_registry,
-                &state.token_map,
-                &state.subscription_map,
+                &state.auth.token_map,
+                &state.filters.subscription_map,
                 state.config.as_ref(),
             )
             .await;
@@ -144,14 +144,14 @@ pub(super) async fn dispatch_connection(
         }
         ClientHandshake::Session(token) => {
             // Resolve username from token (room-level first, then UserRegistry).
-            let resolved = match crate::broker::auth::validate_token(&token, &state.token_map).await
-            {
-                Some(u) => Some(u),
-                None => {
-                    let reg = user_registry.lock().await;
-                    reg.validate_token(&token).map(|u| u.to_owned())
-                }
-            };
+            let resolved =
+                match crate::broker::auth::validate_token(&token, &state.auth.token_map).await {
+                    Some(u) => Some(u),
+                    None => {
+                        let reg = user_registry.lock().await;
+                        reg.validate_token(&token).map(|u| u.to_owned())
+                    }
+                };
             match resolved {
                 Some(u) => u,
                 None => {

--- a/crates/room-cli/src/broker/daemon/mod.rs
+++ b/crates/room-cli/src/broker/daemon/mod.rs
@@ -207,7 +207,8 @@ impl DaemonState {
         let room = rooms
             .get(room_id)
             .ok_or_else(|| format!("room not found: {room_id}"))?;
-        room.token_map
+        room.auth
+            .token_map
             .lock()
             .await
             .insert(token.to_owned(), username.to_owned());
@@ -702,7 +703,7 @@ mod tests {
             .unwrap();
 
         let state = get_room(&daemon, "dm-alice-bob").await;
-        let subs = state.subscription_map.lock().await;
+        let subs = state.filters.subscription_map.lock().await;
         assert_eq!(subs.len(), 2);
         assert_eq!(
             subs.get("alice"),
@@ -724,7 +725,7 @@ mod tests {
             .unwrap();
 
         let state = get_room(&daemon, "lobby").await;
-        let subs = state.subscription_map.lock().await;
+        let subs = state.filters.subscription_map.lock().await;
         assert!(subs.is_empty());
     }
 
@@ -734,7 +735,7 @@ mod tests {
         daemon.create_room("plain").await.unwrap();
 
         let state = get_room(&daemon, "plain").await;
-        let subs = state.subscription_map.lock().await;
+        let subs = state.filters.subscription_map.lock().await;
         assert!(subs.is_empty());
     }
 
@@ -748,7 +749,7 @@ mod tests {
             .unwrap();
 
         let state = get_room(&daemon, "dm-carol-dave").await;
-        let subs = state.subscription_map.lock().await;
+        let subs = state.filters.subscription_map.lock().await;
         // Verify it's Full, not MentionsOnly
         for (_, tier) in subs.iter() {
             assert_eq!(*tier, room_protocol::SubscriptionTier::Full);

--- a/crates/room-cli/src/broker/mod.rs
+++ b/crates/room-cli/src/broker/mod.rs
@@ -145,18 +145,22 @@ impl Broker {
             clients: Arc::new(Mutex::new(HashMap::new())),
             status_map: Arc::new(Mutex::new(HashMap::new())),
             host_user: Arc::new(Mutex::new(None)),
-            token_map: Arc::new(Mutex::new(persisted_tokens)),
-            subscription_map: Arc::new(Mutex::new(persisted_subs)),
+            auth: state::AuthState {
+                token_map: Arc::new(Mutex::new(persisted_tokens)),
+                token_map_path: Arc::new(self.token_map_path.clone()),
+                registry: std::sync::OnceLock::new(),
+            },
+            filters: state::FilterState {
+                subscription_map: Arc::new(Mutex::new(persisted_subs)),
+                subscription_map_path: Arc::new(self.subscription_map_path.clone()),
+                event_filter_state: std::sync::OnceLock::new(),
+            },
             chat_path: Arc::new(self.chat_path.clone()),
-            token_map_path: Arc::new(self.token_map_path.clone()),
-            subscription_map_path: Arc::new(self.subscription_map_path.clone()),
             room_id: Arc::new(self.room_id.clone()),
             shutdown: Arc::new(shutdown_tx),
             seq_counter: Arc::new(AtomicU64::new(0)),
             plugin_registry: Arc::new(registry),
             config: None,
-            registry: std::sync::OnceLock::new(),
-            event_filter_state: std::sync::OnceLock::new(),
         });
         // Attach event filter map (parallel to subscription map).
         {
@@ -228,7 +232,7 @@ async fn handle_client(
     own_tx: broadcast::Sender<String>,
     state: &Arc<RoomState>,
 ) -> anyhow::Result<()> {
-    let token_map = state.token_map.clone();
+    let token_map = state.auth.token_map.clone();
 
     let (read_half, mut write_half) = stream.into_split();
     let mut reader = BufReader::new(read_half);
@@ -264,9 +268,9 @@ async fn handle_client(
                 u,
                 write_half,
                 &token_map,
-                &state.subscription_map,
+                &state.filters.subscription_map,
                 state.config.as_ref(),
-                Some(&state.token_map_path),
+                Some(&state.auth.token_map_path),
             )
             .await;
             // Persist auto-subscription from join so it survives broker restart.
@@ -695,11 +699,11 @@ async fn subscribe_mentioned(msg: &Message, state: &RoomState) -> Vec<String> {
 
     // Collect users to auto-subscribe (brief lock hold).
     let newly_subscribed = {
-        let token_map = state.token_map.lock().await;
+        let token_map = state.auth.token_map.lock().await;
         let registered: std::collections::HashSet<&str> =
             token_map.values().map(String::as_str).collect();
 
-        let mut sub_map = state.subscription_map.lock().await;
+        let mut sub_map = state.filters.subscription_map.lock().await;
         let mut newly = Vec::new();
 
         for username in &mentioned {
@@ -756,18 +760,22 @@ mod tests {
             clients: Arc::new(Mutex::new(HashMap::new())),
             status_map: Arc::new(Mutex::new(HashMap::new())),
             host_user: Arc::new(Mutex::new(None)),
-            token_map: Arc::new(Mutex::new(HashMap::new())),
-            subscription_map: Arc::new(Mutex::new(HashMap::new())),
+            auth: state::AuthState {
+                token_map: Arc::new(Mutex::new(HashMap::new())),
+                token_map_path: Arc::new(chat_path.with_extension("tokens")),
+                registry: std::sync::OnceLock::new(),
+            },
+            filters: state::FilterState {
+                subscription_map: Arc::new(Mutex::new(HashMap::new())),
+                subscription_map_path: Arc::new(chat_path.with_extension("subscriptions")),
+                event_filter_state: std::sync::OnceLock::new(),
+            },
             chat_path: Arc::new(chat_path.clone()),
-            token_map_path: Arc::new(chat_path.with_extension("tokens")),
-            subscription_map_path: Arc::new(chat_path.with_extension("subscriptions")),
             room_id: Arc::new("test-room".to_owned()),
             shutdown: Arc::new(shutdown_tx),
             seq_counter: Arc::new(AtomicU64::new(0)),
             plugin_registry: Arc::new(PluginRegistry::new()),
             config: None,
-            registry: std::sync::OnceLock::new(),
-            event_filter_state: std::sync::OnceLock::new(),
         })
     }
 
@@ -778,7 +786,7 @@ mod tests {
         // Message mentions @alice but alice has no token — should not auto-subscribe.
         let msg = make_message("test-room", "bob", "hey @alice check this");
         subscribe_mentioned(&msg, &state).await;
-        assert!(state.subscription_map.lock().await.is_empty());
+        assert!(state.filters.subscription_map.lock().await.is_empty());
     }
 
     #[tokio::test]
@@ -787,6 +795,7 @@ mod tests {
         let state = make_test_state(tmp.path().to_path_buf());
         // Register alice in token map.
         state
+            .auth
             .token_map
             .lock()
             .await
@@ -794,7 +803,13 @@ mod tests {
         let msg = make_message("test-room", "bob", "hey @alice check this");
         subscribe_mentioned(&msg, &state).await;
         assert_eq!(
-            *state.subscription_map.lock().await.get("alice").unwrap(),
+            *state
+                .filters
+                .subscription_map
+                .lock()
+                .await
+                .get("alice")
+                .unwrap(),
             SubscriptionTier::MentionsOnly
         );
     }
@@ -804,11 +819,13 @@ mod tests {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let state = make_test_state(tmp.path().to_path_buf());
         state
+            .auth
             .token_map
             .lock()
             .await
             .insert("tok-alice".to_owned(), "alice".to_owned());
         state
+            .filters
             .subscription_map
             .lock()
             .await
@@ -817,7 +834,13 @@ mod tests {
         subscribe_mentioned(&msg, &state).await;
         // Should remain Full, not downgraded to MentionsOnly.
         assert_eq!(
-            *state.subscription_map.lock().await.get("alice").unwrap(),
+            *state
+                .filters
+                .subscription_map
+                .lock()
+                .await
+                .get("alice")
+                .unwrap(),
             SubscriptionTier::Full
         );
     }
@@ -827,11 +850,13 @@ mod tests {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let state = make_test_state(tmp.path().to_path_buf());
         state
+            .auth
             .token_map
             .lock()
             .await
             .insert("tok-alice".to_owned(), "alice".to_owned());
         state
+            .filters
             .subscription_map
             .lock()
             .await
@@ -839,7 +864,13 @@ mod tests {
         let msg = make_message("test-room", "bob", "@alice ping");
         subscribe_mentioned(&msg, &state).await;
         assert_eq!(
-            *state.subscription_map.lock().await.get("alice").unwrap(),
+            *state
+                .filters
+                .subscription_map
+                .lock()
+                .await
+                .get("alice")
+                .unwrap(),
             SubscriptionTier::MentionsOnly
         );
     }
@@ -849,11 +880,13 @@ mod tests {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let state = make_test_state(tmp.path().to_path_buf());
         state
+            .auth
             .token_map
             .lock()
             .await
             .insert("tok-alice".to_owned(), "alice".to_owned());
         state
+            .filters
             .subscription_map
             .lock()
             .await
@@ -861,7 +894,13 @@ mod tests {
         let msg = make_message("test-room", "bob", "@alice come back");
         subscribe_mentioned(&msg, &state).await;
         assert_eq!(
-            *state.subscription_map.lock().await.get("alice").unwrap(),
+            *state
+                .filters
+                .subscription_map
+                .lock()
+                .await
+                .get("alice")
+                .unwrap(),
             SubscriptionTier::MentionsOnly
         );
     }
@@ -871,13 +910,13 @@ mod tests {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let state = make_test_state(tmp.path().to_path_buf());
         {
-            let mut tokens = state.token_map.lock().await;
+            let mut tokens = state.auth.token_map.lock().await;
             tokens.insert("tok-alice".to_owned(), "alice".to_owned());
             tokens.insert("tok-carol".to_owned(), "carol".to_owned());
         }
         let msg = make_message("test-room", "bob", "@alice @carol @unknown review this");
         subscribe_mentioned(&msg, &state).await;
-        let sub_map = state.subscription_map.lock().await;
+        let sub_map = state.filters.subscription_map.lock().await;
         assert_eq!(
             *sub_map.get("alice").unwrap(),
             SubscriptionTier::MentionsOnly
@@ -894,13 +933,14 @@ mod tests {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let state = make_test_state(tmp.path().to_path_buf());
         state
+            .auth
             .token_map
             .lock()
             .await
             .insert("tok-alice".to_owned(), "alice".to_owned());
         let msg = make_message("test-room", "bob", "hello everyone");
         subscribe_mentioned(&msg, &state).await;
-        assert!(state.subscription_map.lock().await.is_empty());
+        assert!(state.filters.subscription_map.lock().await.is_empty());
     }
 
     #[tokio::test]
@@ -908,6 +948,7 @@ mod tests {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let state = make_test_state(tmp.path().to_path_buf());
         state
+            .auth
             .token_map
             .lock()
             .await
@@ -927,6 +968,7 @@ mod tests {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let state = make_test_state(tmp.path().to_path_buf());
         state
+            .auth
             .token_map
             .lock()
             .await
@@ -934,7 +976,7 @@ mod tests {
         let msg = make_message("test-room", "bob", "hey @alice");
         subscribe_mentioned(&msg, &state).await;
         // Verify subscriptions were persisted to the .subscriptions file.
-        let loaded = persistence::load_subscription_map(&state.subscription_map_path);
+        let loaded = persistence::load_subscription_map(&state.filters.subscription_map_path);
         assert_eq!(loaded.get("alice"), Some(&SubscriptionTier::MentionsOnly));
     }
 
@@ -946,6 +988,7 @@ mod tests {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let state = make_test_state(tmp.path().to_path_buf());
         state
+            .auth
             .token_map
             .lock()
             .await
@@ -957,7 +1000,7 @@ mod tests {
         assert_eq!(newly, vec!["alice"]);
 
         // Verify subscription is persisted BEFORE any message is in the chat file.
-        let loaded = persistence::load_subscription_map(&state.subscription_map_path);
+        let loaded = persistence::load_subscription_map(&state.filters.subscription_map_path);
         assert_eq!(loaded.get("alice"), Some(&SubscriptionTier::MentionsOnly));
         // Chat file should still be empty (broadcast hasn't happened yet).
         let chat_content = std::fs::read_to_string(tmp.path()).unwrap();

--- a/crates/room-cli/src/broker/persistence.rs
+++ b/crates/room-cli/src/broker/persistence.rs
@@ -39,7 +39,7 @@ pub(crate) fn load_subscription_map(path: &Path) -> HashMap<String, Subscription
 /// than shaving microseconds.
 pub(crate) async fn persist_subscriptions(state: &RoomState) {
     let snapshot = state.subscription_snapshot().await;
-    if let Err(e) = save_subscription_map(&snapshot, &state.subscription_map_path) {
+    if let Err(e) = save_subscription_map(&snapshot, &state.filters.subscription_map_path) {
         eprintln!("[broker] subscription persist failed: {e}");
     }
 }

--- a/crates/room-cli/src/broker/service.rs
+++ b/crates/room-cli/src/broker/service.rs
@@ -87,12 +87,18 @@ impl RoomService for RoomState {
     }
 
     async fn validate_token(&self, token: &str) -> Option<String> {
-        validate_token(token, &self.token_map).await
+        validate_token(token, &self.auth.token_map).await
     }
 
     async fn issue_token(&self, username: &str) -> Result<String, String> {
-        let token = issue_token(username, &self.token_map, Some(&self.token_map_path)).await?;
-        self.subscription_map
+        let token = issue_token(
+            username,
+            &self.auth.token_map,
+            Some(&self.auth.token_map_path),
+        )
+        .await?;
+        self.filters
+            .subscription_map
             .lock()
             .await
             .insert(username.to_owned(), SubscriptionTier::Full);
@@ -229,7 +235,13 @@ mod tests {
         let tmp = NamedTempFile::new().unwrap();
         let state = make_state(tmp.path().to_path_buf());
         state.issue_token("alice").await.unwrap();
-        let tier = state.subscription_map.lock().await.get("alice").copied();
+        let tier = state
+            .filters
+            .subscription_map
+            .lock()
+            .await
+            .get("alice")
+            .copied();
         assert_eq!(
             tier,
             Some(SubscriptionTier::Full),

--- a/crates/room-cli/src/broker/state.rs
+++ b/crates/room-cli/src/broker/state.rs
@@ -36,47 +36,53 @@ pub(crate) type SubscriptionMap = Arc<Mutex<HashMap<String, SubscriptionTier>>>;
 /// broker/daemon startup. Default for users with no entry is `EventFilter::All`.
 pub(crate) type EventFilterMap = Arc<Mutex<HashMap<String, EventFilter>>>;
 
+/// Token and identity state grouped together.
+///
+/// Contains the per-room token map, its persistence path, and the optional
+/// daemon-level user registry. The registry uses `OnceLock` so it can be
+/// set after construction without exceeding the clippy argument threshold.
+pub(crate) struct AuthState {
+    /// Maps token UUID → username. Populated by one-shot JOIN requests.
+    pub(crate) token_map: TokenMap,
+    /// Path to the persisted token-map file (e.g. `~/.room/state/<room_id>.tokens`).
+    pub(crate) token_map_path: Arc<PathBuf>,
+    /// Daemon-level user registry for cross-room identity. Unset in
+    /// single-room mode.
+    pub(crate) registry: OnceLock<Arc<Mutex<UserRegistry>>>,
+}
+
+/// Subscription and event-filter state grouped together.
+///
+/// Contains the per-room subscription map, its persistence path, and the
+/// optional per-user event filter map. The event filter uses `OnceLock` so
+/// it can be set after construction.
+pub(crate) struct FilterState {
+    /// Maps username → subscription tier for this room.
+    pub(crate) subscription_map: SubscriptionMap,
+    /// Path to the persisted subscription-map file (e.g. `~/.room/state/<room_id>.subscriptions`).
+    pub(crate) subscription_map_path: Arc<PathBuf>,
+    /// Per-user event type filter. Set via [`RoomState::set_event_filter_map`]
+    /// after construction. If unset, all event types pass through.
+    pub(crate) event_filter_state: OnceLock<(EventFilterMap, Arc<PathBuf>)>,
+}
+
 /// Shared broker state passed to every client handler.
 pub(crate) struct RoomState {
     pub(crate) clients: ClientMap,
     pub(crate) status_map: StatusMap,
     pub(crate) host_user: HostUser,
-    pub(crate) token_map: TokenMap,
-    pub(crate) subscription_map: SubscriptionMap,
+    pub(crate) auth: AuthState,
+    pub(crate) filters: FilterState,
     pub(crate) chat_path: Arc<PathBuf>,
-    /// Path to the persisted token-map file (e.g. `~/.room/state/<room_id>.tokens`).
-    pub(crate) token_map_path: Arc<PathBuf>,
-    /// Path to the persisted subscription-map file (e.g. `~/.room/state/<room_id>.subscriptions`).
-    pub(crate) subscription_map_path: Arc<PathBuf>,
     pub(crate) room_id: Arc<String>,
     /// Set to `true` by the `/exit` admin command to shut down the broker.
-    /// Using watch so receivers that check after the fact see `true` immediately
-    /// — unlike `Notify`, this avoids the race where `notify_waiters()` fires
-    /// before a task's `.notified()` future is registered.
     pub(crate) shutdown: Arc<watch::Sender<bool>>,
-    /// Monotonically-increasing sequence counter. Incremented for every message
-    /// broadcast or persisted by the broker, starting at 1.
+    /// Monotonically-increasing sequence counter.
     pub(crate) seq_counter: Arc<AtomicU64>,
     /// Plugin registry for dispatching `/` commands to plugins.
     pub(crate) plugin_registry: Arc<PluginRegistry>,
     /// Room visibility and access control configuration.
-    /// `None` for rooms created without explicit config (backward compat).
     pub(crate) config: Option<RoomConfig>,
-    /// Daemon-level user registry for cross-room identity. Unset in
-    /// single-room mode. When set, admin commands (`/kick`, `/reauth`)
-    /// also revoke tokens from the registry so users can rejoin after reauth.
-    ///
-    /// Uses `OnceLock` so it can be set after [`RoomState::new`] without
-    /// requiring an extra constructor parameter (which would exceed the
-    /// clippy `too-many-arguments` threshold).
-    pub(crate) registry: OnceLock<Arc<Mutex<UserRegistry>>>,
-    /// Per-user event type filter. Uses `OnceLock` for the same reason as
-    /// `registry` — avoids exceeding the 7-argument constructor limit.
-    ///
-    /// Set via [`RoomState::set_event_filter_map`] after construction.
-    /// If unset, all event types pass through (equivalent to `EventFilter::All`
-    /// for every user).
-    pub(crate) event_filter_state: OnceLock<(EventFilterMap, Arc<PathBuf>)>,
 }
 
 impl RoomState {
@@ -118,18 +124,22 @@ impl RoomState {
             clients: Arc::new(Mutex::new(HashMap::new())),
             status_map: Arc::new(Mutex::new(HashMap::new())),
             host_user: Arc::new(Mutex::new(None)),
-            token_map,
-            subscription_map,
+            auth: AuthState {
+                token_map,
+                token_map_path: Arc::new(token_map_path),
+                registry: OnceLock::new(),
+            },
+            filters: FilterState {
+                subscription_map,
+                subscription_map_path: Arc::new(subscription_map_path),
+                event_filter_state: OnceLock::new(),
+            },
             chat_path: Arc::new(chat_path),
-            token_map_path: Arc::new(token_map_path),
-            subscription_map_path: Arc::new(subscription_map_path),
             room_id: Arc::new(room_id),
             shutdown: Arc::new(shutdown_tx),
             seq_counter: Arc::new(AtomicU64::new(0)),
             plugin_registry: Arc::new(plugins),
             config,
-            registry: OnceLock::new(),
-            event_filter_state: OnceLock::new(),
         }))
     }
 
@@ -141,7 +151,7 @@ impl RoomState {
     /// `Arc<RoomState>` is shared with other tasks. Silently no-ops if called
     /// a second time (consistent with `OnceLock` semantics).
     pub(crate) fn set_registry(&self, registry: Arc<Mutex<UserRegistry>>) {
-        let _ = self.registry.set(registry);
+        let _ = self.auth.registry.set(registry);
     }
 
     // ── event_filter_map ─────────────────────────────────────────────────────
@@ -151,7 +161,7 @@ impl RoomState {
     /// Must be called at most once, immediately after construction. Silently
     /// no-ops if called a second time (consistent with `OnceLock` semantics).
     pub(crate) fn set_event_filter_map(&self, map: EventFilterMap, path: PathBuf) {
-        let _ = self.event_filter_state.set((map, Arc::new(path)));
+        let _ = self.filters.event_filter_state.set((map, Arc::new(path)));
     }
 
     /// Set a user's event filter.
@@ -159,14 +169,14 @@ impl RoomState {
     /// No-ops if the event filter map has not been attached via
     /// [`set_event_filter_map`].
     pub(crate) async fn set_event_filter(&self, user: &str, filter: EventFilter) {
-        if let Some((map, _)) = self.event_filter_state.get() {
+        if let Some((map, _)) = self.filters.event_filter_state.get() {
             map.lock().await.insert(user.to_owned(), filter);
         }
     }
 
     /// Return all (username, filter) event filter pairs, sorted by username.
     pub(crate) async fn event_filter_entries(&self) -> Vec<(String, EventFilter)> {
-        match self.event_filter_state.get() {
+        match self.filters.event_filter_state.get() {
             Some((map, _)) => {
                 let mut entries: Vec<(String, EventFilter)> = map
                     .lock()
@@ -183,7 +193,7 @@ impl RoomState {
 
     /// Return a cloned snapshot of the event filter map (for persistence).
     pub(crate) async fn event_filter_snapshot(&self) -> HashMap<String, EventFilter> {
-        match self.event_filter_state.get() {
+        match self.filters.event_filter_state.get() {
             Some((map, _)) => map.lock().await.clone(),
             None => HashMap::new(),
         }
@@ -191,7 +201,8 @@ impl RoomState {
 
     /// Return the persistence path for the event filter map, if attached.
     pub(crate) fn event_filter_path(&self) -> Option<&PathBuf> {
-        self.event_filter_state
+        self.filters
+            .event_filter_state
             .get()
             .map(|(_, p): &(EventFilterMap, Arc<PathBuf>)| p.as_ref())
     }
@@ -230,7 +241,8 @@ impl RoomState {
 
     /// Set a user's subscription tier.
     pub(crate) async fn set_subscription(&self, user: &str, tier: SubscriptionTier) {
-        self.subscription_map
+        self.filters
+            .subscription_map
             .lock()
             .await
             .insert(user.to_owned(), tier);
@@ -239,6 +251,7 @@ impl RoomState {
     /// Return all (username, tier) subscription pairs, sorted by username.
     pub(crate) async fn subscription_entries(&self) -> Vec<(String, SubscriptionTier)> {
         let mut entries: Vec<(String, SubscriptionTier)> = self
+            .filters
             .subscription_map
             .lock()
             .await
@@ -251,12 +264,12 @@ impl RoomState {
 
     /// Return a cloned snapshot of the full subscription map (for persistence).
     pub(crate) async fn subscription_snapshot(&self) -> HashMap<String, SubscriptionTier> {
-        self.subscription_map.lock().await.clone()
+        self.filters.subscription_map.lock().await.clone()
     }
 
     /// Number of subscribed users.
     pub(crate) async fn subscription_count(&self) -> usize {
-        self.subscription_map.lock().await.len()
+        self.filters.subscription_map.lock().await.len()
     }
 }
 
@@ -336,7 +349,7 @@ mod tests {
             None,
         )
         .unwrap();
-        assert!(state.token_map.lock().await.contains_key("tok-1"));
+        assert!(state.auth.token_map.lock().await.contains_key("tok-1"));
     }
 
     // ── status_map accessors ──────────────────────────────────────────────────

--- a/crates/room-cli/src/broker/ws/mod.rs
+++ b/crates/room-cli/src/broker/ws/mod.rs
@@ -118,7 +118,7 @@ async fn run_ws_session(
         }
         ClientHandshake::Token(token) => {
             // Try room-level token map first, then fall back to global UserRegistry.
-            let resolved = match validate_token(&token, &state.token_map).await {
+            let resolved = match validate_token(&token, &state.auth.token_map).await {
                 Some(u) => Some(u),
                 None => {
                     if let Some(reg) = user_registry {
@@ -142,7 +142,7 @@ async fn run_ws_session(
         }
         ClientHandshake::Session(token) => {
             // Resolve username from token (room-level first, then UserRegistry).
-            let resolved = match validate_token(&token, &state.token_map).await {
+            let resolved = match validate_token(&token, &state.auth.token_map).await {
                 Some(u) => Some(u),
                 None => {
                     if let Some(reg) = user_registry {
@@ -394,13 +394,20 @@ async fn ws_oneshot_join(
         let _ = ws_tx.send(WsMessage::Close(None)).await;
         return Ok(());
     }
-    match issue_token(username, &state.token_map, Some(&state.token_map_path)).await {
+    match issue_token(
+        username,
+        &state.auth.token_map,
+        Some(&state.auth.token_map_path),
+    )
+    .await
+    {
         Ok(token) => {
             let resp = serde_json::json!({"type":"token","token": token, "username": username});
             let _ = ws_tx.send(WsMessage::Text(resp.to_string().into())).await;
             // Set Full subscription so the joining user receives all messages,
             // matching the UDS join behaviour in auth.rs.
             state
+                .filters
                 .subscription_map
                 .lock()
                 .await


### PR DESCRIPTION
## Summary
- Created `AuthState` sub-struct grouping `token_map`, `token_map_path`, and `registry` (OnceLock)
- Created `FilterState` sub-struct grouping `subscription_map`, `subscription_map_path`, and `event_filter_state` (OnceLock)
- Replaced 6 flat fields on `RoomState` with `auth: AuthState` and `filters: FilterState` — reduces field count from 15 to 11
- Updated all ~112 field access sites across 9 files (broker source + tests)
- Constructor signature unchanged (7 params, within clippy threshold)

## Test plan
- [x] All 1383 Rust tests pass (no test changes needed beyond field path updates)
- [x] cargo check, cargo fmt, cargo clippy -- -D warnings all pass

Closes #545