### PR TITLE
Add EventFilter and non-taskboard event tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **test:** Added 3 DM room semantics integration tests: symmetric ID join+message,
   non-participant poll DirectMessage filtering, offline recipient message visibility
   on rejoin. (#581)
+- **tests:** Added 5 tests for EventFilter and non-taskboard event types — `apply_event_filter`
+  with `StatusChanged`/`ReviewRequested`, exhaustive all-11-variants coverage, event filter
+  persistence round-trip with non-taskboard types, per-room filtering, and Event→System
+  seq ordering over WebSocket transport. (#579)
 
 ### Changed
 

--- a/crates/room-cli/src/broker/persistence.rs
+++ b/crates/room-cli/src/broker/persistence.rs
@@ -84,3 +84,51 @@ pub(crate) async fn persist_event_filters(state: &RoomState) {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use room_protocol::{EventFilter, EventType};
+    use std::collections::{BTreeSet, HashMap};
+
+    #[test]
+    fn save_load_event_filter_map_non_taskboard_types() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("event_filters.json");
+
+        let mut map = HashMap::new();
+
+        // alice: Only{StatusChanged, ReviewRequested} — non-taskboard types
+        let mut types = BTreeSet::new();
+        types.insert(EventType::StatusChanged);
+        types.insert(EventType::ReviewRequested);
+        map.insert("alice".to_string(), EventFilter::Only { types });
+
+        // bob: All
+        map.insert("bob".to_string(), EventFilter::All);
+
+        // carol: None
+        map.insert("carol".to_string(), EventFilter::None);
+
+        save_event_filter_map(&map, &path).unwrap();
+        let loaded = load_event_filter_map(&path);
+
+        assert_eq!(loaded.len(), 3);
+        assert_eq!(loaded.get("bob").unwrap(), &EventFilter::All);
+        assert_eq!(loaded.get("carol").unwrap(), &EventFilter::None);
+
+        // Verify alice's Only filter preserved the exact BTreeSet contents
+        match loaded.get("alice").unwrap() {
+            EventFilter::Only { types } => {
+                assert_eq!(types.len(), 2);
+                assert!(types.contains(&EventType::StatusChanged));
+                assert!(types.contains(&EventType::ReviewRequested));
+                assert!(
+                    !types.contains(&EventType::TaskPosted),
+                    "should not contain taskboard types"
+                );
+            }
+            other => panic!("expected Only filter for alice, got {other}"),
+        }
+    }
+}

--- a/crates/room-cli/src/oneshot/poll/filter_events.rs
+++ b/crates/room-cli/src/oneshot/poll/filter_events.rs
@@ -130,6 +130,118 @@ mod tests {
     }
 
     #[test]
+    fn apply_filter_non_taskboard_event_types() {
+        let mut types = std::collections::BTreeSet::new();
+        types.insert(room_protocol::EventType::StatusChanged);
+        types.insert(room_protocol::EventType::ReviewRequested);
+        let filter = EventFilter::Only { types };
+
+        let mut msgs = vec![
+            make_message("r", "alice", "hello"),
+            make_event_msg("r", room_protocol::EventType::StatusChanged),
+            make_event_msg("r", room_protocol::EventType::ReviewRequested),
+            make_event_msg("r", room_protocol::EventType::TaskPosted),
+            make_event_msg("r", room_protocol::EventType::TaskClaimed),
+        ];
+        apply_event_filter(&mut msgs, &filter);
+        // hello (non-event) + StatusChanged + ReviewRequested survive; TaskPosted + TaskClaimed filtered
+        assert_eq!(msgs.len(), 3);
+        // Verify the surviving events are the right types
+        let event_types: Vec<_> = msgs
+            .iter()
+            .filter_map(|m| match m {
+                Message::Event { event_type, .. } => Some(*event_type),
+                _ => None,
+            })
+            .collect();
+        assert!(event_types.contains(&room_protocol::EventType::StatusChanged));
+        assert!(event_types.contains(&room_protocol::EventType::ReviewRequested));
+        assert!(!event_types.contains(&room_protocol::EventType::TaskPosted));
+    }
+
+    #[test]
+    fn event_filter_only_covers_all_eleven_variants() {
+        let all_variants = [
+            room_protocol::EventType::TaskPosted,
+            room_protocol::EventType::TaskAssigned,
+            room_protocol::EventType::TaskClaimed,
+            room_protocol::EventType::TaskPlanned,
+            room_protocol::EventType::TaskApproved,
+            room_protocol::EventType::TaskUpdated,
+            room_protocol::EventType::TaskReleased,
+            room_protocol::EventType::TaskFinished,
+            room_protocol::EventType::TaskCancelled,
+            room_protocol::EventType::StatusChanged,
+            room_protocol::EventType::ReviewRequested,
+        ];
+
+        for target in &all_variants {
+            // Build a filter that only allows this one variant
+            let mut types = std::collections::BTreeSet::new();
+            types.insert(*target);
+            let filter = EventFilter::Only { types };
+
+            // Create one event per variant
+            let mut msgs: Vec<Message> = all_variants
+                .iter()
+                .map(|et| make_event_msg("r", *et))
+                .collect();
+            apply_event_filter(&mut msgs, &filter);
+
+            assert_eq!(
+                msgs.len(),
+                1,
+                "Only{{{}}} should keep exactly 1 event, got {}",
+                target,
+                msgs.len()
+            );
+            match &msgs[0] {
+                Message::Event { event_type, .. } => {
+                    assert_eq!(event_type, target, "surviving event should be {target}");
+                }
+                other => panic!("expected Event, got {:?}", other),
+            }
+        }
+    }
+
+    #[test]
+    fn per_room_filter_non_taskboard_types() {
+        // Persist a filter map with Only{StatusChanged} for the test room
+        let state_dir = crate::paths::room_state_dir();
+        let _ = std::fs::create_dir_all(&state_dir);
+        let room_id = format!("test-per-room-nontb-{}", std::process::id());
+        let ef_path = crate::paths::broker_event_filters_path(&state_dir, &room_id);
+
+        let mut map = std::collections::HashMap::new();
+        let mut types = std::collections::BTreeSet::new();
+        types.insert(room_protocol::EventType::StatusChanged);
+        map.insert("alice".to_string(), EventFilter::Only { types });
+        let json = serde_json::to_string_pretty(&map).unwrap();
+        std::fs::write(&ef_path, json).unwrap();
+
+        let mut msgs = vec![
+            make_event_msg(&room_id, room_protocol::EventType::StatusChanged),
+            make_event_msg(&room_id, room_protocol::EventType::TaskPosted),
+            make_event_msg(&room_id, room_protocol::EventType::ReviewRequested),
+            make_message(&room_id, "bob", "hello"),
+        ];
+        apply_per_room_event_filter(&mut msgs, &[room_id.clone()], "alice");
+
+        // StatusChanged passes, TaskPosted + ReviewRequested filtered, "hello" passes (non-event)
+        assert_eq!(msgs.len(), 2);
+        let event_types: Vec<_> = msgs
+            .iter()
+            .filter_map(|m| match m {
+                Message::Event { event_type, .. } => Some(*event_type),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(event_types, vec![room_protocol::EventType::StatusChanged]);
+
+        let _ = std::fs::remove_file(&ef_path);
+    }
+
+    #[test]
     fn load_user_event_filter_missing_file_returns_all() {
         let ef = load_user_event_filter("nonexistent-room-ef-test", "alice");
         assert_eq!(ef, EventFilter::All);

--- a/crates/room-cli/tests/events.rs
+++ b/crates/room-cli/tests/events.rs
@@ -415,6 +415,58 @@ async fn events_visible_in_rest_poll() {
         .contains("rest poll test"));
 }
 
+/// Event seq < System seq ordering guarantee holds over WebSocket transport.
+///
+/// The UDS-only test `event_seq_numbers_are_monotonic` verifies this over Unix
+/// sockets. This test extends that guarantee to the WebSocket transport.
+#[tokio::test]
+async fn event_seq_ordering_over_websocket() {
+    let (td, port) = common::TestDaemon::start_with_ws_configs(vec![("ev-ws-ord", None)]).await;
+
+    // UDS client triggers the event
+    let mut alice = DaemonClient::connect(&td.socket_path, "ev-ws-ord", "alice").await;
+    alice
+        .recv_until(|m| matches!(m, Message::Join { user, .. } if user == "alice"))
+        .await;
+
+    // WS client observes it
+    let (_ws_tx, mut ws_rx) = common::ws_connect(port, "ev-ws-ord", "bob").await;
+    common::ws_recv_until(
+        &mut ws_rx,
+        |m| matches!(m, Message::Join { user, .. } if user == "bob"),
+    )
+    .await;
+    alice
+        .recv_until(|m| matches!(m, Message::Join { user, .. } if user == "bob"))
+        .await;
+
+    // Alice posts a task via UDS
+    send_taskboard_cmd(&mut alice, "post", &["ws", "ordering", "test"]).await;
+
+    // WS client: Event arrives first (lower seq), then System (higher seq)
+    let ws_evt = common::ws_recv_until(
+        &mut ws_rx,
+        |m| matches!(m, Message::Event { event_type, .. } if *event_type == EventType::TaskPosted),
+    )
+    .await;
+
+    let ws_sys = common::ws_recv_until(&mut ws_rx, |m| {
+        matches!(m,
+            Message::System { user, content, .. }
+            if user == "plugin:taskboard" && content.contains("tb-001")
+        )
+    })
+    .await;
+
+    let evt_seq = ws_evt.seq().expect("WS event should have seq");
+    let sys_seq = ws_sys.seq().expect("WS system msg should have seq");
+
+    assert!(
+        evt_seq < sys_seq,
+        "WS event seq ({evt_seq}) should be < system seq ({sys_seq})"
+    );
+}
+
 /// Event JSON wire format has correct structure when received via REST.
 #[tokio::test]
 async fn event_wire_format_is_correct() {


### PR DESCRIPTION
## Summary

- Added 5 tests covering EventFilter gaps from #549 P1 audit
- 3 unit tests in `filter_events.rs`: non-taskboard event type filtering, exhaustive all-11-variants coverage, per-room filtering with persisted non-taskboard types
- 1 unit test in `persistence.rs`: save/load round-trip with `Only{StatusChanged, ReviewRequested}` filter
- 1 integration test in `events.rs`: Event→System seq ordering guarantee over WebSocket transport

## Test plan

- [x] `cargo check` passes
- [x] `cargo fmt` clean
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — all tests pass (5 new tests)

Closes #579