### PR TITLE
feat(taskboard): team-restricted task claims (#516)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 > - [room-protocol CHANGELOG](crates/room-protocol/CHANGELOG.md)
 > - [room-ralph CHANGELOG](crates/room-ralph/CHANGELOG.md)
 
+### Added
+
+- **taskboard:** Team-restricted task claims — `/taskboard post --team <name>` restricts
+  claiming and assignment to team members. Backward-compatible NDJSON persistence. (#516)
+
 ### Fixed
 
 - **tui:** Status/system message text no longer appears as fake users in the member panel.

--- a/crates/room-cli/CHANGELOG.md
+++ b/crates/room-cli/CHANGELOG.md
@@ -12,6 +12,11 @@ For changes prior to the workspace restructure (v0.1.2 through v1.0.2), see the
 
 ### Added
 
+- Team-restricted task claims: `/taskboard post --team <name>` creates team-restricted tasks.
+  Only team members can `/taskboard claim` or be `/taskboard assign`-ed to restricted tasks.
+  `TeamAccess` trait in `room-protocol`, `TeamChecker` concrete impl in `room-daemon/plugin/bridge.rs`.
+  `Task` struct gains `team: Option<String>` (backward-compatible NDJSON via `#[serde(default)]`).
+  18 new unit tests. (#516)
 - Cross-room command routing via `--room <id>` flag in `dispatch_plugin`. `CrossRoomResolver`
   trait in `broker/service.rs`, `DaemonRoomResolver` in `broker/daemon/mod.rs`. 13 unit tests
   and 4 daemon integration tests. (#517)

--- a/crates/room-daemon/src/broker/commands.rs
+++ b/crates/room-daemon/src/broker/commands.rs
@@ -656,6 +656,12 @@ async fn dispatch_plugin(
     let metadata = snapshot_metadata(&state.status_map, &state.host_user, &state.chat_path).await;
     let available_commands = state.plugin_registry.all_commands();
 
+    let team_access: Option<Box<dyn room_protocol::plugin::TeamAccess>> = state
+        .auth
+        .registry
+        .get()
+        .map(|reg| Box::new(crate::plugin::bridge::TeamChecker::new(reg)) as _);
+
     let ctx = CommandContext {
         command: cmd.clone(),
         params: params.clone(),
@@ -667,6 +673,7 @@ async fn dispatch_plugin(
         writer: Box::new(writer),
         metadata,
         available_commands,
+        team_access,
     };
 
     let result = plugin.handle(ctx).await?;
@@ -773,6 +780,12 @@ async fn dispatch_cross_room(
     .await;
     let available_commands = target_state.plugin_registry.all_commands();
 
+    let team_access: Option<Box<dyn room_protocol::plugin::TeamAccess>> = target_state
+        .auth
+        .registry
+        .get()
+        .map(|reg| Box::new(crate::plugin::bridge::TeamChecker::new(reg)) as _);
+
     let ctx = CommandContext {
         command: cmd.to_owned(),
         params: params.to_vec(),
@@ -784,6 +797,7 @@ async fn dispatch_cross_room(
         writer: Box::new(writer),
         metadata,
         available_commands,
+        team_access,
     };
 
     let result = plugin.handle(ctx).await?;

--- a/crates/room-daemon/src/plugin/bridge.rs
+++ b/crates/room-daemon/src/plugin/bridge.rs
@@ -15,7 +15,9 @@ use std::{
     },
 };
 
-use room_protocol::plugin::{BoxFuture, HistoryAccess, MessageWriter, RoomMetadata, UserInfo};
+use room_protocol::plugin::{
+    BoxFuture, HistoryAccess, MessageWriter, RoomMetadata, TeamAccess, UserInfo,
+};
 
 use room_protocol::{make_event, make_system, Message};
 
@@ -25,6 +27,7 @@ use crate::{
         state::{ClientMap, StatusMap},
     },
     history,
+    registry::UserRegistry,
 };
 
 // ── HistoryReader ───────────────────────────────────────────────────────────
@@ -206,6 +209,45 @@ pub(crate) async fn snapshot_metadata(
         online_users,
         host,
         message_count,
+    }
+}
+
+// ── TeamChecker ─────────────────────────────────────────────────────────────
+
+/// Concrete [`TeamAccess`] backed by the daemon's [`UserRegistry`].
+///
+/// Wraps the shared registry behind `Arc<tokio::sync::Mutex<_>>`. Each method
+/// uses `try_lock()` for non-blocking access. If the lock is contended (rare —
+/// the registry lock is held only briefly by command handlers), the method
+/// returns a conservative `false`.
+pub struct TeamChecker {
+    registry: Arc<tokio::sync::Mutex<UserRegistry>>,
+}
+
+impl TeamChecker {
+    pub(crate) fn new(registry: &Arc<tokio::sync::Mutex<UserRegistry>>) -> Self {
+        Self {
+            registry: registry.clone(),
+        }
+    }
+}
+
+impl TeamAccess for TeamChecker {
+    fn team_exists(&self, team: &str) -> bool {
+        match self.registry.try_lock() {
+            Ok(reg) => reg.get_team(team).is_some(),
+            Err(_) => false,
+        }
+    }
+
+    fn is_member(&self, team: &str, user: &str) -> bool {
+        match self.registry.try_lock() {
+            Ok(reg) => reg
+                .get_team(team)
+                .map(|t| t.members.contains(user))
+                .unwrap_or(false),
+            Err(_) => false,
+        }
     }
 }
 

--- a/crates/room-daemon/src/plugin/mod.rs
+++ b/crates/room-daemon/src/plugin/mod.rs
@@ -12,13 +12,13 @@ use std::{collections::HashMap, path::Path};
 // imports from `crate::plugin::*` continue to work without changes.
 pub use room_protocol::plugin::{
     BoxFuture, CommandContext, CommandInfo, HistoryAccess, MessageWriter, ParamSchema, ParamType,
-    Plugin, PluginResult, RoomMetadata, UserInfo, PLUGIN_API_VERSION, PROTOCOL_VERSION,
+    Plugin, PluginResult, RoomMetadata, TeamAccess, UserInfo, PLUGIN_API_VERSION, PROTOCOL_VERSION,
 };
 
 // Re-export concrete bridge types. ChatWriter and HistoryReader are public
 // (used in tests and by broker/commands.rs). snapshot_metadata is crate-only.
 pub(crate) use bridge::snapshot_metadata;
-pub use bridge::{ChatWriter, HistoryReader};
+pub use bridge::{ChatWriter, HistoryReader, TeamChecker};
 pub use schema::{all_known_commands, builtin_command_infos};
 
 // ── PluginRegistry ──────────────────────────────────────────────────────────

--- a/crates/room-daemon/src/plugin/queue.rs
+++ b/crates/room-daemon/src/plugin/queue.rs
@@ -323,6 +323,7 @@ mod tests {
                 message_count: 0,
             },
             available_commands: vec![],
+            team_access: None,
         }
     }
 

--- a/crates/room-daemon/src/plugin/stats.rs
+++ b/crates/room-daemon/src/plugin/stats.rs
@@ -179,6 +179,7 @@ mod tests {
                 message_count: 3,
             },
             available_commands: vec![],
+            team_access: None,
         };
 
         let result = StatsPlugin.handle(ctx).await.unwrap();

--- a/crates/room-plugin-taskboard/src/handlers.rs
+++ b/crates/room-plugin-taskboard/src/handlers.rs
@@ -1,10 +1,49 @@
 use super::*;
 
+/// Parse an optional `--team <name>` flag from a slice of arguments.
+///
+/// Returns `(Some(team_name), remaining_args)` if found, or `(None, all_args)` otherwise.
+fn parse_team_flag(args: &[String]) -> (Option<String>, Vec<String>) {
+    let mut team = None;
+    let mut rest = Vec::new();
+    let mut i = 0;
+    while i < args.len() {
+        if args[i] == "--team" {
+            if let Some(name) = args.get(i + 1) {
+                team = Some(name.clone());
+                i += 2;
+                continue;
+            }
+        }
+        rest.push(args[i].clone());
+        i += 1;
+    }
+    (team, rest)
+}
+
 impl TaskboardPlugin {
     pub(super) fn handle_post(&self, ctx: &CommandContext) -> (String, bool) {
-        let description = ctx.params[1..].join(" ");
+        // Parse optional --team flag from params[1..].
+        let raw_args = &ctx.params[1..];
+        let (team, desc_parts) = parse_team_flag(raw_args);
+        let description = desc_parts.join(" ");
         if description.is_empty() {
-            return ("usage: /taskboard post <description>".to_owned(), false);
+            return (
+                "usage: /taskboard post [--team <name>] <description>".to_owned(),
+                false,
+            );
+        }
+        // Validate team exists if specified.
+        if let Some(ref team_name) = team {
+            match ctx.team_access.as_ref() {
+                Some(ta) if !ta.team_exists(team_name) => {
+                    return (format!("team '{team_name}' does not exist"), false);
+                }
+                Some(_) => {}
+                None => {
+                    return ("team restrictions require daemon mode".to_owned(), false);
+                }
+            }
         }
         let mut board = self.board.lock().unwrap();
         let tasks: Vec<Task> = board.iter().map(|lt| lt.task.clone()).collect();
@@ -22,11 +61,16 @@ impl TaskboardPlugin {
             approved_at: None,
             updated_at: None,
             notes: None,
+            team: team.clone(),
         };
         board.push(LiveTask::new(task.clone()));
         let all_tasks: Vec<Task> = board.iter().map(|lt| lt.task.clone()).collect();
         let _ = task::save_tasks(&self.storage_path, &all_tasks);
-        (format!("task {id} posted: {description}"), true)
+        let team_suffix = team.map(|t| format!(" [team: {t}]")).unwrap_or_default();
+        (
+            format!("task {id} posted: {description}{team_suffix}"),
+            true,
+        )
     }
 
     pub(super) fn handle_list(&self) -> String {
@@ -39,10 +83,19 @@ impl TaskboardPlugin {
         if !expired.is_empty() {
             lines.push(format!("expired: {}", expired.join(", ")));
         }
-        lines.push(format!(
-            "{:<8} {:<10} {:<12} {:<12} {}",
-            "ID", "STATUS", "ASSIGNEE", "ELAPSED", "DESCRIPTION"
-        ));
+        // Show TEAM column only if any task has a team restriction.
+        let has_teams = board.iter().any(|lt| lt.task.team.is_some());
+        if has_teams {
+            lines.push(format!(
+                "{:<8} {:<10} {:<12} {:<10} {:<12} {}",
+                "ID", "STATUS", "ASSIGNEE", "TEAM", "ELAPSED", "DESCRIPTION"
+            ));
+        } else {
+            lines.push(format!(
+                "{:<8} {:<10} {:<12} {:<12} {}",
+                "ID", "STATUS", "ASSIGNEE", "ELAPSED", "DESCRIPTION"
+            ));
+        }
         for lt in board.iter() {
             let elapsed = match lt.lease_start {
                 Some(start) => {
@@ -62,10 +115,18 @@ impl TaskboardPlugin {
             } else {
                 lt.task.description.clone()
             };
-            lines.push(format!(
-                "{:<8} {:<10} {:<12} {:<12} {}",
-                lt.task.id, lt.task.status, assignee, elapsed, desc
-            ));
+            if has_teams {
+                let team = lt.task.team.as_deref().unwrap_or("-").to_owned();
+                lines.push(format!(
+                    "{:<8} {:<10} {:<12} {:<10} {:<12} {}",
+                    lt.task.id, lt.task.status, assignee, team, elapsed, desc
+                ));
+            } else {
+                lines.push(format!(
+                    "{:<8} {:<10} {:<12} {:<12} {}",
+                    lt.task.id, lt.task.status, assignee, elapsed, desc
+                ));
+            }
         }
         lines.join("\n")
     }
@@ -89,6 +150,28 @@ impl TaskboardPlugin {
                 ),
                 false,
             );
+        }
+        // Team restriction: if the task has a team, the claimer must be a member.
+        if let Some(ref team_name) = lt.task.team {
+            match ctx.team_access.as_ref() {
+                Some(ta) if !ta.is_member(team_name, &ctx.sender) => {
+                    return (
+                        format!(
+                            "task {task_id} is restricted to team '{team_name}' — you are not a member"
+                        ),
+                        false,
+                    );
+                }
+                None => {
+                    return (
+                        format!(
+                            "task {task_id} has team restriction but team access is unavailable (standalone mode)"
+                        ),
+                        false,
+                    );
+                }
+                _ => {}
+            }
         }
         lt.task.status = TaskStatus::Claimed;
         lt.task.assigned_to = Some(ctx.sender.clone());
@@ -338,6 +421,26 @@ impl TaskboardPlugin {
         if !is_poster && !is_host {
             return ("only the task poster or host can assign".to_owned(), false);
         }
+        // Team restriction: if the task has a team, the target user must be a member.
+        if let Some(ref team_name) = lt.task.team {
+            match ctx.team_access.as_ref() {
+                Some(ta) if !ta.is_member(team_name, target_user) => {
+                    return (
+                        format!("cannot assign {target_user} — not a member of team '{team_name}'"),
+                        false,
+                    );
+                }
+                None => {
+                    return (
+                        format!(
+                            "task {task_id} has team restriction but team access is unavailable (standalone mode)"
+                        ),
+                        false,
+                    );
+                }
+                _ => {}
+            }
+        }
         lt.task.status = TaskStatus::Claimed;
         lt.task.assigned_to = Some(target_user.clone());
         lt.task.claimed_at = Some(chrono::Utc::now());
@@ -366,6 +469,7 @@ impl TaskboardPlugin {
         let plan = t.plan.as_deref().unwrap_or("-");
         let approved_by = t.approved_by.as_deref().unwrap_or("-");
         let notes = t.notes.as_deref().unwrap_or("-");
+        let team = t.team.as_deref().unwrap_or("-");
         let elapsed = match lt.lease_start {
             Some(start) => {
                 let secs = start.elapsed().as_secs();
@@ -378,8 +482,8 @@ impl TaskboardPlugin {
             None => "-".to_owned(),
         };
         format!(
-            "task {}\n  status:      {}\n  description: {}\n  posted by:   {}\n  assigned to: {}\n  plan:        {}\n  approved by: {}\n  notes:       {}\n  lease:       {}",
-            t.id, t.status, t.description, t.posted_by, assignee, plan, approved_by, notes, elapsed
+            "task {}\n  status:      {}\n  description: {}\n  posted by:   {}\n  assigned to: {}\n  team:        {}\n  plan:        {}\n  approved by: {}\n  notes:       {}\n  lease:       {}",
+            t.id, t.status, t.description, t.posted_by, assignee, team, plan, approved_by, notes, elapsed
         )
     }
 
@@ -999,6 +1103,260 @@ mod tests {
         );
     }
 
+    // -- Team restriction tests -------------------------------------------------
+
+    use std::collections::{HashMap, HashSet};
+
+    /// Mock team access for unit tests.
+    struct MockTeamAccess {
+        teams: HashMap<String, HashSet<String>>,
+    }
+
+    impl MockTeamAccess {
+        fn new(teams: Vec<(&str, Vec<&str>)>) -> Self {
+            let mut map = HashMap::new();
+            for (name, members) in teams {
+                map.insert(
+                    name.to_owned(),
+                    members.into_iter().map(|m| m.to_owned()).collect(),
+                );
+            }
+            Self { teams: map }
+        }
+    }
+
+    impl room_protocol::plugin::TeamAccess for MockTeamAccess {
+        fn team_exists(&self, team: &str) -> bool {
+            self.teams.contains_key(team)
+        }
+        fn is_member(&self, team: &str, user: &str) -> bool {
+            self.teams
+                .get(team)
+                .map(|m| m.contains(user))
+                .unwrap_or(false)
+        }
+    }
+
+    fn mock_team_access(
+        teams: Vec<(&str, Vec<&str>)>,
+    ) -> Option<Box<dyn room_protocol::plugin::TeamAccess>> {
+        Some(Box::new(MockTeamAccess::new(teams)))
+    }
+
+    #[test]
+    fn handle_post_with_team_flag() {
+        let (plugin, _tmp) = make_plugin();
+        let ta = mock_team_access(vec![("backend", vec!["alice", "bob"])]);
+        let ctx = test_ctx_with_team_access("alice", &["post", "--team", "backend", "fix api"], ta);
+        let (result, broadcast) = plugin.handle_post(&ctx);
+        assert!(result.contains("tb-001"));
+        assert!(result.contains("[team: backend]"));
+        assert!(broadcast);
+        let board = plugin.board.lock().unwrap();
+        assert_eq!(board[0].task.team.as_deref(), Some("backend"));
+    }
+
+    #[test]
+    fn handle_post_team_not_found() {
+        let (plugin, _tmp) = make_plugin();
+        let ta = mock_team_access(vec![("backend", vec!["alice"])]);
+        let ctx = test_ctx_with_team_access("alice", &["post", "--team", "nope", "task"], ta);
+        let (result, broadcast) = plugin.handle_post(&ctx);
+        assert!(result.contains("does not exist"));
+        assert!(!broadcast);
+    }
+
+    #[test]
+    fn handle_post_team_requires_daemon_mode() {
+        let (plugin, _tmp) = make_plugin();
+        // No team_access (standalone mode).
+        let ctx = test_ctx("alice", &["post", "--team", "backend", "task"]);
+        let (result, broadcast) = plugin.handle_post(&ctx);
+        assert!(result.contains("daemon mode"));
+        assert!(!broadcast);
+    }
+
+    #[test]
+    fn handle_claim_team_member_allowed() {
+        let (plugin, _tmp) = make_plugin();
+        // Post with team restriction.
+        let ta = mock_team_access(vec![("backend", vec!["alice", "bob"])]);
+        let ctx = test_ctx_with_team_access("alice", &["post", "--team", "backend", "fix api"], ta);
+        plugin.handle_post(&ctx);
+        // bob is a member — claim should succeed.
+        let ta2 = mock_team_access(vec![("backend", vec!["alice", "bob"])]);
+        let ctx2 = test_ctx_with_team_access("bob", &["claim", "tb-001"], ta2);
+        let (result, broadcast) = plugin.handle_claim(&ctx2);
+        assert!(result.contains("claimed by bob"));
+        assert!(broadcast);
+    }
+
+    #[test]
+    fn handle_claim_team_non_member_rejected() {
+        let (plugin, _tmp) = make_plugin();
+        let ta = mock_team_access(vec![("backend", vec!["alice"])]);
+        let ctx = test_ctx_with_team_access("alice", &["post", "--team", "backend", "fix api"], ta);
+        plugin.handle_post(&ctx);
+        // charlie is NOT a member — claim should fail.
+        let ta2 = mock_team_access(vec![("backend", vec!["alice"])]);
+        let ctx2 = test_ctx_with_team_access("charlie", &["claim", "tb-001"], ta2);
+        let (result, broadcast) = plugin.handle_claim(&ctx2);
+        assert!(result.contains("restricted to team 'backend'"));
+        assert!(result.contains("not a member"));
+        assert!(!broadcast);
+    }
+
+    #[test]
+    fn handle_claim_team_no_team_access_fails() {
+        let (plugin, _tmp) = make_plugin();
+        // Post with team restriction (need team_access for post).
+        let ta = mock_team_access(vec![("backend", vec!["alice"])]);
+        let ctx = test_ctx_with_team_access("alice", &["post", "--team", "backend", "fix api"], ta);
+        plugin.handle_post(&ctx);
+        // Try to claim without team_access (standalone mode).
+        let ctx2 = test_ctx("alice", &["claim", "tb-001"]);
+        let (result, broadcast) = plugin.handle_claim(&ctx2);
+        assert!(result.contains("team access is unavailable"));
+        assert!(!broadcast);
+    }
+
+    #[test]
+    fn handle_assign_team_member_allowed() {
+        let (plugin, _tmp) = make_plugin();
+        let ta = mock_team_access(vec![("backend", vec!["alice", "bob"])]);
+        let ctx = test_ctx_with_team_access("alice", &["post", "--team", "backend", "fix api"], ta);
+        plugin.handle_post(&ctx);
+        // alice (poster) assigns bob (member) — should succeed.
+        let ta2 = mock_team_access(vec![("backend", vec!["alice", "bob"])]);
+        let ctx2 = test_ctx_with_team_access("alice", &["assign", "tb-001", "bob"], ta2);
+        let (result, broadcast) = plugin.handle_assign(&ctx2);
+        assert!(result.contains("assigned to bob"));
+        assert!(broadcast);
+    }
+
+    #[test]
+    fn handle_assign_team_non_member_rejected() {
+        let (plugin, _tmp) = make_plugin();
+        let ta = mock_team_access(vec![("backend", vec!["alice"])]);
+        let ctx = test_ctx_with_team_access("alice", &["post", "--team", "backend", "fix api"], ta);
+        plugin.handle_post(&ctx);
+        // alice (poster) tries to assign charlie (not a member).
+        let ta2 = mock_team_access(vec![("backend", vec!["alice"])]);
+        let ctx2 = test_ctx_with_team_access("alice", &["assign", "tb-001", "charlie"], ta2);
+        let (result, broadcast) = plugin.handle_assign(&ctx2);
+        assert!(result.contains("not a member of team 'backend'"));
+        assert!(!broadcast);
+    }
+
+    #[test]
+    fn handle_claim_no_team_unrestricted() {
+        let (plugin, _tmp) = make_plugin();
+        // Post WITHOUT team — anyone can claim, even without team_access.
+        plugin.handle_post(&test_ctx("ba", &["post", "open task"]));
+        let (result, broadcast) = plugin.handle_claim(&test_ctx("random", &["claim", "tb-001"]));
+        assert!(result.contains("claimed by random"));
+        assert!(broadcast);
+    }
+
+    #[test]
+    fn handle_show_displays_team() {
+        let (plugin, _tmp) = make_plugin();
+        let ta = mock_team_access(vec![("backend", vec!["alice"])]);
+        let ctx = test_ctx_with_team_access("alice", &["post", "--team", "backend", "fix api"], ta);
+        plugin.handle_post(&ctx);
+        let result = plugin.handle_show(&test_ctx("anyone", &["show", "tb-001"]));
+        assert!(result.contains("team:        backend"));
+    }
+
+    #[test]
+    fn handle_list_shows_team_column_when_tasks_have_teams() {
+        let (plugin, _tmp) = make_plugin();
+        let ta = mock_team_access(vec![("backend", vec!["alice"])]);
+        let ctx = test_ctx_with_team_access("alice", &["post", "--team", "backend", "fix api"], ta);
+        plugin.handle_post(&ctx);
+        plugin.handle_post(&test_ctx("ba", &["post", "open task"]));
+        let result = plugin.handle_list();
+        assert!(result.contains("TEAM"));
+        assert!(result.contains("backend"));
+    }
+
+    #[test]
+    fn handle_list_no_team_column_when_no_teams() {
+        let (plugin, _tmp) = make_plugin();
+        plugin.handle_post(&test_ctx("ba", &["post", "open task"]));
+        let result = plugin.handle_list();
+        assert!(!result.contains("TEAM"));
+    }
+
+    #[test]
+    fn parse_team_flag_extracts_team() {
+        let args: Vec<String> = vec!["--team", "backend", "fix", "api"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        let (team, rest) = parse_team_flag(&args);
+        assert_eq!(team.as_deref(), Some("backend"));
+        assert_eq!(rest, vec!["fix", "api"]);
+    }
+
+    #[test]
+    fn parse_team_flag_no_flag() {
+        let args: Vec<String> = vec!["fix", "the", "bug"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        let (team, rest) = parse_team_flag(&args);
+        assert!(team.is_none());
+        assert_eq!(rest, vec!["fix", "the", "bug"]);
+    }
+
+    #[test]
+    fn parse_team_flag_at_end_no_value() {
+        let args: Vec<String> = vec!["fix", "--team"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        let (team, rest) = parse_team_flag(&args);
+        assert!(team.is_none());
+        assert_eq!(rest, vec!["fix", "--team"]);
+    }
+
+    #[test]
+    fn team_field_serde_backward_compatible() {
+        // Task JSON without "team" field should deserialize with team = None.
+        let json = r#"{"id":"tb-001","description":"test","status":"open","posted_by":"alice","assigned_to":null,"posted_at":"2026-03-13T00:00:00Z","claimed_at":null,"plan":null,"approved_by":null,"approved_at":null,"updated_at":null,"notes":null}"#;
+        let task: Task = serde_json::from_str(json).unwrap();
+        assert!(task.team.is_none());
+    }
+
+    #[test]
+    fn team_field_serde_round_trip() {
+        let mut task = Task {
+            id: "tb-001".to_owned(),
+            description: "test".to_owned(),
+            status: TaskStatus::Open,
+            posted_by: "alice".to_owned(),
+            assigned_to: None,
+            posted_at: chrono::Utc::now(),
+            claimed_at: None,
+            plan: None,
+            approved_by: None,
+            approved_at: None,
+            updated_at: None,
+            notes: None,
+            team: Some("backend".to_owned()),
+        };
+        let json = serde_json::to_string(&task).unwrap();
+        assert!(json.contains("\"team\":\"backend\""));
+        let parsed: Task = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.team.as_deref(), Some("backend"));
+
+        // None team should not appear in JSON (skip_serializing_if).
+        task.team = None;
+        let json2 = serde_json::to_string(&task).unwrap();
+        assert!(!json2.contains("team"));
+    }
+
     // -- Test helpers -----------------------------------------------------------
 
     /// No-op MessageWriter for unit tests — taskboard handler tests never
@@ -1049,6 +1407,23 @@ mod tests {
     }
 
     fn test_ctx_with_host(sender: &str, params: &[&str], host: Option<&str>) -> CommandContext {
+        test_ctx_full(sender, params, host, None)
+    }
+
+    fn test_ctx_with_team_access(
+        sender: &str,
+        params: &[&str],
+        team_access: Option<Box<dyn room_protocol::plugin::TeamAccess>>,
+    ) -> CommandContext {
+        test_ctx_full(sender, params, None, team_access)
+    }
+
+    fn test_ctx_full(
+        sender: &str,
+        params: &[&str],
+        host: Option<&str>,
+        team_access: Option<Box<dyn room_protocol::plugin::TeamAccess>>,
+    ) -> CommandContext {
         CommandContext {
             command: "taskboard".to_owned(),
             params: params.iter().map(|s| s.to_string()).collect(),
@@ -1067,6 +1442,7 @@ mod tests {
                 message_count: 0,
             },
             available_commands: vec![],
+            team_access,
         }
     }
 }

--- a/crates/room-plugin-taskboard/src/lib.rs
+++ b/crates/room-plugin-taskboard/src/lib.rs
@@ -263,6 +263,7 @@ mod tests {
                     approved_at: None,
                     updated_at: None,
                     notes: None,
+                    team: None,
                 };
                 let mut lt = LiveTask::new(t);
                 lt.lease_start = Some(stale);
@@ -282,6 +283,7 @@ mod tests {
                 approved_at: None,
                 updated_at: None,
                 notes: None,
+                team: None,
             };
             let mut lt_finished = LiveTask::new(finished);
             // Manually inject stale lease to simulate edge case.

--- a/crates/room-plugin-taskboard/src/task.rs
+++ b/crates/room-plugin-taskboard/src/task.rs
@@ -44,6 +44,10 @@ pub struct Task {
     pub approved_at: Option<DateTime<Utc>>,
     pub updated_at: Option<DateTime<Utc>>,
     pub notes: Option<String>,
+    /// Optional team restriction — only members of this team can claim or be
+    /// assigned to the task. `None` means unrestricted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub team: Option<String>,
 }
 
 /// In-memory task with a lease timestamp for TTL tracking.
@@ -155,6 +159,7 @@ mod tests {
             approved_at: None,
             updated_at: None,
             notes: None,
+            team: None,
         }
     }
 

--- a/crates/room-protocol/CHANGELOG.md
+++ b/crates/room-protocol/CHANGELOG.md
@@ -17,6 +17,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Plugin versioning: `version()`, `api_version()`, `min_protocol()` methods on `Plugin`
   trait with backward-compatible defaults. `PLUGIN_API_VERSION` and `PROTOCOL_VERSION`
   constants for broker-side compatibility checking. (#512)
+- `TeamAccess` trait in `plugin` module — read-only team membership queries for plugins.
+  `team_exists(team)` and `is_member(team, user)` methods. `CommandContext` gains an
+  optional `team_access` field (`None` in standalone mode, `Some` in daemon mode). (#516)
 
 ## [3.1.0] - 2026-03-13
 

--- a/crates/room-protocol/src/plugin.rs
+++ b/crates/room-protocol/src/plugin.rs
@@ -171,6 +171,11 @@ pub struct CommandContext {
     /// All registered commands (so `/help` can list them without
     /// holding a reference to the registry).
     pub available_commands: Vec<CommandInfo>,
+    /// Optional access to daemon-level team membership.
+    ///
+    /// `Some` in daemon mode (backed by `UserRegistry`), `None` in standalone
+    /// mode where teams are not available.
+    pub team_access: Option<Box<dyn TeamAccess>>,
 }
 
 // ── PluginResult ────────────────────────────────────────────────────────────
@@ -226,6 +231,22 @@ pub trait HistoryAccess: Send + Sync {
 
     /// Count total messages in the chat.
     fn count(&self) -> BoxFuture<'_, anyhow::Result<usize>>;
+}
+
+// ── TeamAccess trait ────────────────────────────────────────────────────────
+
+/// Read-only access to daemon-level team membership.
+///
+/// Plugins use this trait to check whether a user belongs to a team without
+/// depending on `room-daemon` or `UserRegistry` directly. The broker provides
+/// a concrete implementation backed by the registry; standalone mode passes
+/// `None` (no team checking available).
+pub trait TeamAccess: Send + Sync {
+    /// Returns `true` if the named team exists in the registry.
+    fn team_exists(&self, team: &str) -> bool;
+
+    /// Returns `true` if `user` is a member of `team`.
+    fn is_member(&self, team: &str, user: &str) -> bool;
 }
 
 // ── RoomMetadata ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add `--team <name>` flag to `/taskboard post` — creates team-restricted tasks where only members of the specified team can claim or be assigned
- New `TeamAccess` trait in `room-protocol` with `team_exists()` and `is_member()` methods, decoupling the taskboard plugin from `UserRegistry`
- Concrete `TeamChecker` implementation in `room-daemon/plugin/bridge.rs` backed by `UserRegistry` via `try_lock()` for non-blocking sync access
- `Task.team: Option<String>` with `#[serde(default, skip_serializing_if)]` — fully backward-compatible NDJSON persistence (old tasks deserialize with `team: None`)
- `handle_claim` and `handle_assign` enforce team membership; `handle_show` and `handle_list` display team info
- 18 new unit tests: team post/claim/assign (member, non-member, no-access), serde backward compat, parse_team_flag, list/show display

## Files changed

| File | Change |
|---|---|
| `room-protocol/src/plugin.rs` | `TeamAccess` trait + `CommandContext.team_access` field |
| `room-plugin-taskboard/src/task.rs` | `Task.team: Option<String>` |
| `room-plugin-taskboard/src/handlers.rs` | `--team` flag parsing, claim/assign validation, show/list display, 18 tests |
| `room-plugin-taskboard/src/lib.rs` | `team` field in test Task constructors |
| `room-daemon/src/plugin/bridge.rs` | `TeamChecker` struct implementing `TeamAccess` |
| `room-daemon/src/plugin/mod.rs` | Re-export `TeamAccess`, `TeamChecker` |
| `room-daemon/src/broker/commands.rs` | Wire `team_access` into both `CommandContext` construction sites |
| `room-daemon/src/plugin/stats.rs` | Add `team_access: None` to test context |
| `room-daemon/src/plugin/queue.rs` | Add `team_access: None` to test context |
| `CHANGELOG.md` | #516 entry |
| `crates/room-cli/CHANGELOG.md` | #516 entry |
| `crates/room-protocol/CHANGELOG.md` | #516 entry |

## Test plan

- [x] `cargo check` — clean
- [x] `cargo fmt` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — all pass (18 new tests added)
- [x] Backward compatibility: old NDJSON without `team` field deserializes correctly
- [x] Standalone mode: `--team` flag rejected with "daemon mode" message when no team access
- [ ] Integration: daemon-mode `/taskboard post --team backend fix api` + `/taskboard claim` by non-member → rejected

Closes #516