### PR TITLE
fix(tui): show partial messages at viewport bottom when scrolling (#644)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 > - [room-protocol CHANGELOG](crates/room-protocol/CHANGELOG.md)
 > - [room-ralph CHANGELOG](crates/room-ralph/CHANGELOG.md)
 
+### Fixed
+
+- **tui:** Show partial messages at viewport bottom when scrolling — previously the entire
+  message disappeared when its bottom line scrolled off screen. (#644)
+
 ### Added
 
 - CI changelog enforcement — PRs must include a changelog entry under `[Unreleased]`. (#499)

--- a/crates/room-cli/src/tui/mod.rs
+++ b/crates/room-cli/src/tui/mod.rs
@@ -561,17 +561,29 @@ pub async fn run(
 
             let (start_msg_idx, skip_first) = find_view_start(&heights, view_top);
 
-            let visible: Vec<ListItem> = msg_texts[start_msg_idx..]
-                .iter()
-                .enumerate()
-                .map(|(i, text)| {
-                    if i == 0 && skip_first > 0 {
-                        ListItem::new(Text::from(text.lines[skip_first..].to_vec()))
-                    } else {
-                        ListItem::new(text.clone())
-                    }
-                })
-                .collect();
+            let mut visible: Vec<ListItem> = Vec::new();
+            let mut lines_remaining = msg_area_height;
+            for (i, text) in msg_texts[start_msg_idx..].iter().enumerate() {
+                if lines_remaining == 0 {
+                    break;
+                }
+                let lines = if i == 0 && skip_first > 0 {
+                    &text.lines[skip_first..]
+                } else {
+                    &text.lines[..]
+                };
+                let line_count = lines.len().max(1);
+                if line_count <= lines_remaining {
+                    visible.push(ListItem::new(Text::from(lines.to_vec())));
+                    lines_remaining -= line_count;
+                } else {
+                    // Partially visible message at viewport bottom — show
+                    // only the lines that fit instead of hiding the entire
+                    // message.
+                    visible.push(ListItem::new(Text::from(lines[..lines_remaining].to_vec())));
+                    lines_remaining = 0;
+                }
+            }
 
             let title = if scroll_offset > 0 {
                 format!(" {} [↑ {} lines] ", room_id_display, scroll_offset)

--- a/crates/room-cli/src/tui/render.rs
+++ b/crates/room-cli/src/tui/render.rs
@@ -311,6 +311,34 @@ pub(super) fn find_view_start(heights: &[usize], view_top: usize) -> (usize, usi
     (heights.len(), 0)
 }
 
+/// Compute per-message visible line counts for a viewport window.
+///
+/// Given message `heights`, the viewport `height`, and the `view_top` line
+/// index, returns a vec of `(message_index, visible_line_count)` pairs for
+/// every message that has at least one line inside the viewport. Messages
+/// partially clipped at the top or bottom are included with only their
+/// visible line count.
+#[cfg(test)]
+fn visible_line_counts(
+    heights: &[usize],
+    view_top: usize,
+    viewport_height: usize,
+) -> Vec<(usize, usize)> {
+    let (start_idx, skip_first) = find_view_start(heights, view_top);
+    let mut result = Vec::new();
+    let mut remaining = viewport_height;
+    for (i, &h) in heights[start_idx..].iter().enumerate() {
+        if remaining == 0 {
+            break;
+        }
+        let lines = if i == 0 { h - skip_first } else { h };
+        let visible = lines.min(remaining);
+        result.push((start_idx + i, visible));
+        remaining -= visible;
+    }
+    result
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -441,5 +469,58 @@ mod tests {
                 "scroll_offset={offset}, view_top={view_top}"
             );
         }
+    }
+
+    // ── visible_line_counts tests ─────────────────────────────────────────
+
+    #[test]
+    fn visible_line_counts_all_fit() {
+        // 3 messages, each 1 line, viewport of 5 — all fit fully.
+        let counts = visible_line_counts(&[1, 1, 1], 0, 5);
+        assert_eq!(counts, vec![(0, 1), (1, 1), (2, 1)]);
+    }
+
+    #[test]
+    fn visible_line_counts_bottom_truncation() {
+        // 3 messages of heights [2, 5, 3], total=10, viewport=4, view_top=0.
+        // msg0 fully visible (2 lines), msg1 partially visible (2 of 5 lines).
+        let counts = visible_line_counts(&[2, 5, 3], 0, 4);
+        assert_eq!(counts, vec![(0, 2), (1, 2)]);
+    }
+
+    #[test]
+    fn visible_line_counts_top_skip_and_bottom_truncation() {
+        // heights [3, 4, 2], total=9, viewport=3, view_top=2.
+        // msg0: 3 lines, skip 2 → 1 visible line.
+        // msg1: 4 lines, only 2 fit → 2 visible lines.
+        let counts = visible_line_counts(&[3, 4, 2], 2, 3);
+        assert_eq!(counts, vec![(0, 1), (1, 2)]);
+    }
+
+    #[test]
+    fn visible_line_counts_single_tall_message() {
+        // One 10-line message, viewport=3, view_top=4.
+        // Skip 4 lines, show 3 of remaining 6.
+        let counts = visible_line_counts(&[10], 4, 3);
+        assert_eq!(counts, vec![(0, 3)]);
+    }
+
+    #[test]
+    fn visible_line_counts_exact_fit() {
+        // heights [2, 3], viewport=5, view_top=0 — exactly fills viewport.
+        let counts = visible_line_counts(&[2, 3], 0, 5);
+        assert_eq!(counts, vec![(0, 2), (1, 3)]);
+    }
+
+    #[test]
+    fn visible_line_counts_empty() {
+        let counts = visible_line_counts(&[], 0, 5);
+        assert_eq!(counts, vec![]);
+    }
+
+    #[test]
+    fn visible_line_counts_zero_viewport() {
+        let counts = visible_line_counts(&[3, 2], 0, 0);
+        assert_eq!(counts, vec![]);
     }
 }


### PR DESCRIPTION
## Summary
- Fix partial message visibility when scrolling — previously, multi-line messages disappeared entirely when their bottom line scrolled off the viewport
- Root cause: ratatui's `List` widget skips `ListItem`s that don't fully fit at the bottom of the render area
- Fix: manually truncate visible items in the rendering loop to show only lines that fit, instead of relying on ratatui's clipping
- Add `visible_line_counts()` helper function with 7 regression tests covering top-skip, bottom-truncation, exact-fit, and edge cases

## Test plan
- [x] `cargo check` passes
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] All tests pass (7 new viewport tests)
- [x] No test count regression

Closes #644
