### PR TITLE
docs: fix stale paths after crate extraction

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,9 +20,19 @@ The README covers installation and basic usage. This folder contains deep-dive d
 | [troubleshooting.md](troubleshooting.md) | FAQ and common errors |
 | [contributing.md](contributing.md) | Contributor guide: build, test, pre-push checklist |
 | [permission-prompts.md](permission-prompts.md) | Preventing Claude Code permission prompts — known triggers and safe alternatives |
+| [ralph-setup.md](ralph-setup.md) | room-ralph setup: permissions, personality, memory |
 
-## Hive (product layer)
+## Design documents
+
+| File | Description |
+|------|-------------|
+| [design-253-room-visibility.md](design-253-room-visibility.md) | Design doc for room visibility and ACLs |
+| [design-agent-spawn.md](design-agent-spawn.md) | Design doc for `/agent` and `/spawn` commands (#434) |
+| [design-shared-knowledge.md](design-shared-knowledge.md) | Design doc for shared knowledge system (#480) |
+
+## PRDs
 
 | Folder | Description |
 |--------|-------------|
-| [hive/](hive/) | PRDs for the Hive orchestration layer — workspaces, teams, agent discovery |
+| [prd/hive/](prd/hive/) | PRDs for the Hive orchestration layer — workspaces, teams, agent discovery |
+| [prd/agent/](prd/agent/) | PRDs for agent autonomy — personality system, `/agent` plugin, agent health |

--- a/docs/design-agent-spawn.md
+++ b/docs/design-agent-spawn.md
@@ -343,13 +343,13 @@ accepts the risk by explicitly passing the flag.
 ### Phase 1: Spawn MVP (plugin + /agent + /agent list + /agent stop)
 
 Files:
-- `crates/room-cli/src/plugin/agent.rs` — NEW: `AgentPlugin` struct, spawn/list/stop
+- `crates/room-daemon/src/plugin/agent.rs` — NEW: `AgentPlugin` struct, spawn/list/stop
   handlers, `SpawnedAgent` tracking map, PID persistence to
   `~/.room/state/agents-<room>.json`, `--allow-all` passthrough
-- `crates/room-cli/src/plugin/mod.rs` — register `AgentPlugin` in default plugin set
-- `crates/room-cli/src/broker/mod.rs` — pass socket path to plugin context (extend
+- `crates/room-daemon/src/plugin/mod.rs` — register `AgentPlugin` in default plugin set
+- `crates/room-daemon/src/broker/mod.rs` — pass socket path to plugin context (extend
   `CommandContext` or `RoomMetadata` with socket info)
-- `crates/room-cli/src/paths.rs` — add `agents_state_path()` helper
+- `crates/room-daemon/src/paths.rs` — add `agents_state_path()` helper
 
 Tests:
 - Unit tests for param validation, username collision checks, PID file round-trip
@@ -359,7 +359,7 @@ Tests:
 ### Phase 2: Personalities (/spawn + registry)
 
 Files:
-- `crates/room-cli/src/plugin/agent.rs` — add personality registry, TOML loading,
+- `crates/room-daemon/src/plugin/agent.rs` — add personality registry, TOML loading,
   built-in defaults, `/spawn` command handler
 - `~/.room/personalities/*.toml` — user-defined personalities (not in repo)
 
@@ -370,9 +370,9 @@ Tests:
 ### Phase 3: Lifecycle hardening
 
 Files:
-- `crates/room-cli/src/plugin/agent.rs` — orphan cleanup on shutdown, `/agent logs`,
+- `crates/room-daemon/src/plugin/agent.rs` — orphan cleanup on shutdown, `/agent logs`,
   exit code tracking
-- `crates/room-cli/src/paths.rs` — add `agent_log_dir()` path helper
+- `crates/room-daemon/src/paths.rs` — add `agent_log_dir()` path helper
 
 Tests:
 - Integration test: broker shutdown reaps spawned agents
@@ -382,7 +382,7 @@ Tests:
 
 Files:
 - `crates/room-cli/src/tui/widgets.rs` — personality name completion in palette
-- `crates/room-cli/src/plugin/agent.rs` — dynamic `CommandInfo` with personality names
+- `crates/room-daemon/src/plugin/agent.rs` — dynamic `CommandInfo` with personality names
 
 Tests:
 - Unit test: palette filters personality names on keystroke

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -10,7 +10,7 @@ protocol).
 ## Broker plugin system
 
 The broker has a compiled-in plugin system defined in
-`crates/room-cli/src/plugin/mod.rs`. Plugins can register slash commands,
+`crates/room-daemon/src/plugin/mod.rs`. Plugins can register slash commands,
 react to user join/leave events, read chat history, and write messages back
 to the room.
 

--- a/docs/prd/agent/prd-agent-plugin.md
+++ b/docs/prd/agent/prd-agent-plugin.md
@@ -268,11 +268,11 @@ consumers (Hive, scripts, other agents). This pattern applies to all plugin resp
 ### Phase 1: Spawn MVP
 
 Files:
-- `crates/room-cli/src/plugin/agent.rs` — NEW: `AgentPlugin` struct, spawn/list/stop
+- `crates/room-daemon/src/plugin/agent.rs` — NEW: `AgentPlugin` struct, spawn/list/stop
   handlers, `SpawnedAgent` tracking, PID persistence, `--allow-all` passthrough
-- `crates/room-cli/src/plugin/mod.rs` — register `AgentPlugin`
-- `crates/room-cli/src/broker/mod.rs` — expose socket path in `CommandContext`
-- `crates/room-cli/src/paths.rs` — add `agents_state_path()`, `agent_log_dir()`
+- `crates/room-daemon/src/plugin/mod.rs` — register `AgentPlugin`
+- `crates/room-daemon/src/broker/mod.rs` — expose socket path in `CommandContext`
+- `crates/room-daemon/src/paths.rs` — add `agents_state_path()`, `agent_log_dir()`
 - `crates/room-ralph/src/room.rs` — check `ROOM_TOKEN` env var, skip join/subscribe
   if set
 
@@ -284,7 +284,7 @@ Tests:
 ### Phase 2: Personalities and /spawn
 
 Files:
-- `crates/room-cli/src/plugin/agent.rs` — personality registry, TOML loading,
+- `crates/room-daemon/src/plugin/agent.rs` — personality registry, TOML loading,
   built-in defaults, `/spawn` handler
 - `crates/room-ralph/src/personalities.rs` — extend with full personality schema
 
@@ -296,7 +296,7 @@ Tests:
 ### Phase 3: Lifecycle hardening
 
 Files:
-- `crates/room-cli/src/plugin/agent.rs` — orphan cleanup on shutdown, `/agent logs`,
+- `crates/room-daemon/src/plugin/agent.rs` — orphan cleanup on shutdown, `/agent logs`,
   exit code tracking, structured response `data` field
 
 Tests:
@@ -308,7 +308,7 @@ Tests:
 
 Files:
 - `crates/room-cli/src/tui/widgets.rs` — personality name completion in palette
-- `crates/room-cli/src/plugin/agent.rs` — dynamic `CommandInfo` with personality names
+- `crates/room-daemon/src/plugin/agent.rs` — dynamic `CommandInfo` with personality names
 
 Tests:
 - Unit: palette filters personality names on keystroke

--- a/docs/prd/agent/prd-personality.md
+++ b/docs/prd/agent/prd-personality.md
@@ -183,7 +183,7 @@ When Hive is present, it owns personality management:
 
 ### Files
 
-- `crates/room-cli/src/plugin/agent.rs` — personality registry, TOML loading, built-in
+- `crates/room-daemon/src/plugin/agent.rs` — personality registry, TOML loading, built-in
   defaults
 - `crates/room-ralph/src/personalities.rs` — built-in personality definitions (already
   exists for profiles, extend with full personality schema)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -44,17 +44,20 @@ cargo test broadcast
 crates/room-protocol/src/
   lib.rs                — unit tests for Message serde, parse_client_line, parse_mentions
 
-crates/room-cli/src/
+crates/room-daemon/src/
   history.rs            — unit tests for NDJSON load/append
   broker/auth.rs        — unit tests for token issuance, persistence, join permissions
   broker/commands.rs    — unit tests for route_command, validate_params, built-in commands
   broker/fanout.rs      — unit tests for broadcast_and_persist, dm_and_persist
-  plugin/mod.rs         — unit tests for PluginRegistry, builtin_command_infos
-  plugin/help.rs        — unit tests for /help output
+  plugin/mod.rs         — unit tests for PluginRegistry, builtin_command_infos, /help output
   plugin/stats.rs       — unit tests for /stats output
   plugin/queue.rs       — unit tests for /queue NDJSON persistence and subcommands
-  plugin/taskboard/mod.rs — unit tests for /taskboard subcommands, approve permissions, lifecycle
-  plugin/taskboard/task.rs — unit tests for Task model, LiveTask lease, NDJSON round-trip
+
+crates/room-plugin-taskboard/src/
+  lib.rs                — unit tests for /taskboard subcommands, approve permissions, lifecycle
+  task.rs               — unit tests for Task model, LiveTask lease, NDJSON round-trip
+
+crates/room-cli/src/
   tui/input.rs          — unit tests for handle_key, cursor, key bindings
   tui/render.rs         — unit tests for wrap_words, format_message
   tui/widgets.rs        — unit tests for CommandPalette, MentionPicker
@@ -193,11 +196,13 @@ async fn my_feature_works() {
 
 ## Test baseline
 
-**Current: 1373 Rust tests + 107 shell tests** (as of v3.1.0)
+**Current: 1517 Rust tests + 107 shell tests** (as of v3.1.0)
 
 | Crate | Unit | Integration | Total |
 |-------|------|-------------|-------|
 | room-protocol | 116 | — | 116 |
+| room-daemon | — | — | (counted via room-cli) |
+| room-plugin-taskboard | — | — | (counted via room-cli) |
 | room-cli | 888 | 195 | 1083 |
 | room-ralph | 164 | 10 | 174 |
 


### PR DESCRIPTION
## Summary

- Fix all documentation paths that still referenced `room-cli` for modules that moved to `room-daemon` and `room-plugin-taskboard` during sprint 15 refactors (#511, #454)
- Add missing entries to `docs/README.md` index (ralph-setup.md, 3 design docs, prd/agent/ directory)
- Update test baseline in `docs/testing.md` from 1373 to 1517

## Files modified

| File | Change |
|------|--------|
| `docs/README.md` | Added missing index entries |
| `docs/plugin.md` | `room-cli` → `room-daemon` for plugin module path |
| `docs/testing.md` | Updated unit test paths, removed non-existent `plugin/help.rs`, updated baseline |
| `docs/design-agent-spawn.md` | Updated all implementation plan paths |
| `docs/prd/agent/prd-agent-plugin.md` | Updated implementation plan paths |
| `docs/prd/agent/prd-personality.md` | Updated plugin path |

## Note for BA

CLAUDE.md has similar stale paths (workspace structure, codebase overview, test baseline sections) but is owned by BA for post-sprint updates. Items documented in #676.

Closes #676

## Test plan

- [x] Docs-only change — no code affected
- [x] All referenced paths verified against actual filesystem

🤖 Generated with [Claude Code](https://claude.com/claude-code)