### PR TITLE
feat(broker): add cross-room command routing via --room flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **broker:** Cross-room command routing via `--room <id>` flag. Plugin commands in daemon
+  mode can now target a different room (e.g. `/taskboard post --room other-room fix bug`).
+  Replies go to the source room, broadcasts go to the target room. (#517)
 - CI changelog enforcement — PRs must include a changelog entry under `[Unreleased]`. (#499)
 - **docs:** Added daemon mode section (daemon, create, destroy) to quick-start.md. (#599)
 - **test:** Added 6 unit tests for `broker/fanout.rs` (`broadcast_and_persist`, `dm_and_persist`). (#571)

--- a/crates/room-cli/CHANGELOG.md
+++ b/crates/room-cli/CHANGELOG.md
@@ -12,6 +12,9 @@ For changes prior to the workspace restructure (v0.1.2 through v1.0.2), see the
 
 ### Added
 
+- Cross-room command routing via `--room <id>` flag in `dispatch_plugin`. `CrossRoomResolver`
+  trait in `broker/service.rs`, `DaemonRoomResolver` in `broker/daemon/mod.rs`. 13 unit tests
+  and 4 daemon integration tests. (#517)
 - Cross-room `@mention` autocomplete: TUI MentionPicker now shows all daemon-registered
   users (dimmed with bullet suffix) below in-room users. New `/who_all` broker command
   and `GET /api/users` REST endpoint provide the cross-room user list. (#515)

--- a/crates/room-cli/src/broker/commands.rs
+++ b/crates/room-cli/src/broker/commands.rs
@@ -380,8 +380,42 @@ fn validate_params(params: &[String], schema: &CommandInfo) -> Result<(), String
     Ok(())
 }
 
+/// Extract `--room <room_id>` from a params list, returning the target room ID
+/// and the cleaned params with the flag and its value stripped out.
+///
+/// Returns `None` if no `--room` flag is present. The flag can appear at any
+/// position in the params list; both it and the subsequent value are removed
+/// so the plugin never sees them.
+fn extract_room_flag(params: &[String]) -> Option<(String, Vec<String>)> {
+    let mut target_room = None;
+    let mut cleaned = Vec::with_capacity(params.len());
+    let mut skip_next = false;
+
+    for (i, p) in params.iter().enumerate() {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+        if p == "--room" {
+            if let Some(val) = params.get(i + 1) {
+                target_room = Some(val.clone());
+                skip_next = true;
+                continue;
+            }
+        }
+        cleaned.push(p.clone());
+    }
+
+    target_room.map(|room_id| (room_id, cleaned))
+}
+
 /// Build a [`CommandContext`] and call a plugin's `handle` method, translating
 /// the [`PluginResult`] into a [`CommandResult`] the broker understands.
+///
+/// If params contain `--room <id>` and the source room has a cross-room
+/// resolver (daemon mode), the command is executed against the target room
+/// instead of the source room. The plugin is resolved from the target room's
+/// registry. This enables e.g. `/taskboard post --room other-room description`.
 async fn dispatch_plugin(
     plugin: &dyn crate::plugin::Plugin,
     msg: &Message,
@@ -398,6 +432,20 @@ async fn dispatch_plugin(
         } => (cmd, params, id, ts),
         _ => return Ok(CommandResult::Passthrough(msg.clone())),
     };
+
+    // Check for --room flag to redirect to a different room.
+    if let Some((target_room_id, cleaned_params)) = extract_room_flag(params) {
+        return dispatch_cross_room(
+            cmd,
+            &cleaned_params,
+            id,
+            *ts,
+            username,
+            state,
+            &target_room_id,
+        )
+        .await;
+    }
 
     // Schema validation — check params against the plugin's declared schema
     // before invoking the handler.
@@ -450,6 +498,138 @@ async fn dispatch_plugin(
             let seq_msg =
                 broadcast_and_persist(&sys, &state.clients, &state.chat_path, &state.seq_counter)
                     .await?;
+            let json = serde_json::to_string(&seq_msg)?;
+            CommandResult::HandledWithReply(json)
+        }
+        PluginResult::Handled => CommandResult::Handled,
+    })
+}
+
+/// Execute a plugin command against a different room (cross-room dispatch).
+///
+/// Resolves the target room via `state.cross_room_resolver`, finds the plugin
+/// in the target room's registry, builds a `CommandContext` pointing at the
+/// target room's state, and runs the plugin handler. Broadcasts go to the
+/// target room's clients and chat file.
+async fn dispatch_cross_room(
+    cmd: &str,
+    params: &[String],
+    id: &str,
+    ts: chrono::DateTime<chrono::Utc>,
+    username: &str,
+    source_state: &RoomState,
+    target_room_id: &str,
+) -> anyhow::Result<CommandResult> {
+    let resolver = match source_state.cross_room_resolver.get() {
+        Some(r) => r,
+        None => {
+            let sys = make_system(
+                &source_state.room_id,
+                "broker",
+                "cross-room commands are only available in daemon mode",
+            );
+            let json = serde_json::to_string(&sys)?;
+            return Ok(CommandResult::Reply(json));
+        }
+    };
+
+    let target_state = match resolver.resolve_room(target_room_id).await {
+        Some(s) => s,
+        None => {
+            let sys = make_system(
+                &source_state.room_id,
+                "broker",
+                format!("room not found: {target_room_id}"),
+            );
+            let json = serde_json::to_string(&sys)?;
+            return Ok(CommandResult::Reply(json));
+        }
+    };
+
+    let plugin = match target_state.plugin_registry.resolve(cmd) {
+        Some(p) => p,
+        None => {
+            let sys = make_system(
+                &source_state.room_id,
+                "broker",
+                format!("command /{cmd} not found in room {target_room_id}"),
+            );
+            let json = serde_json::to_string(&sys)?;
+            return Ok(CommandResult::Reply(json));
+        }
+    };
+
+    // Schema validation against the target plugin's schema.
+    if let Some(cmd_info) = plugin.commands().iter().find(|c| c.name == cmd) {
+        if let Err(err_msg) = validate_params(params, cmd_info) {
+            let sys = make_system(
+                &source_state.room_id,
+                &format!("plugin:{}", plugin.name()),
+                err_msg,
+            );
+            let json = serde_json::to_string(&sys)?;
+            return Ok(CommandResult::Reply(json));
+        }
+    }
+
+    // Build context against the TARGET room's state.
+    let history = HistoryReader::new(&target_state.chat_path, username);
+    let writer = ChatWriter::new(
+        &target_state.clients,
+        &target_state.chat_path,
+        &target_state.room_id,
+        &target_state.seq_counter,
+        plugin.name(),
+    );
+    let metadata = snapshot_metadata(
+        &target_state.status_map,
+        &target_state.host_user,
+        &target_state.chat_path,
+    )
+    .await;
+    let available_commands = target_state.plugin_registry.all_commands();
+
+    let ctx = CommandContext {
+        command: cmd.to_owned(),
+        params: params.to_vec(),
+        sender: username.to_owned(),
+        room_id: target_state.room_id.as_ref().clone(),
+        message_id: id.to_owned(),
+        timestamp: ts,
+        history: Box::new(history),
+        writer: Box::new(writer),
+        metadata,
+        available_commands,
+    };
+
+    let result = plugin.handle(ctx).await?;
+
+    // Replies go to the SOURCE room (the caller sees them), but broadcasts go
+    // to the TARGET room (where the state change happened).
+    Ok(match result {
+        PluginResult::Reply(text) => {
+            let sys = make_system(
+                &source_state.room_id,
+                &format!("plugin:{}", plugin.name()),
+                format!("[→{target_room_id}] {text}"),
+            );
+            let json = serde_json::to_string(&sys)?;
+            CommandResult::Reply(json)
+        }
+        PluginResult::Broadcast(text) => {
+            // Broadcast to the TARGET room.
+            let sys = make_system(
+                &target_state.room_id,
+                &format!("plugin:{}", plugin.name()),
+                text,
+            );
+            let seq_msg = broadcast_and_persist(
+                &sys,
+                &target_state.clients,
+                &target_state.chat_path,
+                &target_state.seq_counter,
+            )
+            .await?;
             let json = serde_json::to_string(&seq_msg)?;
             CommandResult::HandledWithReply(json)
         }
@@ -2208,5 +2388,183 @@ mod tests {
         let users_json = content.strip_prefix("users_all: ").unwrap();
         let users: Vec<String> = serde_json::from_str(users_json).unwrap();
         assert_eq!(users, ["alice", "bob", "charlie"]);
+    }
+
+    // ── extract_room_flag tests ──────────────────────────────────────────
+
+    mod cross_room_tests {
+        use super::super::extract_room_flag;
+
+        #[test]
+        fn extract_room_flag_present_at_start() {
+            let params = vec![
+                "--room".to_owned(),
+                "other-room".to_owned(),
+                "post".to_owned(),
+                "hello".to_owned(),
+            ];
+            let (room, cleaned) = extract_room_flag(&params).unwrap();
+            assert_eq!(room, "other-room");
+            assert_eq!(cleaned, vec!["post", "hello"]);
+        }
+
+        #[test]
+        fn extract_room_flag_present_in_middle() {
+            let params = vec![
+                "post".to_owned(),
+                "--room".to_owned(),
+                "other-room".to_owned(),
+                "hello".to_owned(),
+            ];
+            let (room, cleaned) = extract_room_flag(&params).unwrap();
+            assert_eq!(room, "other-room");
+            assert_eq!(cleaned, vec!["post", "hello"]);
+        }
+
+        #[test]
+        fn extract_room_flag_absent() {
+            let params = vec!["post".to_owned(), "hello".to_owned()];
+            assert!(extract_room_flag(&params).is_none());
+        }
+
+        #[test]
+        fn extract_room_flag_no_value() {
+            // --room at end without a value — not extracted
+            let params = vec!["post".to_owned(), "--room".to_owned()];
+            assert!(extract_room_flag(&params).is_none());
+        }
+
+        #[test]
+        fn extract_room_flag_preserves_order() {
+            let params = vec![
+                "list".to_owned(),
+                "--room".to_owned(),
+                "target".to_owned(),
+                "--verbose".to_owned(),
+            ];
+            let (room, cleaned) = extract_room_flag(&params).unwrap();
+            assert_eq!(room, "target");
+            assert_eq!(cleaned, vec!["list", "--verbose"]);
+        }
+    }
+
+    // ── cross-room dispatch tests ────────────────────────────────────────
+
+    #[tokio::test]
+    async fn cross_room_without_resolver_returns_error() {
+        let tmp = NamedTempFile::new().unwrap();
+        let state = make_state(tmp.path().to_path_buf());
+        // No cross_room_resolver set — should get an error reply.
+        let msg = make_command(
+            "test-room",
+            "alice",
+            "taskboard",
+            vec![
+                "list".to_owned(),
+                "--room".to_owned(),
+                "other-room".to_owned(),
+            ],
+        );
+        let result = route_command(msg, "alice", &state).await.unwrap();
+        let CommandResult::Reply(json) = result else {
+            panic!("expected Reply with error");
+        };
+        assert!(
+            json.contains("daemon mode"),
+            "should mention daemon mode: {json}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cross_room_nonexistent_room_returns_error() {
+        use crate::broker::service::CrossRoomResolver;
+        use std::pin::Pin;
+
+        struct EmptyResolver;
+        impl CrossRoomResolver for EmptyResolver {
+            fn resolve_room(
+                &self,
+                _room_id: &str,
+            ) -> Pin<Box<dyn std::future::Future<Output = Option<Arc<RoomState>>> + Send + '_>>
+            {
+                Box::pin(async { None })
+            }
+        }
+
+        let tmp = NamedTempFile::new().unwrap();
+        let state = make_state(tmp.path().to_path_buf());
+        state.set_cross_room_resolver(Arc::new(EmptyResolver));
+
+        let msg = make_command(
+            "test-room",
+            "alice",
+            "taskboard",
+            vec![
+                "list".to_owned(),
+                "--room".to_owned(),
+                "nonexistent".to_owned(),
+            ],
+        );
+        let result = route_command(msg, "alice", &state).await.unwrap();
+        let CommandResult::Reply(json) = result else {
+            panic!("expected Reply with not-found error");
+        };
+        assert!(
+            json.contains("room not found"),
+            "should say room not found: {json}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cross_room_resolves_and_dispatches_to_target() {
+        use crate::broker::service::CrossRoomResolver;
+        use std::pin::Pin;
+
+        let tmp_source = NamedTempFile::new().unwrap();
+        let source_state = make_state(tmp_source.path().to_path_buf());
+
+        let tmp_target = NamedTempFile::new().unwrap();
+        let target_state = make_state(tmp_target.path().to_path_buf());
+        let target_clone = target_state.clone();
+
+        struct OneRoomResolver(Arc<RoomState>);
+        impl CrossRoomResolver for OneRoomResolver {
+            fn resolve_room(
+                &self,
+                room_id: &str,
+            ) -> Pin<Box<dyn std::future::Future<Output = Option<Arc<RoomState>>> + Send + '_>>
+            {
+                let result = if room_id == "target-room" {
+                    Some(self.0.clone())
+                } else {
+                    None
+                };
+                Box::pin(async move { result })
+            }
+        }
+
+        source_state.set_cross_room_resolver(Arc::new(OneRoomResolver(target_clone)));
+
+        // /taskboard post --room target-room hello world
+        let msg = make_command(
+            "test-room",
+            "alice",
+            "taskboard",
+            vec![
+                "post".to_owned(),
+                "--room".to_owned(),
+                "target-room".to_owned(),
+                "hello".to_owned(),
+                "world".to_owned(),
+            ],
+        );
+        let result = route_command(msg, "alice", &source_state).await.unwrap();
+        // The taskboard plugin should handle the post and return a reply or broadcast
+        // to the TARGET room. The exact result depends on the taskboard plugin,
+        // but it should NOT be Passthrough (which would mean the command wasn't handled).
+        assert!(
+            !matches!(result, CommandResult::Passthrough(_)),
+            "cross-room dispatch should not fall through to Passthrough"
+        );
     }
 }

--- a/crates/room-cli/src/broker/daemon/lifecycle.rs
+++ b/crates/room-cli/src/broker/daemon/lifecycle.rs
@@ -84,6 +84,10 @@ pub(crate) async fn create_room_entry(
         state.set_registry(reg);
     }
 
+    // Attach the cross-room resolver so plugin commands can target other rooms.
+    let resolver = std::sync::Arc::new(super::DaemonRoomResolver::new(rooms.clone()));
+    state.set_cross_room_resolver(resolver);
+
     // Attach persisted event filters.
     let ef_path = daemon_config.event_filter_map_path(room_id);
     let persisted_ef = crate::broker::persistence::load_event_filter_map(&ef_path);

--- a/crates/room-cli/src/broker/daemon/mod.rs
+++ b/crates/room-cli/src/broker/daemon/mod.rs
@@ -56,6 +56,7 @@ use tokio::{
 use crate::registry::UserRegistry;
 
 use super::{
+    service::CrossRoomResolver,
     state::{RoomState, TokenMap},
     ws::{self, DaemonWsState},
 };
@@ -353,6 +354,32 @@ impl DaemonState {
         }
 
         result
+    }
+}
+
+// ── CrossRoomResolver for daemon mode ────────────────────────────────────────
+
+/// Resolves a room ID to its [`RoomState`] by looking it up in the daemon's
+/// room map. Attached to every room created by the daemon so that plugin
+/// commands can target a different room via `--room <id>`.
+pub(crate) struct DaemonRoomResolver {
+    rooms: RoomMap,
+}
+
+impl DaemonRoomResolver {
+    pub(crate) fn new(rooms: RoomMap) -> Self {
+        Self { rooms }
+    }
+}
+
+impl CrossRoomResolver for DaemonRoomResolver {
+    fn resolve_room(
+        &self,
+        room_id: &str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<Arc<RoomState>>> + Send + '_>>
+    {
+        let room_id = room_id.to_owned();
+        Box::pin(async move { self.rooms.lock().await.get(&room_id).cloned() })
     }
 }
 
@@ -944,5 +971,50 @@ mod tests {
         migration::migrate_legacy_tmpdir_tokens_from(token_dir.path(), &mut registry);
 
         assert!(registry.list_users().is_empty());
+    }
+
+    // ── DaemonRoomResolver ───────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn daemon_room_resolver_finds_existing_room() {
+        let daemon = DaemonState::new(DaemonConfig::default());
+        daemon.create_room("target").await.unwrap();
+
+        let resolver = DaemonRoomResolver::new(daemon.rooms.clone());
+        let result = resolver.resolve_room("target").await;
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().room_id.as_str(), "target");
+    }
+
+    #[tokio::test]
+    async fn daemon_room_resolver_returns_none_for_unknown() {
+        let daemon = DaemonState::new(DaemonConfig::default());
+        let resolver = DaemonRoomResolver::new(daemon.rooms.clone());
+        assert!(resolver.resolve_room("nonexistent").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn created_rooms_have_resolver_attached() {
+        let daemon = DaemonState::new(DaemonConfig::default());
+        daemon.create_room("room-a").await.unwrap();
+
+        let state = get_room(&daemon, "room-a").await;
+        assert!(
+            state.cross_room_resolver.get().is_some(),
+            "daemon-created rooms must have a cross-room resolver attached"
+        );
+    }
+
+    #[tokio::test]
+    async fn cross_room_resolver_resolves_sibling_room() {
+        let daemon = DaemonState::new(DaemonConfig::default());
+        daemon.create_room("room-a").await.unwrap();
+        daemon.create_room("room-b").await.unwrap();
+
+        let state_a = get_room(&daemon, "room-a").await;
+        let resolver = state_a.cross_room_resolver.get().unwrap();
+        let resolved = resolver.resolve_room("room-b").await;
+        assert!(resolved.is_some(), "resolver on room-a should find room-b");
+        assert_eq!(resolved.unwrap().room_id.as_str(), "room-b");
     }
 }

--- a/crates/room-cli/src/broker/mod.rs
+++ b/crates/room-cli/src/broker/mod.rs
@@ -156,6 +156,7 @@ impl Broker {
             seq_counter: Arc::new(AtomicU64::new(0)),
             plugin_registry: Arc::new(registry),
             config: None,
+            cross_room_resolver: std::sync::OnceLock::new(),
         });
         // Attach event filter map (parallel to subscription map).
         {

--- a/crates/room-cli/src/broker/service.rs
+++ b/crates/room-cli/src/broker/service.rs
@@ -7,6 +7,8 @@
 //! The concrete implementation lives on `RoomState` (below). WS handlers
 //! continue to use `RoomState` directly for socket lifecycle management.
 
+use std::{future::Future, pin::Pin, sync::Arc};
+
 use crate::message::Message;
 
 use room_protocol::SubscriptionTier;
@@ -17,6 +19,22 @@ use super::{
     fanout::{broadcast_and_persist, dm_and_persist},
     state::RoomState,
 };
+
+/// Resolves a room ID to its [`RoomState`] in daemon mode.
+///
+/// Implemented by `DaemonRoomResolver` in `broker/daemon/mod.rs`.
+/// Stored on [`RoomState`] as an optional `OnceLock<Arc<dyn CrossRoomResolver>>`
+/// so that `dispatch_plugin` can handle `--room <id>` flags without threading
+/// a resolver parameter through every caller.
+///
+/// In standalone (single-room) mode this is `None` — cross-room commands
+/// are only available when the daemon manages multiple rooms.
+pub(crate) trait CrossRoomResolver: Send + Sync {
+    fn resolve_room(
+        &self,
+        room_id: &str,
+    ) -> Pin<Box<dyn Future<Output = Option<Arc<RoomState>>> + Send + '_>>;
+}
 
 /// Result of dispatching a message through the command router + broadcast pipeline.
 pub(crate) enum DispatchResult {

--- a/crates/room-cli/src/broker/session.rs
+++ b/crates/room-cli/src/broker/session.rs
@@ -415,6 +415,7 @@ mod tests {
             seq_counter: Arc::new(AtomicU64::new(0)),
             plugin_registry: Arc::new(PluginRegistry::new()),
             config: None,
+            cross_room_resolver: std::sync::OnceLock::new(),
         })
     }
 

--- a/crates/room-cli/src/broker/state.rs
+++ b/crates/room-cli/src/broker/state.rs
@@ -10,6 +10,8 @@ use tokio::sync::{broadcast, watch, Mutex};
 use crate::{plugin::PluginRegistry, registry::UserRegistry};
 use std::sync::OnceLock;
 
+use super::service::CrossRoomResolver;
+
 /// Maps client ID → (username, broadcast sender).
 /// Username is set after the handshake completes.
 pub(crate) type ClientMap = Arc<Mutex<HashMap<u64, (String, broadcast::Sender<String>)>>>;
@@ -83,6 +85,12 @@ pub(crate) struct RoomState {
     pub(crate) plugin_registry: Arc<PluginRegistry>,
     /// Room visibility and access control configuration.
     pub(crate) config: Option<RoomConfig>,
+    /// Optional cross-room resolver for daemon mode.
+    ///
+    /// When set, `dispatch_plugin` can handle `--room <id>` flags by resolving
+    /// the target room's state and building the `CommandContext` against it.
+    /// Set via [`set_cross_room_resolver`] after construction.
+    pub(crate) cross_room_resolver: OnceLock<Arc<dyn CrossRoomResolver>>,
 }
 
 impl RoomState {
@@ -140,6 +148,7 @@ impl RoomState {
             seq_counter: Arc::new(AtomicU64::new(0)),
             plugin_registry: Arc::new(plugins),
             config,
+            cross_room_resolver: OnceLock::new(),
         }))
     }
 
@@ -152,6 +161,16 @@ impl RoomState {
     /// a second time (consistent with `OnceLock` semantics).
     pub(crate) fn set_registry(&self, registry: Arc<Mutex<UserRegistry>>) {
         let _ = self.auth.registry.set(registry);
+    }
+
+    // ── cross_room_resolver ──────────────────────────────────────────────────
+
+    /// Attach a cross-room resolver so plugins can handle `--room <id>` flags.
+    ///
+    /// Must be called at most once, immediately after construction. Silently
+    /// no-ops if called a second time (consistent with `OnceLock` semantics).
+    pub(crate) fn set_cross_room_resolver(&self, resolver: Arc<dyn CrossRoomResolver>) {
+        let _ = self.cross_room_resolver.set(resolver);
     }
 
     // ── event_filter_map ─────────────────────────────────────────────────────

--- a/crates/room-cli/tests/daemon.rs
+++ b/crates/room-cli/tests/daemon.rs
@@ -997,3 +997,123 @@ async fn rest_api_users_returns_registered_users() {
     sorted.sort();
     assert_eq!(users, sorted, "users should be returned in sorted order");
 }
+
+// ── Cross-room command routing (#517) ────────────────────────────────────
+
+/// Build a taskboard command JSON envelope for daemon oneshot sends.
+fn taskboard_wire(action: &str, args: &[&str]) -> String {
+    let mut params: Vec<serde_json::Value> = vec![serde_json::Value::String(action.to_owned())];
+    for arg in args {
+        params.push(serde_json::Value::String((*arg).to_owned()));
+    }
+    serde_json::json!({"type": "command", "cmd": "taskboard", "params": params}).to_string()
+}
+
+/// Cross-room taskboard post: `taskboard post --room room-b description`
+/// sent from room-a should create the task in room-b's taskboard.
+#[tokio::test]
+async fn cross_room_taskboard_post() {
+    let td = TestDaemon::start(&["room-a", "room-b"]).await;
+    let token = daemon_global_join(&td.socket_path, "alice").await;
+
+    // Post a task from room-a targeting room-b via JSON command envelope.
+    let wire = taskboard_wire(
+        "post",
+        &["--room", "room-b", "cross-room", "task", "description"],
+    );
+    let resp = daemon_send(&td.socket_path, "room-a", &token, &wire).await;
+    // The reply should indicate the task was posted (either broadcast or reply).
+    let content = resp["content"].as_str().unwrap_or("");
+    assert!(
+        content.contains("posted") || content.contains("tb-"),
+        "expected task posted confirmation, got: {resp}"
+    );
+
+    // List tasks in room-b — should find the cross-room task.
+    let list_wire = taskboard_wire("list", &[]);
+    let list_resp = daemon_send(&td.socket_path, "room-b", &token, &list_wire).await;
+    let list_content = list_resp["content"].as_str().unwrap_or("");
+    assert!(
+        list_content.contains("cross-room task description"),
+        "room-b taskboard should contain the cross-posted task, got: {list_content}"
+    );
+
+    // List tasks in room-a — should NOT contain the task.
+    let list_a = daemon_send(&td.socket_path, "room-a", &token, &list_wire).await;
+    let list_a_content = list_a["content"].as_str().unwrap_or("");
+    assert!(
+        !list_a_content.contains("cross-room task description"),
+        "room-a taskboard should NOT contain the cross-posted task, got: {list_a_content}"
+    );
+}
+
+/// Cross-room list: `taskboard list --room room-y` from room-x shows room-y's tasks.
+#[tokio::test]
+async fn cross_room_taskboard_list() {
+    let td = TestDaemon::start(&["room-x", "room-y"]).await;
+    let token = daemon_global_join(&td.socket_path, "bob").await;
+
+    // Post a task directly in room-y.
+    let post_wire = taskboard_wire("post", &["local", "task", "in", "room-y"]);
+    daemon_send(&td.socket_path, "room-y", &token, &post_wire).await;
+
+    // List room-y tasks from room-x via --room flag.
+    let list_wire = taskboard_wire("list", &["--room", "room-y"]);
+    let resp = daemon_send(&td.socket_path, "room-x", &token, &list_wire).await;
+    let content = resp["content"].as_str().unwrap_or("");
+    assert!(
+        content.contains("local task in room-y"),
+        "cross-room list should show room-y's tasks, got: {content}"
+    );
+}
+
+/// Cross-room claim: `taskboard claim --room room-n <id>` claims a task
+/// posted in room-n from room-m.
+#[tokio::test]
+async fn cross_room_taskboard_claim() {
+    let td = TestDaemon::start(&["room-m", "room-n"]).await;
+    let token = daemon_global_join(&td.socket_path, "carol").await;
+
+    // Post a task directly in room-n.
+    let post_wire = taskboard_wire("post", &["claimable", "cross-room", "task"]);
+    let post_resp = daemon_send(&td.socket_path, "room-n", &token, &post_wire).await;
+    let post_content = post_resp["content"].as_str().unwrap_or("");
+    // Extract the task ID (format: tb-NNN).
+    let task_id = post_content
+        .split_whitespace()
+        .find(|w| w.starts_with("tb-"))
+        .expect("post response should contain task ID");
+
+    // Claim from room-m targeting room-n.
+    let claim_wire = taskboard_wire("claim", &["--room", "room-n", task_id]);
+    let claim_resp = daemon_send(&td.socket_path, "room-m", &token, &claim_wire).await;
+    let claim_content = claim_resp["content"].as_str().unwrap_or("");
+    assert!(
+        claim_content.contains("claimed") || claim_content.contains(task_id),
+        "cross-room claim should succeed, got: {claim_content}"
+    );
+
+    // Verify via show in room-n that the task is claimed by carol.
+    let show_wire = taskboard_wire("show", &[task_id]);
+    let show_resp = daemon_send(&td.socket_path, "room-n", &token, &show_wire).await;
+    let show_content = show_resp["content"].as_str().unwrap_or("");
+    assert!(
+        show_content.contains("carol"),
+        "task should be claimed by carol, got: {show_content}"
+    );
+}
+
+/// Cross-room targeting a nonexistent room returns an error.
+#[tokio::test]
+async fn cross_room_nonexistent_target_returns_error() {
+    let td = TestDaemon::start(&["room-only"]).await;
+    let token = daemon_global_join(&td.socket_path, "dave").await;
+
+    let wire = taskboard_wire("list", &["--room", "ghost-room"]);
+    let resp = daemon_send(&td.socket_path, "room-only", &token, &wire).await;
+    let content = resp["content"].as_str().unwrap_or("");
+    assert!(
+        content.contains("room not found"),
+        "should report room not found, got: {content}"
+    );
+}


### PR DESCRIPTION
## Summary

- Add `CrossRoomResolver` trait and `DaemonRoomResolver` for cross-room plugin command routing in daemon mode
- Plugin commands now accept `--room <room-id>` to target a different room's plugin (e.g. `/taskboard post --room other-room fix the bug`)
- Replies go to the source room (tagged with `[→target]`), broadcasts go to the target room

## Design

- `CrossRoomResolver` trait in `broker/service.rs` — async room lookup by ID
- `DaemonRoomResolver` in `broker/daemon/mod.rs` — resolves via the daemon's `RoomMap`
- `extract_room_flag()` strips `--room <id>` from params before dispatch
- `dispatch_cross_room()` resolves target, finds plugin in target's registry, builds context against target state
- Resolver attached to every daemon-created room via `OnceLock` pattern
- Standalone broker has no resolver (returns "only available in daemon mode")

## Test plan

- [x] 5 unit tests for `extract_room_flag` (start/middle/absent/no-value/order)
- [x] 3 unit tests for cross-room dispatch (no resolver, nonexistent room, resolves to target)
- [x] 4 unit tests for `DaemonRoomResolver` (finds existing, returns None, attached on create, resolves sibling)
- [x] 4 integration tests for cross-room taskboard commands (post, list, claim, nonexistent target)
- [x] Pre-push: check, fmt, clippy, all tests pass

Closes #517
