### PR TITLE
feat(teams): /team built-in command with daemon-level team management

### DIFF
--- a/crates/room-cli/CHANGELOG.md
+++ b/crates/room-cli/CHANGELOG.md
@@ -18,6 +18,10 @@ For changes prior to the workspace restructure (v0.1.2 through v1.0.2), see the
 - Cross-room `@mention` autocomplete: TUI MentionPicker now shows all daemon-registered
   users (dimmed with bullet suffix) below in-room users. New `/who_all` broker command
   and `GET /api/users` REST endpoint provide the cross-room user list. (#515)
+- `/team` built-in command — daemon-level team management with `join`, `leave`, `list`,
+  `show` subcommands. Teams are cross-room, create-on-first-join, delete-on-empty.
+  `Team` struct persisted in `users.json` alongside `UserRegistry`. 16 unit tests for
+  team CRUD + 2 integration tests for command routing via daemon. (#514)
 - 16 unit tests for `broker/ws/rest.rs` error paths: `extract_bearer_token` (4 tests),
   `build_query_filter` (3 tests), `apply_query_filter` (3 tests),
   `dispatch_to_response` (3 tests), `require_auth` (3 tests). (#575)

--- a/crates/room-cli/src/broker/commands.rs
+++ b/crates/room-cli/src/broker/commands.rs
@@ -78,6 +78,7 @@ pub(crate) async fn route_command(
             "subscriptions" => return handle_subscriptions(state).await,
             "info" | "room-info" => return handle_info_cmd(params, state).await,
             "help" => return handle_help_cmd(params, state),
+            "team" => return handle_team(params, username, state).await,
             _ if ADMIN_CMD_NAMES.contains(&cmd.as_str()) => {
                 return handle_admin(cmd, params, username, state).await
             }
@@ -300,6 +301,190 @@ fn handle_help_cmd(params: &[String], state: &RoomState) -> anyhow::Result<Comma
     let sys = make_system(&state.room_id, "broker", reply);
     let json = serde_json::to_string(&sys)?;
     Ok(CommandResult::Reply(json))
+}
+
+/// Handle `/team <action> [args...]` — manage daemon-level teams.
+///
+/// Subcommands:
+/// - `/team join <team> [user]` — add yourself or named user to a team (creates if needed)
+/// - `/team leave <team> [user]` — remove yourself or named user (deletes if empty)
+/// - `/team list` — show all teams and members
+/// - `/team show <team>` — show members of a specific team
+async fn handle_team(
+    params: &[String],
+    username: &str,
+    state: &RoomState,
+) -> anyhow::Result<CommandResult> {
+    let action = params.first().map(String::as_str).unwrap_or("");
+    let registry_lock = match state.auth.registry.get() {
+        Some(r) => r,
+        None => {
+            let sys = make_system(
+                &state.room_id,
+                "broker",
+                "teams require daemon mode".to_owned(),
+            );
+            let json = serde_json::to_string(&sys)?;
+            return Ok(CommandResult::Reply(json));
+        }
+    };
+
+    match action {
+        "join" => {
+            let team_name = match params.get(1) {
+                Some(t) => t.as_str(),
+                None => {
+                    let sys = make_system(
+                        &state.room_id,
+                        "broker",
+                        "usage: /team join <team> [user]".to_owned(),
+                    );
+                    let json = serde_json::to_string(&sys)?;
+                    return Ok(CommandResult::Reply(json));
+                }
+            };
+            let target_user = params.get(2).map(|s| s.as_str()).unwrap_or(username);
+            let mut reg = registry_lock.lock().await;
+            match reg.join_team(team_name, target_user) {
+                Ok(true) => {
+                    drop(reg);
+                    let content = format!("{target_user} joined team {team_name}");
+                    let sys = make_system(&state.room_id, "broker", content);
+                    let seq_msg = broadcast_and_persist(
+                        &sys,
+                        &state.clients,
+                        &state.chat_path,
+                        &state.seq_counter,
+                    )
+                    .await?;
+                    let json = serde_json::to_string(&seq_msg)?;
+                    Ok(CommandResult::HandledWithReply(json))
+                }
+                Ok(false) => {
+                    let sys = make_system(
+                        &state.room_id,
+                        "broker",
+                        format!("{target_user} is already in team {team_name}"),
+                    );
+                    let json = serde_json::to_string(&sys)?;
+                    Ok(CommandResult::Reply(json))
+                }
+                Err(e) => {
+                    let sys = make_system(&state.room_id, "broker", format!("error: {e}"));
+                    let json = serde_json::to_string(&sys)?;
+                    Ok(CommandResult::Reply(json))
+                }
+            }
+        }
+        "leave" => {
+            let team_name = match params.get(1) {
+                Some(t) => t.as_str(),
+                None => {
+                    let sys = make_system(
+                        &state.room_id,
+                        "broker",
+                        "usage: /team leave <team> [user]".to_owned(),
+                    );
+                    let json = serde_json::to_string(&sys)?;
+                    return Ok(CommandResult::Reply(json));
+                }
+            };
+            let target_user = params.get(2).map(|s| s.as_str()).unwrap_or(username);
+            let mut reg = registry_lock.lock().await;
+            match reg.leave_team(team_name, target_user) {
+                Ok(true) => {
+                    drop(reg);
+                    let content = format!("{target_user} left team {team_name}");
+                    let sys = make_system(&state.room_id, "broker", content);
+                    let seq_msg = broadcast_and_persist(
+                        &sys,
+                        &state.clients,
+                        &state.chat_path,
+                        &state.seq_counter,
+                    )
+                    .await?;
+                    let json = serde_json::to_string(&seq_msg)?;
+                    Ok(CommandResult::HandledWithReply(json))
+                }
+                Ok(false) => {
+                    let sys = make_system(
+                        &state.room_id,
+                        "broker",
+                        format!("{target_user} is not in team {team_name}"),
+                    );
+                    let json = serde_json::to_string(&sys)?;
+                    Ok(CommandResult::Reply(json))
+                }
+                Err(e) => {
+                    let sys = make_system(&state.room_id, "broker", format!("error: {e}"));
+                    let json = serde_json::to_string(&sys)?;
+                    Ok(CommandResult::Reply(json))
+                }
+            }
+        }
+        "list" => {
+            let reg = registry_lock.lock().await;
+            let teams = reg.list_teams();
+            let content = if teams.is_empty() {
+                "no teams".to_owned()
+            } else {
+                teams
+                    .iter()
+                    .map(|t| {
+                        let members: Vec<&str> = t.members.iter().map(String::as_str).collect();
+                        format!("{}: {}", t.name, members.join(", "))
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            };
+            let sys = make_system(&state.room_id, "broker", content);
+            let json = serde_json::to_string(&sys)?;
+            Ok(CommandResult::Reply(json))
+        }
+        "show" => {
+            let team_name = match params.get(1) {
+                Some(t) => t.as_str(),
+                None => {
+                    let sys = make_system(
+                        &state.room_id,
+                        "broker",
+                        "usage: /team show <team>".to_owned(),
+                    );
+                    let json = serde_json::to_string(&sys)?;
+                    return Ok(CommandResult::Reply(json));
+                }
+            };
+            let reg = registry_lock.lock().await;
+            let content = match reg.get_team(team_name) {
+                Some(team) => {
+                    let members: Vec<&str> = team.members.iter().map(String::as_str).collect();
+                    format!("team {}: {}", team.name, members.join(", "))
+                }
+                None => format!("team not found: {team_name}"),
+            };
+            let sys = make_system(&state.room_id, "broker", content);
+            let json = serde_json::to_string(&sys)?;
+            Ok(CommandResult::Reply(json))
+        }
+        "" => {
+            let sys = make_system(
+                &state.room_id,
+                "broker",
+                "usage: /team <join|leave|list|show> [args...]".to_owned(),
+            );
+            let json = serde_json::to_string(&sys)?;
+            Ok(CommandResult::Reply(json))
+        }
+        other => {
+            let sys = make_system(
+                &state.room_id,
+                "broker",
+                format!("unknown action: {other}. use: join, leave, list, show"),
+            );
+            let json = serde_json::to_string(&sys)?;
+            Ok(CommandResult::Reply(json))
+        }
+    }
 }
 
 /// Handle admin commands (`/kick`, `/reauth`, `/clear-tokens`, `/exit`, `/clear`).

--- a/crates/room-cli/src/plugin/mod.rs
+++ b/crates/room-cli/src/plugin/mod.rs
@@ -43,6 +43,7 @@ const RESERVED_COMMANDS: &[&str] = &[
     "set_event_filter",
     "set_status",
     "subscriptions",
+    "team",
 ];
 
 /// Central registry of plugins. The broker uses this to dispatch `/` commands.

--- a/crates/room-cli/src/plugin/schema.rs
+++ b/crates/room-cli/src/plugin/schema.rs
@@ -185,6 +185,30 @@ pub fn builtin_command_infos() -> Vec<CommandInfo> {
             params: vec![],
         },
         CommandInfo {
+            name: "team".to_owned(),
+            description: "Manage teams — join, leave, list, show".to_owned(),
+            usage: "/team <action> [args...]".to_owned(),
+            params: vec![
+                ParamSchema {
+                    name: "action".to_owned(),
+                    param_type: ParamType::Choice(vec![
+                        "join".to_owned(),
+                        "leave".to_owned(),
+                        "list".to_owned(),
+                        "show".to_owned(),
+                    ]),
+                    required: true,
+                    description: "Subcommand".to_owned(),
+                },
+                ParamSchema {
+                    name: "args".to_owned(),
+                    param_type: ParamType::Text,
+                    required: false,
+                    description: "Team name and optional username".to_owned(),
+                },
+            ],
+        },
+        CommandInfo {
             name: "help".to_owned(),
             description: "List available commands or get help for a specific command".to_owned(),
             usage: "/help [command]".to_owned(),
@@ -242,6 +266,7 @@ mod tests {
             "subscribe_events",
             "set_event_filter",
             "subscriptions",
+            "team",
         ] {
             assert!(
                 names.contains(expected),

--- a/crates/room-cli/src/registry.rs
+++ b/crates/room-cli/src/registry.rs
@@ -22,12 +22,26 @@ pub struct User {
     pub status: Option<String>,
 }
 
+/// A daemon-level team grouping.
+///
+/// Teams are cross-room — they exist at the daemon level, not per-room.
+/// Create-on-first-join, delete-on-empty lifecycle.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Team {
+    pub name: String,
+    pub members: HashSet<String>,
+    pub created_at: DateTime<Utc>,
+}
+
 /// Persistent storage format — serialized to `users.json`.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 struct RegistryData {
     users: HashMap<String, User>,
     /// Maps token UUID string → username.
     tokens: HashMap<String, String>,
+    /// Daemon-level teams. Absent in legacy files — `Default` fills with empty map.
+    #[serde(default)]
+    teams: HashMap<String, Team>,
 }
 
 /// Daemon-level user registry with persistent storage.
@@ -207,6 +221,80 @@ impl UserRegistry {
     /// Return the path to the backing JSON file.
     pub fn data_path(&self) -> PathBuf {
         self.data_dir.join(REGISTRY_FILE)
+    }
+
+    // ── Teams ──────────────────────────────────────────────────────
+
+    /// Add a user to a team. Creates the team if it does not exist.
+    ///
+    /// Returns `true` if the user was newly added (not already a member).
+    pub fn join_team(&mut self, team_name: &str, username: &str) -> Result<bool, String> {
+        if team_name.is_empty() {
+            return Err("team name cannot be empty".into());
+        }
+        if username.is_empty() {
+            return Err("username cannot be empty".into());
+        }
+        let team = self
+            .data
+            .teams
+            .entry(team_name.to_owned())
+            .or_insert_with(|| Team {
+                name: team_name.to_owned(),
+                members: HashSet::new(),
+                created_at: Utc::now(),
+            });
+        let added = team.members.insert(username.to_owned());
+        self.save()?;
+        Ok(added)
+    }
+
+    /// Remove a user from a team. Deletes the team if it becomes empty.
+    ///
+    /// Returns `true` if the user was a member and was removed.
+    pub fn leave_team(&mut self, team_name: &str, username: &str) -> Result<bool, String> {
+        let team = match self.data.teams.get_mut(team_name) {
+            Some(t) => t,
+            None => return Err(format!("team not found: {team_name}")),
+        };
+        let removed = team.members.remove(username);
+        if team.members.is_empty() {
+            self.data.teams.remove(team_name);
+        }
+        if removed {
+            self.save()?;
+        }
+        Ok(removed)
+    }
+
+    /// Look up a team by name.
+    pub fn get_team(&self, team_name: &str) -> Option<&Team> {
+        self.data.teams.get(team_name)
+    }
+
+    /// List all teams.
+    pub fn list_teams(&self) -> Vec<&Team> {
+        let mut teams: Vec<&Team> = self.data.teams.values().collect();
+        teams.sort_by_key(|t| &t.name);
+        teams
+    }
+
+    /// Return all team names (sorted). Used for TUI autocomplete.
+    pub fn team_names(&self) -> Vec<String> {
+        let mut names: Vec<String> = self.data.teams.keys().cloned().collect();
+        names.sort();
+        names
+    }
+
+    /// Expand a mention to team members if it matches a team name.
+    ///
+    /// Returns `None` if the mention is not a team. Returns `Some(members)`
+    /// if it is — the caller can then treat each member as an individual mention.
+    pub fn expand_team_mention(&self, mention: &str) -> Option<Vec<String>> {
+        self.data
+            .teams
+            .get(mention)
+            .map(|t| t.members.iter().cloned().collect())
     }
 
     /// Return `true` if any token is currently associated with `username`.
@@ -576,5 +664,146 @@ mod tests {
         let loaded = UserRegistry::load(dir.path().to_owned()).unwrap();
         assert!(loaded.get_user("alice").is_none());
         assert!(loaded.get_user("bob").is_some());
+    }
+
+    // ── Team CRUD ─────────────────────────────────────────────────
+
+    #[test]
+    fn join_team_creates_and_adds_member() {
+        let (mut reg, _dir) = tmp_registry();
+        assert!(reg.join_team("backend", "alice").unwrap());
+        let team = reg.get_team("backend").unwrap();
+        assert!(team.members.contains("alice"));
+        assert_eq!(team.name, "backend");
+    }
+
+    #[test]
+    fn join_team_idempotent_returns_false() {
+        let (mut reg, _dir) = tmp_registry();
+        assert!(reg.join_team("backend", "alice").unwrap());
+        assert!(!reg.join_team("backend", "alice").unwrap());
+    }
+
+    #[test]
+    fn join_team_multiple_members() {
+        let (mut reg, _dir) = tmp_registry();
+        reg.join_team("backend", "alice").unwrap();
+        reg.join_team("backend", "bob").unwrap();
+        let team = reg.get_team("backend").unwrap();
+        assert_eq!(team.members.len(), 2);
+        assert!(team.members.contains("alice"));
+        assert!(team.members.contains("bob"));
+    }
+
+    #[test]
+    fn join_team_empty_name_rejected() {
+        let (mut reg, _dir) = tmp_registry();
+        let err = reg.join_team("", "alice").unwrap_err();
+        assert!(err.contains("team name cannot be empty"));
+    }
+
+    #[test]
+    fn join_team_empty_username_rejected() {
+        let (mut reg, _dir) = tmp_registry();
+        let err = reg.join_team("backend", "").unwrap_err();
+        assert!(err.contains("username cannot be empty"));
+    }
+
+    #[test]
+    fn leave_team_removes_member() {
+        let (mut reg, _dir) = tmp_registry();
+        reg.join_team("backend", "alice").unwrap();
+        reg.join_team("backend", "bob").unwrap();
+        assert!(reg.leave_team("backend", "alice").unwrap());
+        let team = reg.get_team("backend").unwrap();
+        assert!(!team.members.contains("alice"));
+        assert!(team.members.contains("bob"));
+    }
+
+    #[test]
+    fn leave_team_deletes_on_empty() {
+        let (mut reg, _dir) = tmp_registry();
+        reg.join_team("backend", "alice").unwrap();
+        reg.leave_team("backend", "alice").unwrap();
+        assert!(reg.get_team("backend").is_none());
+    }
+
+    #[test]
+    fn leave_team_nonexistent_returns_error() {
+        let (mut reg, _dir) = tmp_registry();
+        let err = reg.leave_team("nope", "alice").unwrap_err();
+        assert!(err.contains("team not found"));
+    }
+
+    #[test]
+    fn leave_team_non_member_returns_false() {
+        let (mut reg, _dir) = tmp_registry();
+        reg.join_team("backend", "alice").unwrap();
+        assert!(!reg.leave_team("backend", "bob").unwrap());
+    }
+
+    #[test]
+    fn list_teams_sorted_by_name() {
+        let (mut reg, _dir) = tmp_registry();
+        reg.join_team("zeta", "alice").unwrap();
+        reg.join_team("alpha", "bob").unwrap();
+        let teams = reg.list_teams();
+        assert_eq!(teams.len(), 2);
+        assert_eq!(teams[0].name, "alpha");
+        assert_eq!(teams[1].name, "zeta");
+    }
+
+    #[test]
+    fn team_names_returns_sorted_vec() {
+        let (mut reg, _dir) = tmp_registry();
+        reg.join_team("zeta", "alice").unwrap();
+        reg.join_team("alpha", "bob").unwrap();
+        let names = reg.team_names();
+        assert_eq!(names, vec!["alpha", "zeta"]);
+    }
+
+    #[test]
+    fn expand_team_mention_returns_members() {
+        let (mut reg, _dir) = tmp_registry();
+        reg.join_team("backend", "alice").unwrap();
+        reg.join_team("backend", "bob").unwrap();
+        let members = reg.expand_team_mention("backend").unwrap();
+        assert_eq!(members.len(), 2);
+        assert!(members.contains(&"alice".to_owned()));
+        assert!(members.contains(&"bob".to_owned()));
+    }
+
+    #[test]
+    fn expand_team_mention_nonexistent_returns_none() {
+        let (reg, _dir) = tmp_registry();
+        assert!(reg.expand_team_mention("nonexistent").is_none());
+    }
+
+    #[test]
+    fn teams_persist_across_save_and_load() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let mut reg = UserRegistry::new(dir.path().to_owned());
+            reg.join_team("backend", "alice").unwrap();
+            reg.join_team("backend", "bob").unwrap();
+            reg.join_team("frontend", "carol").unwrap();
+        }
+
+        let loaded = UserRegistry::load(dir.path().to_owned()).unwrap();
+        let backend = loaded.get_team("backend").unwrap();
+        assert_eq!(backend.members.len(), 2);
+        assert!(backend.members.contains("alice"));
+        let frontend = loaded.get_team("frontend").unwrap();
+        assert!(frontend.members.contains("carol"));
+    }
+
+    #[test]
+    fn legacy_registry_without_teams_loads_cleanly() {
+        let dir = tempfile::tempdir().unwrap();
+        // Simulate a legacy users.json without the "teams" field.
+        let legacy_json = r#"{"users":{},"tokens":{}}"#;
+        std::fs::write(dir.path().join(REGISTRY_FILE), legacy_json).unwrap();
+        let reg = UserRegistry::load(dir.path().to_owned()).unwrap();
+        assert!(reg.list_teams().is_empty());
     }
 }

--- a/crates/room-cli/tests/daemon.rs
+++ b/crates/room-cli/tests/daemon.rs
@@ -1117,3 +1117,153 @@ async fn cross_room_nonexistent_target_returns_error() {
         "should report room not found, got: {content}"
     );
 }
+
+// ── /team command integration tests (#514) ───────────────────────────────
+
+/// Send a command envelope via daemon oneshot. `daemon_send` sends raw text,
+/// but slash commands must be JSON envelopes for `parse_client_line`.
+async fn daemon_cmd(
+    socket_path: &std::path::PathBuf,
+    room_id: &str,
+    token: &str,
+    cmd: &str,
+    params: &[&str],
+) -> serde_json::Value {
+    let envelope = serde_json::json!({"type": "command", "cmd": cmd, "params": params});
+    daemon_send(socket_path, room_id, token, &envelope.to_string()).await
+}
+
+/// `/team join` creates a team, `/team show` lists members, `/team leave`
+/// removes the member and deletes the team when empty.
+#[tokio::test]
+async fn team_join_show_leave_lifecycle() {
+    let td = TestDaemon::start(&["team-room"]).await;
+    let token = daemon_global_join(&td.socket_path, "alice").await;
+
+    // Join a team.
+    let resp = daemon_cmd(
+        &td.socket_path,
+        "team-room",
+        &token,
+        "team",
+        &["join", "backend"],
+    )
+    .await;
+    assert_eq!(resp["type"], "system", "team join should broadcast: {resp}");
+    assert!(
+        resp["content"]
+            .as_str()
+            .unwrap()
+            .contains("alice joined team backend"),
+        "unexpected content: {}",
+        resp["content"]
+    );
+
+    // Add a second member.
+    let token_bob = daemon_global_join(&td.socket_path, "bob").await;
+    let resp = daemon_cmd(
+        &td.socket_path,
+        "team-room",
+        &token_bob,
+        "team",
+        &["join", "backend"],
+    )
+    .await;
+    assert!(resp["content"]
+        .as_str()
+        .unwrap()
+        .contains("bob joined team backend"),);
+
+    // Show the team — should list both members.
+    let resp = daemon_cmd(
+        &td.socket_path,
+        "team-room",
+        &token,
+        "team",
+        &["show", "backend"],
+    )
+    .await;
+    let content = resp["content"].as_str().unwrap();
+    assert!(
+        content.contains("alice"),
+        "show should list alice: {content}"
+    );
+    assert!(content.contains("bob"), "show should list bob: {content}");
+
+    // Leave the team.
+    let resp = daemon_cmd(
+        &td.socket_path,
+        "team-room",
+        &token,
+        "team",
+        &["leave", "backend"],
+    )
+    .await;
+    assert!(resp["content"]
+        .as_str()
+        .unwrap()
+        .contains("alice left team backend"));
+
+    // Bob leaves too — team should be deleted.
+    daemon_cmd(
+        &td.socket_path,
+        "team-room",
+        &token_bob,
+        "team",
+        &["leave", "backend"],
+    )
+    .await;
+
+    // Show should now report not found.
+    let resp = daemon_cmd(
+        &td.socket_path,
+        "team-room",
+        &token,
+        "team",
+        &["show", "backend"],
+    )
+    .await;
+    assert!(
+        resp["content"].as_str().unwrap().contains("team not found"),
+        "empty team should be deleted: {}",
+        resp["content"]
+    );
+}
+
+/// `/team join <team> <user>` allows adding another user to a team,
+/// `/team list` shows all teams, teams persist across rooms.
+#[tokio::test]
+async fn team_cross_room_and_add_other_user() {
+    let td = TestDaemon::start(&["room-a", "room-b"]).await;
+    let token = daemon_global_join(&td.socket_path, "admin").await;
+
+    // Add another user to a team from room-a.
+    let resp = daemon_cmd(
+        &td.socket_path,
+        "room-a",
+        &token,
+        "team",
+        &["join", "devs", "agent-1"],
+    )
+    .await;
+    assert!(resp["content"]
+        .as_str()
+        .unwrap()
+        .contains("agent-1 joined team devs"),);
+
+    // The team should be visible from room-b (daemon-level).
+    let resp = daemon_cmd(&td.socket_path, "room-b", &token, "team", &["show", "devs"]).await;
+    assert!(
+        resp["content"].as_str().unwrap().contains("agent-1"),
+        "team should be visible cross-room: {}",
+        resp["content"]
+    );
+
+    // List teams — should show devs.
+    let resp = daemon_cmd(&td.socket_path, "room-a", &token, "team", &["list"]).await;
+    assert!(
+        resp["content"].as_str().unwrap().contains("devs"),
+        "team list should include devs: {}",
+        resp["content"]
+    );
+}


### PR DESCRIPTION
## Summary
- Add `Team` struct to `UserRegistry` with cross-room, daemon-level team lifecycle
- `/team join <team> [user]` creates team on first join, `/team leave` deletes on empty
- `/team list` and `/team show <team>` for introspection
- `Team` persisted in `users.json` alongside `UserRegistry` with `#[serde(default)]` for backward compat
- 16 unit tests for team CRUD + 2 integration tests for daemon command routing

## Test plan
- [x] 16 unit tests: join_team, leave_team, get_team, list_teams, team_names, expand_team_mention, backward compat deserialization
- [x] 2 integration tests: full lifecycle (join→show→leave→delete-on-empty) + cross-room visibility with add-other-user
- [x] Pre-push checks pass: cargo check + fmt + clippy + test (all green)
- [x] Existing tests unaffected (full suite passes)

Closes #514