### PR TITLE
refactor(broker): extract token persistence to token_store.rs (#588)

### DIFF
--- a/crates/room-cli/CHANGELOG.md
+++ b/crates/room-cli/CHANGELOG.md
@@ -28,6 +28,8 @@ For changes prior to the workspace restructure (v0.1.2 through v1.0.2), see the
   `Plugin` by depending only on `room-protocol`. (#558)
 - Extracted `builtin_command_infos()` and `all_known_commands()` to `plugin/schema.rs`.
   `plugin/mod.rs` now contains only `PluginRegistry` and re-exports. (#587)
+- Extracted token persistence (`save_token_map`, `load_token_map`) from `broker/auth.rs` to
+  new `broker/token_store.rs`. Separates disk I/O from auth logic. (#588)
 
 ### Fixed
 

--- a/crates/room-cli/src/broker/admin.rs
+++ b/crates/room-cli/src/broker/admin.rs
@@ -5,7 +5,7 @@
 
 use crate::message::make_system;
 
-use super::{auth::save_token_map, fanout::broadcast_and_persist, state::RoomState};
+use super::{fanout::broadcast_and_persist, state::RoomState, token_store::save_token_map};
 
 /// Admin command names — routed through `handle_admin_cmd` when received as
 /// a `Message::Command` with one of these cmd values.
@@ -368,7 +368,7 @@ mod tests {
         handle_admin_cmd("kick bob", "alice", &state).await;
 
         // Load from disk — KICKED sentinel must be persisted
-        let loaded = crate::broker::auth::load_token_map(&state.auth.token_map_path);
+        let loaded = crate::broker::token_store::load_token_map(&state.auth.token_map_path);
         assert!(
             loaded.contains_key("KICKED:bob"),
             "KICKED sentinel must be persisted to disk"
@@ -394,7 +394,7 @@ mod tests {
 
         handle_admin_cmd("reauth bob", "alice", &state).await;
 
-        let loaded = crate::broker::auth::load_token_map(&state.auth.token_map_path);
+        let loaded = crate::broker::token_store::load_token_map(&state.auth.token_map_path);
         assert!(
             !loaded.values().any(|u| u == "bob"),
             "bob must be fully removed from disk after reauth"
@@ -416,7 +416,7 @@ mod tests {
 
         handle_admin_cmd("clear-tokens", "alice", &state).await;
 
-        let loaded = crate::broker::auth::load_token_map(&state.auth.token_map_path);
+        let loaded = crate::broker::token_store::load_token_map(&state.auth.token_map_path);
         assert!(
             loaded.is_empty(),
             "token map on disk must be empty after clear-tokens"
@@ -440,7 +440,7 @@ mod tests {
         handle_admin_cmd("kick bob", "alice", &state).await;
 
         // Simulate broker restart: load token map from disk into fresh state
-        let loaded = crate::broker::auth::load_token_map(&state.auth.token_map_path);
+        let loaded = crate::broker::token_store::load_token_map(&state.auth.token_map_path);
         let new_map: super::super::state::TokenMap = Arc::new(Mutex::new(loaded));
 
         // The original token must be invalid

--- a/crates/room-cli/src/broker/auth.rs
+++ b/crates/room-cli/src/broker/auth.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -9,31 +8,7 @@ use uuid::Uuid;
 use crate::registry::UserRegistry;
 
 use super::state::{SubscriptionMap, TokenMap};
-
-// ── Token persistence ────────────────────────────────────────────────────────
-
-/// Write a token map to disk as JSON.
-pub(crate) fn save_token_map(map: &HashMap<String, String>, path: &Path) -> Result<(), String> {
-    let json = serde_json::to_string_pretty(&map).map_err(|e| format!("serialize tokens: {e}"))?;
-    std::fs::write(path, json).map_err(|e| format!("write {}: {e}", path.display()))
-}
-
-/// Load a token map from disk. Returns an empty map if the file does not exist.
-///
-/// `token_map_path` is the `.tokens` file (see [`crate::paths::broker_tokens_path`]).
-pub(crate) fn load_token_map(token_map_path: &Path) -> HashMap<String, String> {
-    let contents = match std::fs::read_to_string(token_map_path) {
-        Ok(c) => c,
-        Err(_) => return HashMap::new(),
-    };
-    serde_json::from_str(&contents).unwrap_or_else(|e| {
-        eprintln!(
-            "[auth] corrupt token file {}: {e}",
-            token_map_path.display()
-        );
-        HashMap::new()
-    })
-}
+use super::token_store::save_token_map;
 
 /// Check whether `username` is allowed to join a room with the given config.
 ///
@@ -273,6 +248,7 @@ pub(crate) async fn handle_oneshot_join_with_registry(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::broker::token_store::load_token_map;
     use room_protocol::{RoomConfig, RoomVisibility};
     use std::{collections::HashMap, sync::Arc};
     use tokio::sync::Mutex;
@@ -506,39 +482,7 @@ mod tests {
         assert!(check_send_permission("anyone", None).is_ok());
     }
 
-    // ── Token persistence ─────────────────────────────────────────────────
-
-    #[test]
-    fn load_token_map_missing_file_returns_empty() {
-        let dir = tempfile::tempdir().unwrap();
-        let token_map_path = dir.path().join("nonexistent.tokens");
-        let map = load_token_map(&token_map_path);
-        assert!(map.is_empty());
-    }
-
-    #[test]
-    fn save_and_load_round_trip() {
-        let dir = tempfile::tempdir().unwrap();
-        let token_map_path = dir.path().join("test.tokens");
-
-        let mut original = HashMap::new();
-        original.insert("tok-1".to_owned(), "alice".to_owned());
-        original.insert("tok-2".to_owned(), "bob".to_owned());
-
-        save_token_map(&original, &token_map_path).unwrap();
-        let loaded = load_token_map(&token_map_path);
-        assert_eq!(loaded, original);
-    }
-
-    #[test]
-    fn load_token_map_corrupt_file_returns_empty() {
-        let dir = tempfile::tempdir().unwrap();
-        let token_map_path = dir.path().join("corrupt.tokens");
-        std::fs::write(&token_map_path, "not json{{{").unwrap();
-
-        let map = load_token_map(&token_map_path);
-        assert!(map.is_empty());
-    }
+    // ── Token persistence integration ───────────────────────────────────
 
     #[tokio::test]
     async fn issue_token_persists_to_disk() {

--- a/crates/room-cli/src/broker/daemon/migration.rs
+++ b/crates/room-cli/src/broker/daemon/migration.rs
@@ -26,7 +26,7 @@ pub(crate) fn load_or_migrate_registry(config: &DaemonConfig) -> UserRegistry {
         // Migration path: import from legacy tokens.json if present.
         let tokens_path = config.system_tokens_path();
         if tokens_path.exists() {
-            let legacy = crate::broker::auth::load_token_map(&tokens_path);
+            let legacy = crate::broker::token_store::load_token_map(&tokens_path);
             if !legacy.is_empty() {
                 eprintln!(
                     "[daemon] migrating {} token(s) from tokens.json to users.json",

--- a/crates/room-cli/src/broker/mod.rs
+++ b/crates/room-cli/src/broker/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod handshake;
 pub(crate) mod persistence;
 pub(crate) mod service;
 pub(crate) mod state;
+pub(crate) mod token_store;
 pub(crate) mod ws;
 
 use std::{
@@ -126,7 +127,7 @@ impl Broker {
         let registry = PluginRegistry::with_all_plugins(&self.chat_path)?;
 
         // Load persisted state from a previous broker session (if any).
-        let persisted_tokens = auth::load_token_map(&self.token_map_path);
+        let persisted_tokens = token_store::load_token_map(&self.token_map_path);
         if !persisted_tokens.is_empty() {
             eprintln!(
                 "[broker] loaded {} persisted token(s)",

--- a/crates/room-cli/src/broker/token_store.rs
+++ b/crates/room-cli/src/broker/token_store.rs
@@ -1,0 +1,62 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+/// Write a token map to disk as JSON.
+pub(crate) fn save_token_map(map: &HashMap<String, String>, path: &Path) -> Result<(), String> {
+    let json = serde_json::to_string_pretty(&map).map_err(|e| format!("serialize tokens: {e}"))?;
+    std::fs::write(path, json).map_err(|e| format!("write {}: {e}", path.display()))
+}
+
+/// Load a token map from disk. Returns an empty map if the file does not exist.
+///
+/// `token_map_path` is the `.tokens` file (see [`crate::paths::broker_tokens_path`]).
+pub(crate) fn load_token_map(token_map_path: &Path) -> HashMap<String, String> {
+    let contents = match std::fs::read_to_string(token_map_path) {
+        Ok(c) => c,
+        Err(_) => return HashMap::new(),
+    };
+    serde_json::from_str(&contents).unwrap_or_else(|e| {
+        eprintln!(
+            "[auth] corrupt token file {}: {e}",
+            token_map_path.display()
+        );
+        HashMap::new()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_token_map_missing_file_returns_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let token_map_path = dir.path().join("nonexistent.tokens");
+        let map = load_token_map(&token_map_path);
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn save_and_load_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let token_map_path = dir.path().join("test.tokens");
+
+        let mut original = HashMap::new();
+        original.insert("tok-1".to_owned(), "alice".to_owned());
+        original.insert("tok-2".to_owned(), "bob".to_owned());
+
+        save_token_map(&original, &token_map_path).unwrap();
+        let loaded = load_token_map(&token_map_path);
+        assert_eq!(loaded, original);
+    }
+
+    #[test]
+    fn load_token_map_corrupt_file_returns_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let token_map_path = dir.path().join("corrupt.tokens");
+        std::fs::write(&token_map_path, "not json{{{").unwrap();
+
+        let map = load_token_map(&token_map_path);
+        assert!(map.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- Extract `save_token_map` and `load_token_map` from `broker/auth.rs` to new `broker/token_store.rs`, separating disk I/O from auth logic.
- Update imports in `broker/mod.rs`, `broker/admin.rs`, and `broker/daemon/migration.rs`.
- Move 3 pure persistence unit tests to `token_store.rs`; keep integration tests in `auth.rs`.
- auth.rs: 843 → 787 lines. token_store.rs: 62 lines.

Closes #588

## Test plan
- [x] All 1383 Rust tests pass (`cargo test`)
- [x] `cargo check` clean
- [x] `cargo fmt` — no changes
- [x] `cargo clippy -- -D warnings` — clean
- [ ] Verify token persistence still works end-to-end (save/load round-trip covered by moved unit tests)
- [ ] Verify daemon migration path still calls `token_store::load_token_map` correctly