### PR TITLE
feat(plugin): add versioning and compatibility system (#512)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **plugin:** Plugin versioning and compatibility system — `version()`, `api_version()`,
+  `min_protocol()` on `Plugin` trait with backward-compatible defaults. Broker rejects
+  incompatible plugins at registration. `PLUGIN_API_VERSION` and `PROTOCOL_VERSION`
+  constants. (#512)
 - **broker:** Cross-room command routing via `--room <id>` flag. Plugin commands in daemon
   mode can now target a different room (e.g. `/taskboard post --room other-room fix bug`).
   Replies go to the source room, broadcasts go to the target room. (#517)

--- a/crates/room-cli/CHANGELOG.md
+++ b/crates/room-cli/CHANGELOG.md
@@ -32,6 +32,10 @@ For changes prior to the workspace restructure (v0.1.2 through v1.0.2), see the
 - 3 DM room semantics integration tests: symmetric ID join+message,
   non-participant poll DirectMessage filtering, offline recipient message
   visibility on rejoin. (#581)
+- Plugin versioning and compatibility: `PluginRegistry::register()` now validates
+  `api_version()` and `min_protocol()` before accepting a plugin. Rejects plugins
+  compiled against a future API or requiring a newer protocol than the running broker.
+  `semver_satisfies()` helper for version comparison. 15 new unit tests. (#512)
 
 ### Changed
 

--- a/crates/room-cli/src/plugin/mod.rs
+++ b/crates/room-cli/src/plugin/mod.rs
@@ -12,7 +12,7 @@ use std::{collections::HashMap, path::Path};
 // imports from `crate::plugin::*` continue to work without changes.
 pub use room_protocol::plugin::{
     BoxFuture, CommandContext, CommandInfo, HistoryAccess, MessageWriter, ParamSchema, ParamType,
-    Plugin, PluginResult, RoomMetadata, UserInfo,
+    Plugin, PluginResult, RoomMetadata, UserInfo, PLUGIN_API_VERSION, PROTOCOL_VERSION,
 };
 
 // Re-export concrete bridge types. ChatWriter and HistoryReader are public
@@ -81,9 +81,29 @@ impl PluginRegistry {
         Ok(registry)
     }
 
-    /// Register a plugin. Returns an error if any command name collides with
-    /// a built-in command or another plugin's command.
+    /// Register a plugin. Returns an error if:
+    /// - any command name collides with a built-in or another plugin's command
+    /// - `api_version()` exceeds the current [`PLUGIN_API_VERSION`]
+    /// - `min_protocol()` is newer than the running [`PROTOCOL_VERSION`]
     pub fn register(&mut self, plugin: Box<dyn Plugin>) -> anyhow::Result<()> {
+        // ── Version compatibility checks ────────────────────────────────
+        let api_v = plugin.api_version();
+        if api_v > PLUGIN_API_VERSION {
+            anyhow::bail!(
+                "plugin '{}' requires api_version {api_v} but broker supports up to {PLUGIN_API_VERSION}",
+                plugin.name(),
+            );
+        }
+
+        let min_proto = plugin.min_protocol();
+        if !semver_satisfies(PROTOCOL_VERSION, min_proto) {
+            anyhow::bail!(
+                "plugin '{}' requires room-protocol >= {min_proto} but broker has {PROTOCOL_VERSION}",
+                plugin.name(),
+            );
+        }
+
+        // ── Command name uniqueness checks ──────────────────────────────
         let idx = self.plugins.len();
         for cmd in plugin.commands() {
             if RESERVED_COMMANDS.contains(&cmd.name.as_str()) {
@@ -159,6 +179,19 @@ impl Default for PluginRegistry {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Returns `true` if `running >= required` using semver major.minor.patch
+/// comparison. Malformed versions are treated as `(0, 0, 0)`.
+fn semver_satisfies(running: &str, required: &str) -> bool {
+    let parse = |s: &str| -> (u64, u64, u64) {
+        let mut parts = s.split('.');
+        let major = parts.next().and_then(|p| p.parse().ok()).unwrap_or(0);
+        let minor = parts.next().and_then(|p| p.parse().ok()).unwrap_or(0);
+        let patch = parts.next().and_then(|p| p.parse().ok()).unwrap_or(0);
+        (major, minor, patch)
+    };
+    parse(running) >= parse(required)
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────────
@@ -554,5 +587,208 @@ mod tests {
         .unwrap();
         // Number params must not produce completions — only Choice does.
         assert!(reg.completions_for("repeat", 0).is_empty());
+    }
+
+    // ── semver_satisfies tests ──────────────────────────────────────────
+
+    #[test]
+    fn semver_satisfies_equal_versions() {
+        assert!(super::semver_satisfies("3.1.0", "3.1.0"));
+    }
+
+    #[test]
+    fn semver_satisfies_running_newer_major() {
+        assert!(super::semver_satisfies("4.0.0", "3.1.0"));
+    }
+
+    #[test]
+    fn semver_satisfies_running_newer_minor() {
+        assert!(super::semver_satisfies("3.2.0", "3.1.0"));
+    }
+
+    #[test]
+    fn semver_satisfies_running_newer_patch() {
+        assert!(super::semver_satisfies("3.1.1", "3.1.0"));
+    }
+
+    #[test]
+    fn semver_satisfies_running_older_fails() {
+        assert!(!super::semver_satisfies("3.0.9", "3.1.0"));
+    }
+
+    #[test]
+    fn semver_satisfies_running_older_major_fails() {
+        assert!(!super::semver_satisfies("2.9.9", "3.0.0"));
+    }
+
+    #[test]
+    fn semver_satisfies_zero_required_always_passes() {
+        assert!(super::semver_satisfies("0.0.1", "0.0.0"));
+        assert!(super::semver_satisfies("3.1.0", "0.0.0"));
+    }
+
+    #[test]
+    fn semver_satisfies_malformed_treated_as_zero() {
+        assert!(super::semver_satisfies("garbage", "0.0.0"));
+        assert!(super::semver_satisfies("3.1.0", "garbage"));
+        assert!(super::semver_satisfies("garbage", "garbage"));
+    }
+
+    // ── Version compatibility in register() ─────────────────────────────
+
+    /// A plugin that reports a future api_version the broker does not support.
+    struct FutureApiPlugin;
+
+    impl Plugin for FutureApiPlugin {
+        fn name(&self) -> &str {
+            "future-api"
+        }
+
+        fn api_version(&self) -> u32 {
+            PLUGIN_API_VERSION + 1
+        }
+
+        fn commands(&self) -> Vec<CommandInfo> {
+            vec![CommandInfo {
+                name: "future".to_owned(),
+                description: "from the future".to_owned(),
+                usage: "/future".to_owned(),
+                params: vec![],
+            }]
+        }
+
+        fn handle(&self, _ctx: CommandContext) -> BoxFuture<'_, anyhow::Result<PluginResult>> {
+            Box::pin(async { Ok(PluginResult::Handled) })
+        }
+    }
+
+    #[test]
+    fn register_rejects_future_api_version() {
+        let mut reg = PluginRegistry::new();
+        let result = reg.register(Box::new(FutureApiPlugin));
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("api_version"),
+            "error should mention api_version: {err}"
+        );
+        assert!(
+            err.contains("future-api"),
+            "error should mention plugin name: {err}"
+        );
+    }
+
+    /// A plugin that requires a protocol version newer than what we have.
+    struct FutureProtocolPlugin;
+
+    impl Plugin for FutureProtocolPlugin {
+        fn name(&self) -> &str {
+            "future-proto"
+        }
+
+        fn min_protocol(&self) -> &str {
+            "99.0.0"
+        }
+
+        fn commands(&self) -> Vec<CommandInfo> {
+            vec![CommandInfo {
+                name: "proto".to_owned(),
+                description: "needs future protocol".to_owned(),
+                usage: "/proto".to_owned(),
+                params: vec![],
+            }]
+        }
+
+        fn handle(&self, _ctx: CommandContext) -> BoxFuture<'_, anyhow::Result<PluginResult>> {
+            Box::pin(async { Ok(PluginResult::Handled) })
+        }
+    }
+
+    #[test]
+    fn register_rejects_incompatible_min_protocol() {
+        let mut reg = PluginRegistry::new();
+        let result = reg.register(Box::new(FutureProtocolPlugin));
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("room-protocol"),
+            "error should mention room-protocol: {err}"
+        );
+        assert!(
+            err.contains("99.0.0"),
+            "error should mention required version: {err}"
+        );
+    }
+
+    #[test]
+    fn register_accepts_compatible_versioned_plugin() {
+        let mut reg = PluginRegistry::new();
+        // DummyPlugin uses defaults: api_version=1, min_protocol="0.0.0"
+        let result = reg.register(Box::new(DummyPlugin {
+            name: "compat",
+            cmd: "compat_cmd",
+        }));
+        assert!(result.is_ok());
+        assert!(reg.resolve("compat_cmd").is_some());
+    }
+
+    #[test]
+    fn register_version_check_runs_before_command_check() {
+        // A plugin with a future api_version AND a reserved command name.
+        // The api_version check should fire first.
+        struct DoubleBadPlugin;
+
+        impl Plugin for DoubleBadPlugin {
+            fn name(&self) -> &str {
+                "double-bad"
+            }
+
+            fn api_version(&self) -> u32 {
+                PLUGIN_API_VERSION + 1
+            }
+
+            fn commands(&self) -> Vec<CommandInfo> {
+                vec![CommandInfo {
+                    name: "kick".to_owned(),
+                    description: "bad".to_owned(),
+                    usage: "/kick".to_owned(),
+                    params: vec![],
+                }]
+            }
+
+            fn handle(&self, _ctx: CommandContext) -> BoxFuture<'_, anyhow::Result<PluginResult>> {
+                Box::pin(async { Ok(PluginResult::Handled) })
+            }
+        }
+
+        let mut reg = PluginRegistry::new();
+        let result = reg.register(Box::new(DoubleBadPlugin));
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        // Should fail on api_version, not on the reserved command
+        assert!(
+            err.contains("api_version"),
+            "should reject on api_version first: {err}"
+        );
+    }
+
+    #[test]
+    fn failed_version_check_does_not_pollute_registry() {
+        let mut reg = PluginRegistry::new();
+        reg.register(Box::new(DummyPlugin {
+            name: "good",
+            cmd: "foo",
+        }))
+        .unwrap();
+
+        // Attempt to register a plugin with incompatible protocol
+        let result = reg.register(Box::new(FutureProtocolPlugin));
+        assert!(result.is_err());
+
+        // Original registration must be intact
+        assert!(reg.resolve("foo").is_some());
+        assert_eq!(reg.all_commands().len(), 1);
+        // Failed plugin's command must not appear
+        assert!(reg.resolve("proto").is_none());
     }
 }

--- a/crates/room-cli/src/plugin/queue.rs
+++ b/crates/room-cli/src/plugin/queue.rs
@@ -91,6 +91,10 @@ impl Plugin for QueuePlugin {
         "queue"
     }
 
+    fn version(&self) -> &str {
+        env!("CARGO_PKG_VERSION")
+    }
+
     fn commands(&self) -> Vec<CommandInfo> {
         Self::default_commands()
     }

--- a/crates/room-cli/src/plugin/stats.rs
+++ b/crates/room-cli/src/plugin/stats.rs
@@ -16,6 +16,10 @@ impl Plugin for StatsPlugin {
         "stats"
     }
 
+    fn version(&self) -> &str {
+        env!("CARGO_PKG_VERSION")
+    }
+
     fn commands(&self) -> Vec<CommandInfo> {
         vec![CommandInfo {
             name: "stats".to_owned(),

--- a/crates/room-plugin-taskboard/src/lib.rs
+++ b/crates/room-plugin-taskboard/src/lib.rs
@@ -116,6 +116,10 @@ impl Plugin for TaskboardPlugin {
         "taskboard"
     }
 
+    fn version(&self) -> &str {
+        env!("CARGO_PKG_VERSION")
+    }
+
     fn commands(&self) -> Vec<CommandInfo> {
         Self::default_commands()
     }
@@ -177,6 +181,28 @@ mod tests {
     fn plugin_name() {
         let (plugin, _tmp) = make_plugin();
         assert_eq!(plugin.name(), "taskboard");
+    }
+
+    #[test]
+    fn plugin_version_matches_crate() {
+        let (plugin, _tmp) = make_plugin();
+        assert_eq!(plugin.version(), env!("CARGO_PKG_VERSION"));
+    }
+
+    #[test]
+    fn plugin_api_version_is_current() {
+        let (plugin, _tmp) = make_plugin();
+        assert_eq!(
+            plugin.api_version(),
+            room_protocol::plugin::PLUGIN_API_VERSION
+        );
+    }
+
+    #[test]
+    fn plugin_min_protocol_is_compatible() {
+        let (plugin, _tmp) = make_plugin();
+        // Default min_protocol is "0.0.0", which is always satisfied.
+        assert_eq!(plugin.min_protocol(), "0.0.0");
     }
 
     #[test]

--- a/crates/room-protocol/CHANGELOG.md
+++ b/crates/room-protocol/CHANGELOG.md
@@ -14,6 +14,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `CommandContext`, `RoomMetadata`, `UserInfo`, `BoxFuture`, and new
   `MessageWriter`/`HistoryAccess` async traits. External crates can implement
   plugins by depending only on `room-protocol`. (#558)
+- Plugin versioning: `version()`, `api_version()`, `min_protocol()` methods on `Plugin`
+  trait with backward-compatible defaults. `PLUGIN_API_VERSION` and `PROTOCOL_VERSION`
+  constants for broker-side compatibility checking. (#512)
 
 ## [3.1.0] - 2026-03-13
 

--- a/crates/room-protocol/src/plugin.rs
+++ b/crates/room-protocol/src/plugin.rs
@@ -32,6 +32,35 @@ pub trait Plugin: Send + Sync {
     /// Unique identifier for this plugin (e.g. `"stats"`, `"help"`).
     fn name(&self) -> &str;
 
+    /// Semantic version of this plugin (e.g. `"1.0.0"`).
+    ///
+    /// Used for diagnostics and `/info` output. Defaults to `"0.0.0"` for
+    /// plugins that do not track their own version.
+    fn version(&self) -> &str {
+        "0.0.0"
+    }
+
+    /// Plugin API version this plugin was written against.
+    ///
+    /// The broker rejects plugins whose `api_version()` exceeds the current
+    /// [`PLUGIN_API_VERSION`]. Bump this constant when the `Plugin` trait
+    /// gains new required methods or changes existing method signatures.
+    ///
+    /// Defaults to `1` (the initial API revision).
+    fn api_version(&self) -> u32 {
+        1
+    }
+
+    /// Minimum `room-protocol` crate version this plugin requires, as a
+    /// semver string (e.g. `"3.1.0"`).
+    ///
+    /// The broker rejects plugins whose `min_protocol()` is newer than the
+    /// running `room-protocol` version. Defaults to `"0.0.0"` (compatible
+    /// with any protocol version).
+    fn min_protocol(&self) -> &str {
+        "0.0.0"
+    }
+
     /// Commands this plugin handles. Each entry drives `/help` output
     /// and TUI autocomplete.
     ///
@@ -59,6 +88,19 @@ pub trait Plugin: Send + Sync {
     /// must not block — spawn a task if async work is needed.
     fn on_user_leave(&self, _user: &str) {}
 }
+
+/// Current Plugin API version. Increment when the `Plugin` trait changes in
+/// a way that requires plugin authors to update their code (new required
+/// methods, changed signatures, removed defaults).
+///
+/// Plugins returning an `api_version()` higher than this are rejected at
+/// registration.
+pub const PLUGIN_API_VERSION: u32 = 1;
+
+/// The `room-protocol` crate version, derived from `Cargo.toml` at compile
+/// time. Used by the broker to reject plugins that require a newer protocol
+/// than the one currently running.
+pub const PROTOCOL_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 // ── CommandInfo ─────────────────────────────────────────────────────────────
 
@@ -246,5 +288,88 @@ mod tests {
             }
         );
         assert_ne!(ParamType::Text, ParamType::Choice(vec!["a".to_owned()]));
+    }
+
+    // ── Versioning defaults ─────────────────────────────────────────────
+
+    struct DefaultsPlugin;
+
+    impl Plugin for DefaultsPlugin {
+        fn name(&self) -> &str {
+            "defaults"
+        }
+
+        fn handle(&self, _ctx: CommandContext) -> BoxFuture<'_, anyhow::Result<PluginResult>> {
+            Box::pin(async { Ok(PluginResult::Handled) })
+        }
+    }
+
+    #[test]
+    fn default_version_is_zero() {
+        assert_eq!(DefaultsPlugin.version(), "0.0.0");
+    }
+
+    #[test]
+    fn default_api_version_is_one() {
+        assert_eq!(DefaultsPlugin.api_version(), 1);
+    }
+
+    #[test]
+    fn default_min_protocol_is_zero() {
+        assert_eq!(DefaultsPlugin.min_protocol(), "0.0.0");
+    }
+
+    #[test]
+    fn plugin_api_version_const_is_one() {
+        assert_eq!(PLUGIN_API_VERSION, 1);
+    }
+
+    #[test]
+    fn protocol_version_const_matches_cargo() {
+        // PROTOCOL_VERSION is set at compile time via env!("CARGO_PKG_VERSION").
+        // It must be a non-empty semver string with at least major.minor.patch.
+        assert!(!PROTOCOL_VERSION.is_empty());
+        let parts: Vec<&str> = PROTOCOL_VERSION.split('.').collect();
+        assert!(
+            parts.len() >= 3,
+            "PROTOCOL_VERSION must be major.minor.patch, got: {PROTOCOL_VERSION}"
+        );
+        for part in &parts {
+            assert!(
+                part.parse::<u64>().is_ok(),
+                "each segment must be numeric, got: {part}"
+            );
+        }
+    }
+
+    struct VersionedPlugin;
+
+    impl Plugin for VersionedPlugin {
+        fn name(&self) -> &str {
+            "versioned"
+        }
+
+        fn version(&self) -> &str {
+            "2.5.1"
+        }
+
+        fn api_version(&self) -> u32 {
+            1
+        }
+
+        fn min_protocol(&self) -> &str {
+            "3.0.0"
+        }
+
+        fn handle(&self, _ctx: CommandContext) -> BoxFuture<'_, anyhow::Result<PluginResult>> {
+            Box::pin(async { Ok(PluginResult::Handled) })
+        }
+    }
+
+    #[test]
+    fn custom_version_methods_override_defaults() {
+        assert_eq!(VersionedPlugin.version(), "2.5.1");
+        assert_eq!(VersionedPlugin.api_version(), 1);
+        assert_eq!(VersionedPlugin.min_protocol(), "3.0.0");
     }
 }


### PR DESCRIPTION
## Summary

- Add `version()`, `api_version()`, `min_protocol()` methods to `Plugin` trait in `room-protocol` with backward-compatible defaults (all existing plugins compile unchanged)
- `PluginRegistry::register()` now validates plugin compatibility before accepting registration — rejects plugins with `api_version()` > `PLUGIN_API_VERSION` or `min_protocol()` newer than `PROTOCOL_VERSION`
- `PLUGIN_API_VERSION` (u32 = 1) and `PROTOCOL_VERSION` (compile-time from Cargo.toml) constants exported from `room-protocol::plugin`
- Built-in plugins (stats, queue, taskboard) implement `version()` returning their crate version via `env!("CARGO_PKG_VERSION")`
- Minimal `semver_satisfies()` helper for major.minor.patch comparison without external dependency
- 15 new unit tests: 7 for `semver_satisfies`, 5 for registry version checks, 3 for taskboard plugin versioning

## Test plan

- [x] All 15 new tests pass
- [x] Full pre-push checks pass (`bash scripts/pre-push.sh`)
- [x] CHANGELOG entries in root, room-cli, and room-protocol

Closes #512
