### PR TITLE
refactor(tui): decompose run() into testable helpers (#634)

### DIFF
--- a/crates/room-cli/src/tui/event_loop.rs
+++ b/crates/room-cli/src/tui/event_loop.rs
@@ -262,9 +262,15 @@ async fn handle_event(
                         username: cfg.username,
                         history_lines: cfg.history_lines,
                     };
-                    if let Err(e) =
-                        handle_dm_action(tabs, active_tab, input_state, &dm_cfg, target_user, content)
-                            .await
+                    if let Err(e) = handle_dm_action(
+                        tabs,
+                        active_tab,
+                        input_state,
+                        &dm_cfg,
+                        target_user,
+                        content,
+                    )
+                    .await
                     {
                         return Ok(EventAction::Error(e));
                     }


### PR DESCRIPTION
## Summary
- Extract `setup_socket_reader()`, `compute_layout_metrics()`, and `handle_event()` from the monolithic `run()` function in `event_loop.rs`
- `compute_layout_metrics()` is now a pure function returning a `LayoutMetrics` struct, making layout computation unit-testable
- `run()` reduced from ~350 lines to ~80-line orchestrator calling the extracted helpers
- Added 7 unit tests for `compute_layout_metrics()` covering scroll clamping, multi-tab layouts, narrow terminals, and edge cases

## Test plan
- [x] All 1554 existing tests pass (zero regressions)
- [x] 7 new unit tests for `compute_layout_metrics()` cover:
  - Single-tab and multi-tab constraint generation
  - Narrow terminal dimensions
  - Cursor scroll-down past MAX_INPUT_LINES
  - Cursor scroll-up when input_row_scroll overshoots
  - Empty input baseline
  - Minimum terminal size edge case
- [ ] Manual TUI smoke test (open a room, send messages, scroll, tab switch)

Closes #634

🤖 Generated with [Claude Code](https://claude.com/claude-code)