### PR TITLE
fix(tui): status/system text appearing in user list panel (#656)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **tui:** Status/system message text no longer appears as fake users in the member panel.
+  Commas in status text caused the `/who` parser to split status fragments into separate
+  usernames. Fixed by sanitizing commas in broker output and adding parser-side validation. (#656)
 - **tui:** Show partial messages at viewport bottom when scrolling — previously the entire
   message disappeared when its bottom line scrolled off screen. (#644)
 

--- a/crates/room-cli/src/broker/commands.rs
+++ b/crates/room-cli/src/broker/commands.rs
@@ -109,7 +109,17 @@ async fn handle_who(state: &RoomState) -> anyhow::Result<CommandResult> {
         .status_entries()
         .await
         .into_iter()
-        .map(|(u, s)| if s.is_empty() { u } else { format!("{u}: {s}") })
+        .map(|(u, s)| {
+            if s.is_empty() {
+                u
+            } else {
+                // Sanitize commas in status text so the TUI parser
+                // (which splits on ", ") doesn't treat status fragments
+                // as separate usernames (#656).
+                let safe = s.replace(", ", "; ");
+                format!("{u}: {safe}")
+            }
+        })
         .collect();
     let content = if entries.is_empty() {
         "no users online".to_owned()
@@ -750,6 +760,33 @@ mod tests {
             panic!("expected Reply");
         };
         assert!(json.contains("reviewing PR"));
+    }
+
+    #[tokio::test]
+    async fn route_command_who_sanitizes_commas_in_status() {
+        let tmp = NamedTempFile::new().unwrap();
+        let state = make_state(tmp.path().to_path_buf());
+        {
+            let mut map = state.status_map.lock().await;
+            map.insert("alice".to_owned(), "PR #630 merged, #636 filed".to_owned());
+            map.insert("bob".to_owned(), String::new());
+        }
+        let msg = make_command("test-room", "alice", "who", vec![]);
+        let CommandResult::Reply(json) = route_command(msg, "alice", &state).await.unwrap() else {
+            panic!("expected Reply");
+        };
+        // The comma in the status must be replaced so the TUI parser
+        // doesn't treat "#636 filed" as a separate username (#656).
+        assert!(
+            !json.contains("PR #630 merged, #636"),
+            "raw comma must be sanitized: {json}"
+        );
+        assert!(
+            json.contains("PR #630 merged; #636 filed"),
+            "comma should be replaced with semicolon: {json}"
+        );
+        // bob should still appear as a separate entry
+        assert!(json.contains("bob"), "bob should be listed: {json}");
     }
 
     // ── route_command: admin permission gating ────────────────────────────

--- a/crates/room-cli/src/tui/mod.rs
+++ b/crates/room-cli/src/tui/mod.rs
@@ -1362,4 +1362,44 @@ mod tests {
         // alice should still be online
         assert!(tab.online_users.contains(&"alice".to_owned()));
     }
+
+    // ── #656 regression: status commas must not leak fake users ────────
+
+    #[tokio::test]
+    async fn process_message_who_with_comma_status_no_fake_users() {
+        let (_, rx) = mpsc::unbounded_channel();
+        let (_, wh) = tokio::net::UnixStream::pair().unwrap().1.into_split();
+        let mut tab = RoomTab {
+            room_id: "test".into(),
+            messages: Vec::new(),
+            online_users: Vec::new(),
+            user_statuses: HashMap::new(),
+            subscription_tiers: HashMap::new(),
+            unread_count: 0,
+            scroll_offset: 0,
+            msg_rx: rx,
+            write_half: wh,
+        };
+        let mut cm = ColorMap::new();
+
+        // Simulate a /who response where alice's status contains a comma.
+        // The broker should sanitize this, but even if it doesn't, the
+        // parser must not treat "#636 filed" as a username.
+        tab.process_message(
+            make_system("online \u{2014} alice: PR #630 merged, #636 filed, bob"),
+            &mut cm,
+            true,
+        );
+        assert_eq!(
+            tab.online_users.len(),
+            2,
+            "only alice and bob are real users"
+        );
+        assert!(tab.online_users.contains(&"alice".to_owned()));
+        assert!(tab.online_users.contains(&"bob".to_owned()));
+        assert!(
+            !tab.online_users.contains(&"#636 filed".to_owned()),
+            "status fragment must not appear as a user"
+        );
+    }
 }

--- a/crates/room-cli/src/tui/parse.rs
+++ b/crates/room-cli/src/tui/parse.rs
@@ -94,12 +94,16 @@ pub(super) fn seed_online_users_from_who(
                 Some((u, s)) => (u.trim().to_owned(), s.trim().to_owned()),
                 None => (entry.trim().to_owned(), String::new()),
             };
-            if !username.is_empty() {
-                if !online_users.contains(&username) {
-                    online_users.push(username.clone());
-                }
-                user_statuses.insert(username, status);
+            // Usernames never contain spaces. If a bare entry (no ": ")
+            // contains whitespace, it is a status-text fragment leaked by
+            // a comma in the status string — skip it (#656).
+            if username.is_empty() || username.contains(' ') {
+                continue;
             }
+            if !online_users.contains(&username) {
+                online_users.push(username.clone());
+            }
+            user_statuses.insert(username, status);
         }
     }
 }
@@ -199,6 +203,33 @@ mod tests {
     #[test]
     fn seed_who_does_not_duplicate_existing_users() {
         let mut users = vec!["alice".to_owned()];
+        let mut statuses = HashMap::new();
+        seed_online_users_from_who("online \u{2014} alice, bob", &mut users, &mut statuses);
+        assert_eq!(users, ["alice", "bob"]);
+    }
+
+    #[test]
+    fn seed_who_rejects_bare_entry_with_spaces() {
+        // If the broker ever leaks a raw comma in status text, the parser
+        // must not treat multi-word fragments as usernames (#656).
+        let mut users = Vec::new();
+        let mut statuses = HashMap::new();
+        seed_online_users_from_who(
+            "online \u{2014} alice: PR #630 merged, #636 filed, bob",
+            &mut users,
+            &mut statuses,
+        );
+        assert_eq!(users, ["alice", "bob"]);
+        assert!(
+            !users.contains(&"#636 filed".to_owned()),
+            "status fragment must not appear as a user"
+        );
+    }
+
+    #[test]
+    fn seed_who_single_word_bare_entry_accepted() {
+        // A single word without spaces is a legitimate bare username.
+        let mut users = Vec::new();
         let mut statuses = HashMap::new();
         seed_online_users_from_who("online \u{2014} alice, bob", &mut users, &mut statuses);
         assert_eq!(users, ["alice", "bob"]);


### PR DESCRIPTION
## Summary

- **Root cause:** The `/who` handler joins status entries with `", "` but status text can contain commas (e.g. `"PR #630 merged, #636 filed"`). The TUI parser (`seed_online_users_from_who`) splits on `", "` and treats status fragments like `"#636 filed"` as separate usernames.
- **Broker fix:** Sanitize `", "` → `"; "` in status text before joining `/who` entries (`broker/commands.rs`)
- **Parser defense:** Reject bare entries (no `": "`) that contain spaces — valid usernames never have spaces (`tui/parse.rs`)
- **Tests:** 4 new tests — broker `/who` output sanitization, parser bare-entry rejection, parser single-word acceptance, and end-to-end `process_message` regression

## Test plan

- [x] `cargo check` passes
- [x] `cargo fmt` — no changes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — all tests pass, 4 new tests added
- [x] Regression test verifies `"#636 filed"` is not added to `online_users`

Closes #656
