### PR TITLE
feat(taskboard): filter finished/cancelled from default list

### DIFF
--- a/crates/room-plugin-taskboard/src/handlers.rs
+++ b/crates/room-plugin-taskboard/src/handlers.rs
@@ -73,18 +73,33 @@ impl TaskboardPlugin {
         )
     }
 
-    pub(super) fn handle_list(&self) -> String {
+    pub(super) fn handle_list(&self, show_all: bool) -> String {
         let expired = self.sweep_expired();
         let board = self.board.lock().unwrap();
         if board.is_empty() {
             return "taskboard is empty".to_owned();
         }
+        // Filter tasks: by default hide finished/cancelled.
+        let visible: Vec<&LiveTask> = if show_all {
+            board.iter().collect()
+        } else {
+            board
+                .iter()
+                .filter(|lt| {
+                    !matches!(lt.task.status, TaskStatus::Finished | TaskStatus::Cancelled)
+                })
+                .collect()
+        };
+        if visible.is_empty() {
+            return "no active tasks (use /taskboard list all to see finished/cancelled)"
+                .to_owned();
+        }
         let mut lines = Vec::new();
         if !expired.is_empty() {
             lines.push(format!("expired: {}", expired.join(", ")));
         }
-        // Show TEAM column only if any task has a team restriction.
-        let has_teams = board.iter().any(|lt| lt.task.team.is_some());
+        // Show TEAM column only if any visible task has a team restriction.
+        let has_teams = visible.iter().any(|lt| lt.task.team.is_some());
         if has_teams {
             lines.push(format!(
                 "{:<8} {:<10} {:<12} {:<10} {:<12} {}",
@@ -96,7 +111,7 @@ impl TaskboardPlugin {
                 "ID", "STATUS", "ASSIGNEE", "ELAPSED", "DESCRIPTION"
             ));
         }
-        for lt in board.iter() {
+        for lt in visible.iter() {
             let elapsed = match lt.lease_start {
                 Some(start) => {
                     let secs = start.elapsed().as_secs();
@@ -769,7 +784,7 @@ mod tests {
         let (plugin, _tmp) = make_plugin();
         plugin.handle_post(&test_ctx("ba", &["post", "first task"]));
         plugin.handle_post(&test_ctx("ba", &["post", "second task"]));
-        let result = plugin.handle_list();
+        let result = plugin.handle_list(true);
         assert!(result.contains("tb-001"));
         assert!(result.contains("tb-002"));
         assert!(result.contains("first task"));
@@ -778,7 +793,7 @@ mod tests {
     #[test]
     fn handle_list_empty() {
         let (plugin, _tmp) = make_plugin();
-        let result = plugin.handle_list();
+        let result = plugin.handle_list(true);
         assert_eq!(result, "taskboard is empty");
     }
 
@@ -847,7 +862,7 @@ mod tests {
             board[0].lease_start =
                 Some(std::time::Instant::now() - std::time::Duration::from_secs(700));
         }
-        let result = plugin.handle_list();
+        let result = plugin.handle_list(true);
         assert!(result.contains("expired"));
         let board = plugin.board.lock().unwrap();
         assert_eq!(board[0].task.status, TaskStatus::Open);
@@ -1092,7 +1107,7 @@ mod tests {
         plugin.handle_post(&test_ctx("ba", &["post", &mixed]));
 
         // This is the call that panicked before the fix.
-        let result = plugin.handle_list();
+        let result = plugin.handle_list(true);
 
         assert!(result.contains("tb-001"));
         assert!(result.contains("tb-002"));
@@ -1275,7 +1290,7 @@ mod tests {
         let ctx = test_ctx_with_team_access("alice", &["post", "--team", "backend", "fix api"], ta);
         plugin.handle_post(&ctx);
         plugin.handle_post(&test_ctx("ba", &["post", "open task"]));
-        let result = plugin.handle_list();
+        let result = plugin.handle_list(true);
         assert!(result.contains("TEAM"));
         assert!(result.contains("backend"));
     }
@@ -1284,7 +1299,7 @@ mod tests {
     fn handle_list_no_team_column_when_no_teams() {
         let (plugin, _tmp) = make_plugin();
         plugin.handle_post(&test_ctx("ba", &["post", "open task"]));
-        let result = plugin.handle_list();
+        let result = plugin.handle_list(true);
         assert!(!result.contains("TEAM"));
     }
 

--- a/crates/room-plugin-taskboard/src/lib.rs
+++ b/crates/room-plugin-taskboard/src/lib.rs
@@ -129,7 +129,10 @@ impl Plugin for TaskboardPlugin {
             let action = ctx.params.first().map(String::as_str).unwrap_or("");
             let (result, broadcast) = match action {
                 "post" => self.handle_post(&ctx),
-                "list" => (self.handle_list(), false),
+                "list" => {
+                    let show_all = ctx.params.get(1).map(|s| s.as_str()) == Some("all");
+                    (self.handle_list(show_all), false)
+                }
                 "claim" => self.handle_claim(&ctx),
                 "assign" => self.handle_assign(&ctx),
                 "plan" => self.handle_plan(&ctx),
@@ -237,6 +240,84 @@ mod tests {
         assert_eq!(default.len(), instance.len());
         assert_eq!(default[0].name, instance[0].name);
         assert_eq!(default[0].params.len(), instance[0].params.len());
+    }
+
+    fn seed_task(plugin: &TaskboardPlugin, id: &str, status: TaskStatus) {
+        let mut board = plugin.board.lock().unwrap();
+        let t = task::Task {
+            id: id.to_owned(),
+            description: format!("task {id}"),
+            status,
+            posted_by: "alice".to_owned(),
+            assigned_to: if status != TaskStatus::Open {
+                Some("bob".to_owned())
+            } else {
+                None
+            },
+            posted_at: chrono::Utc::now(),
+            claimed_at: None,
+            plan: None,
+            approved_by: None,
+            approved_at: None,
+            updated_at: None,
+            notes: None,
+            team: None,
+        };
+        board.push(LiveTask::new(t));
+    }
+
+    #[test]
+    fn handle_list_filters_terminal_tasks() {
+        let (plugin, _tmp) = make_plugin();
+        seed_task(&plugin, "tb-001", TaskStatus::Open);
+        seed_task(&plugin, "tb-002", TaskStatus::Claimed);
+        seed_task(&plugin, "tb-003", TaskStatus::Finished);
+        seed_task(&plugin, "tb-004", TaskStatus::Cancelled);
+
+        let output = plugin.handle_list(false);
+        assert!(output.contains("tb-001"), "open task should appear");
+        assert!(output.contains("tb-002"), "claimed task should appear");
+        assert!(!output.contains("tb-003"), "finished task should be hidden");
+        assert!(
+            !output.contains("tb-004"),
+            "cancelled task should be hidden"
+        );
+    }
+
+    #[test]
+    fn handle_list_all_shows_everything() {
+        let (plugin, _tmp) = make_plugin();
+        seed_task(&plugin, "tb-001", TaskStatus::Open);
+        seed_task(&plugin, "tb-002", TaskStatus::Finished);
+        seed_task(&plugin, "tb-003", TaskStatus::Cancelled);
+
+        let output = plugin.handle_list(true);
+        assert!(output.contains("tb-001"), "open task should appear");
+        assert!(
+            output.contains("tb-002"),
+            "finished task should appear with all"
+        );
+        assert!(
+            output.contains("tb-003"),
+            "cancelled task should appear with all"
+        );
+    }
+
+    #[test]
+    fn handle_list_empty_after_filter() {
+        let (plugin, _tmp) = make_plugin();
+        seed_task(&plugin, "tb-001", TaskStatus::Finished);
+        seed_task(&plugin, "tb-002", TaskStatus::Cancelled);
+
+        let output = plugin.handle_list(false);
+        assert!(
+            output.contains("no active tasks"),
+            "should show helpful empty message, got: {output}"
+        );
+        assert!(
+            output.contains("/taskboard list all"),
+            "should hint at 'list all' command"
+        );
     }
 
     /// Multiple tasks with expired leases must all be swept in a single call,


### PR DESCRIPTION
## Summary

- `/taskboard list` now shows only active tasks (open, claimed, planned, approved) by default
- `/taskboard list all` shows the full board including finished and cancelled tasks
- When all tasks are terminal, displays a helpful message: "no active tasks (use /taskboard list all to see finished/cancelled)"

## Files modified

- `crates/room-plugin-taskboard/src/handlers.rs` — `handle_list()` now accepts `show_all: bool`, filters terminal statuses by default
- `crates/room-plugin-taskboard/src/lib.rs` — dispatch parses `all` modifier from params, 3 new tests

## Test plan

- [x] `handle_list_filters_terminal_tasks` — finished/cancelled hidden by default
- [x] `handle_list_all_shows_everything` — `all` modifier shows everything
- [x] `handle_list_empty_after_filter` — helpful message when all tasks are terminal
- [x] All 79 existing taskboard tests pass (6 existing `handle_list` callers updated)
- [x] `cargo clippy -- -D warnings` clean

Closes #604

🤖 Generated with [Claude Code](https://claude.com/claude-code)