### PR TITLE
feat: AgentPlugin scaffold with /agent spawn/list/stop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1983,6 +1983,7 @@ dependencies = [
  "chrono",
  "futures-util",
  "regex",
+ "room-plugin-agent",
  "room-plugin-taskboard",
  "room-protocol",
  "serde",
@@ -1991,6 +1992,20 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "uuid",
+]
+
+[[package]]
+name = "room-plugin-agent"
+version = "3.2.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "libc",
+ "room-protocol",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/room-daemon/Cargo.toml
+++ b/crates/room-daemon/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/lib.rs"
 [dependencies]
 room-protocol = { path = "../room-protocol", version = "3.2.0" }
 room-plugin-taskboard = { path = "../room-plugin-taskboard", version = "3.2.0" }
+room-plugin-agent = { path = "../room-plugin-agent", version = "3.2.0" }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/room-daemon/src/broker/mod.rs
+++ b/crates/room-daemon/src/broker/mod.rs
@@ -118,7 +118,7 @@ impl Broker {
 
         let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
 
-        let registry = PluginRegistry::with_all_plugins(&self.chat_path)?;
+        let registry = PluginRegistry::with_all_plugins(&self.chat_path, Some(&self.socket_path))?;
 
         // Load persisted state from a previous broker session (if any).
         let persisted_tokens = token_store::load_token_map(&self.token_map_path);

--- a/crates/room-daemon/src/broker/state.rs
+++ b/crates/room-daemon/src/broker/state.rs
@@ -123,7 +123,7 @@ impl RoomState {
         subscription_map: SubscriptionMap,
         config: Option<RoomConfig>,
     ) -> Result<Arc<Self>, String> {
-        let plugins = crate::plugin::PluginRegistry::with_all_plugins(&chat_path)
+        let plugins = crate::plugin::PluginRegistry::with_all_plugins(&chat_path, None)
             .map_err(|e| format!("plugin error: {e}"))?;
 
         let (shutdown_tx, _) = watch::channel(false);

--- a/crates/room-daemon/src/plugin/mod.rs
+++ b/crates/room-daemon/src/plugin/mod.rs
@@ -3,6 +3,8 @@ pub mod queue;
 pub mod schema;
 pub mod stats;
 
+/// Re-export the agent plugin from its own crate.
+pub use room_plugin_agent as agent;
 /// Re-export the taskboard plugin from its own crate.
 pub use room_plugin_taskboard as taskboard;
 
@@ -64,8 +66,14 @@ impl PluginRegistry {
     /// Create a registry with all standard plugins registered.
     ///
     /// Both standalone and daemon broker modes should call this so that every
-    /// room has the same set of `/` commands available.
-    pub(crate) fn with_all_plugins(chat_path: &Path) -> anyhow::Result<Self> {
+    /// room has the same set of `/` commands available. When `socket_path` is
+    /// provided, the agent plugin is registered so `/agent spawn` can pass
+    /// the socket to spawned ralph processes. Pass `None` in test contexts
+    /// where spawning is not needed.
+    pub(crate) fn with_all_plugins(
+        chat_path: &Path,
+        socket_path: Option<&Path>,
+    ) -> anyhow::Result<Self> {
         let mut registry = Self::new();
 
         let queue_path = queue::QueuePlugin::queue_path_from_chat(chat_path);
@@ -78,6 +86,17 @@ impl PluginRegistry {
             taskboard_path,
             None,
         )))?;
+
+        // Agent plugin — only registered when a socket path is available.
+        if let Some(sock) = socket_path {
+            let agents_state_path = chat_path.with_extension("agents");
+            let log_dir = crate::paths::room_home().join("logs");
+            registry.register(Box::new(agent::AgentPlugin::new(
+                agents_state_path,
+                sock.to_owned(),
+                log_dir,
+            )))?;
+        }
 
         Ok(registry)
     }

--- a/crates/room-daemon/src/plugin/schema.rs
+++ b/crates/room-daemon/src/plugin/schema.rs
@@ -1,6 +1,6 @@
 use room_protocol::plugin::{CommandInfo, ParamSchema, ParamType, Plugin};
 
-use super::{queue, stats, taskboard};
+use super::{agent, queue, stats, taskboard};
 
 // ── Built-in command schemas ───────────────────────────────────────────────
 
@@ -231,6 +231,7 @@ pub fn all_known_commands() -> Vec<CommandInfo> {
     cmds.extend(queue::QueuePlugin::default_commands());
     cmds.extend(stats::StatsPlugin.commands());
     cmds.extend(taskboard::TaskboardPlugin::default_commands());
+    cmds.extend(agent::AgentPlugin::default_commands());
     cmds
 }
 

--- a/crates/room-plugin-agent/Cargo.toml
+++ b/crates/room-plugin-agent/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "room-plugin-agent"
+version = "3.2.0"
+edition = "2021"
+description = "Agent spawn/stop/list plugin for the room multi-user chat system"
+license = "MIT"
+repository = "https://github.com/knoxio/room"
+
+[dependencies]
+room-protocol = { path = "../room-protocol", version = "3.2.0" }
+chrono = { version = "0.4", features = ["serde"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+anyhow = "1"
+libc = "0.2"
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["rt", "macros"] }
+
+[lints]
+workspace = true

--- a/crates/room-plugin-agent/src/lib.rs
+++ b/crates/room-plugin-agent/src/lib.rs
@@ -1,0 +1,644 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use room_protocol::plugin::{
+    BoxFuture, CommandContext, CommandInfo, ParamSchema, ParamType, Plugin, PluginResult,
+};
+
+/// A spawned agent process tracked by the plugin.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpawnedAgent {
+    pub username: String,
+    pub pid: u32,
+    pub model: String,
+    pub spawned_at: DateTime<Utc>,
+    pub log_path: PathBuf,
+    pub room_id: String,
+}
+
+/// Agent spawn/stop/list plugin.
+///
+/// Manages ralph agent processes spawned from within a room. Tracks PIDs,
+/// provides `/agent spawn`, `/agent list`, and `/agent stop` commands.
+pub struct AgentPlugin {
+    /// Running agents keyed by username.
+    agents: Arc<Mutex<HashMap<String, SpawnedAgent>>>,
+    /// Path to persist agent state (e.g. `~/.room/state/agents-<room>.json`).
+    state_path: PathBuf,
+    /// Socket path to pass to spawned ralph processes.
+    socket_path: PathBuf,
+    /// Directory for agent log files.
+    log_dir: PathBuf,
+}
+
+impl AgentPlugin {
+    /// Create a new agent plugin.
+    ///
+    /// Loads previously persisted agent state and prunes entries whose
+    /// processes are no longer running.
+    pub fn new(state_path: PathBuf, socket_path: PathBuf, log_dir: PathBuf) -> Self {
+        let agents = load_agents(&state_path);
+        // Prune dead agents on startup
+        let agents: HashMap<String, SpawnedAgent> = agents
+            .into_iter()
+            .filter(|(_, a)| is_process_alive(a.pid))
+            .collect();
+        let plugin = Self {
+            agents: Arc::new(Mutex::new(agents)),
+            state_path,
+            socket_path,
+            log_dir,
+        };
+        plugin.persist();
+        plugin
+    }
+
+    /// Returns the command info for the TUI command palette without needing
+    /// an instantiated plugin. Used by `all_known_commands()`.
+    pub fn default_commands() -> Vec<CommandInfo> {
+        vec![CommandInfo {
+            name: "agent".to_owned(),
+            description: "Spawn, list, or stop ralph agents".to_owned(),
+            usage: "/agent <action> [args...]".to_owned(),
+            params: vec![
+                ParamSchema {
+                    name: "action".to_owned(),
+                    param_type: ParamType::Choice(vec![
+                        "spawn".to_owned(),
+                        "list".to_owned(),
+                        "stop".to_owned(),
+                    ]),
+                    required: true,
+                    description: "Subcommand".to_owned(),
+                },
+                ParamSchema {
+                    name: "args".to_owned(),
+                    param_type: ParamType::Text,
+                    required: false,
+                    description: "Arguments for the subcommand".to_owned(),
+                },
+            ],
+        }]
+    }
+
+    fn persist(&self) {
+        let agents = self.agents.lock().unwrap();
+        if let Ok(json) = serde_json::to_string_pretty(&*agents) {
+            let _ = fs::write(&self.state_path, json);
+        }
+    }
+
+    fn handle_spawn(&self, ctx: &CommandContext) -> Result<String, String> {
+        // Parse: /agent spawn <username> [--model <model>] [--issue <N>] [--prompt <text>]
+        let params = &ctx.params;
+        if params.len() < 2 {
+            return Err(
+                "usage: /agent spawn <username> [--model <model>] [--issue <N>] [--prompt <text>]"
+                    .to_owned(),
+            );
+        }
+
+        let username = &params[1];
+
+        // Validate username is not empty
+        if username.is_empty() || username.starts_with('-') {
+            return Err("invalid username".to_owned());
+        }
+
+        // Check for collision with online users
+        if ctx
+            .metadata
+            .online_users
+            .iter()
+            .any(|u| u.username == *username)
+        {
+            return Err(format!("username '{username}' is already online"));
+        }
+
+        // Check for collision with already-spawned agents
+        {
+            let agents = self.agents.lock().unwrap();
+            if agents.contains_key(username.as_str()) {
+                return Err(format!(
+                    "agent '{username}' is already running (pid {})",
+                    agents[username.as_str()].pid
+                ));
+            }
+        }
+
+        // Parse optional flags from params[2..]
+        let mut model = "sonnet".to_owned();
+        let mut issue: Option<String> = None;
+        let mut prompt: Option<String> = None;
+
+        let mut i = 2;
+        while i < params.len() {
+            match params[i].as_str() {
+                "--model" => {
+                    i += 1;
+                    if i < params.len() {
+                        model = params[i].clone();
+                    }
+                }
+                "--issue" => {
+                    i += 1;
+                    if i < params.len() {
+                        issue = Some(params[i].clone());
+                    }
+                }
+                "--prompt" => {
+                    i += 1;
+                    if i < params.len() {
+                        prompt = Some(params[i].clone());
+                    }
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+
+        // Create log directory
+        let _ = fs::create_dir_all(&self.log_dir);
+
+        let ts = Utc::now().format("%Y%m%d-%H%M%S");
+        let log_path = self.log_dir.join(format!("agent-{username}-{ts}.log"));
+
+        let log_file =
+            fs::File::create(&log_path).map_err(|e| format!("failed to create log file: {e}"))?;
+        let stderr_file = log_file
+            .try_clone()
+            .map_err(|e| format!("failed to clone log file handle: {e}"))?;
+
+        // Build the room-ralph command
+        let mut cmd = Command::new("room-ralph");
+        cmd.arg(&ctx.room_id)
+            .arg(username)
+            .arg("--socket")
+            .arg(&self.socket_path)
+            .arg("--model")
+            .arg(&model);
+
+        if let Some(ref iss) = issue {
+            cmd.arg("--issue").arg(iss);
+        }
+        if let Some(ref p) = prompt {
+            cmd.arg("--prompt").arg(p);
+        }
+
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::from(log_file))
+            .stderr(Stdio::from(stderr_file));
+
+        let child = cmd
+            .spawn()
+            .map_err(|e| format!("failed to spawn room-ralph: {e}"))?;
+
+        let pid = child.id();
+
+        let agent = SpawnedAgent {
+            username: username.clone(),
+            pid,
+            model: model.clone(),
+            spawned_at: Utc::now(),
+            log_path: log_path.clone(),
+            room_id: ctx.room_id.clone(),
+        };
+
+        {
+            let mut agents = self.agents.lock().unwrap();
+            agents.insert(username.clone(), agent);
+        }
+        self.persist();
+
+        Ok(format!(
+            "agent {username} spawned (pid {pid}, model: {model})"
+        ))
+    }
+
+    fn handle_list(&self) -> String {
+        let agents = self.agents.lock().unwrap();
+        if agents.is_empty() {
+            return "no agents spawned".to_owned();
+        }
+
+        let mut lines = vec!["username     | pid   | model  | uptime  | status".to_owned()];
+
+        let now = Utc::now();
+        let mut entries: Vec<_> = agents.values().collect();
+        entries.sort_by_key(|a| a.spawned_at);
+
+        for agent in entries {
+            let uptime = format_duration(now - agent.spawned_at);
+            let status = if is_process_alive(agent.pid) {
+                "running"
+            } else {
+                "exited"
+            };
+            lines.push(format!(
+                "{:<12} | {:<5} | {:<6} | {:<7} | {}",
+                agent.username, agent.pid, agent.model, uptime, status,
+            ));
+        }
+
+        lines.join("\n")
+    }
+
+    fn handle_stop(&self, params: &[String]) -> Result<String, String> {
+        if params.len() < 2 {
+            return Err("usage: /agent stop <username>".to_owned());
+        }
+
+        let username = &params[1];
+
+        let agent = {
+            let agents = self.agents.lock().unwrap();
+            agents.get(username.as_str()).cloned()
+        };
+
+        let Some(agent) = agent else {
+            return Err(format!("no agent named '{username}'"));
+        };
+
+        // Send SIGTERM, then SIGKILL if still alive after 2s
+        stop_process(agent.pid);
+
+        {
+            let mut agents = self.agents.lock().unwrap();
+            agents.remove(username.as_str());
+        }
+        self.persist();
+
+        Ok(format!(
+            "agent {} stopped (was pid {})",
+            username, agent.pid
+        ))
+    }
+}
+
+impl Plugin for AgentPlugin {
+    fn name(&self) -> &str {
+        "agent"
+    }
+
+    fn version(&self) -> &str {
+        env!("CARGO_PKG_VERSION")
+    }
+
+    fn commands(&self) -> Vec<CommandInfo> {
+        Self::default_commands()
+    }
+
+    fn handle(&self, ctx: CommandContext) -> BoxFuture<'_, anyhow::Result<PluginResult>> {
+        Box::pin(async move {
+            let action = ctx.params.first().map(|s| s.as_str()).unwrap_or("");
+
+            match action {
+                "spawn" => match self.handle_spawn(&ctx) {
+                    Ok(msg) => Ok(PluginResult::Broadcast(msg)),
+                    Err(e) => Ok(PluginResult::Reply(e)),
+                },
+                "list" => Ok(PluginResult::Reply(self.handle_list())),
+                "stop" => match self.handle_stop(&ctx.params) {
+                    Ok(msg) => Ok(PluginResult::Broadcast(msg)),
+                    Err(e) => Ok(PluginResult::Reply(e)),
+                },
+                _ => Ok(PluginResult::Reply(
+                    "unknown action. usage: /agent spawn|list|stop".to_owned(),
+                )),
+            }
+        })
+    }
+}
+
+/// Check whether a process with the given PID is still running.
+fn is_process_alive(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        // kill(pid, 0) checks existence without sending a signal
+        unsafe { libc::kill(pid as i32, 0) == 0 }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        false
+    }
+}
+
+/// Send SIGTERM to a process, wait 2 seconds, then SIGKILL if still alive.
+fn stop_process(pid: u32) {
+    #[cfg(unix)]
+    {
+        unsafe {
+            libc::kill(pid as i32, libc::SIGTERM);
+        }
+        std::thread::sleep(std::time::Duration::from_secs(2));
+        if is_process_alive(pid) {
+            unsafe {
+                libc::kill(pid as i32, libc::SIGKILL);
+            }
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+    }
+}
+
+/// Format a chrono Duration as a human-readable string (e.g. "14m", "2h").
+fn format_duration(d: chrono::Duration) -> String {
+    let secs = d.num_seconds();
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 3600 {
+        format!("{}m", secs / 60)
+    } else {
+        format!("{}h", secs / 3600)
+    }
+}
+
+/// Load agent state from a JSON file, returning an empty map on error.
+fn load_agents(path: &std::path::Path) -> HashMap<String, SpawnedAgent> {
+    match fs::read_to_string(path) {
+        Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
+        Err(_) => HashMap::new(),
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use room_protocol::plugin::{RoomMetadata, UserInfo};
+
+    fn test_plugin(dir: &std::path::Path) -> AgentPlugin {
+        AgentPlugin::new(
+            dir.join("agents.json"),
+            dir.join("room.sock"),
+            dir.join("logs"),
+        )
+    }
+
+    fn make_ctx(_plugin: &AgentPlugin, params: Vec<&str>, online: Vec<&str>) -> CommandContext {
+        CommandContext {
+            command: "agent".to_owned(),
+            params: params.into_iter().map(|s| s.to_owned()).collect(),
+            sender: "host".to_owned(),
+            room_id: "test-room".to_owned(),
+            message_id: "msg-1".to_owned(),
+            timestamp: Utc::now(),
+            history: Box::new(NoopHistory),
+            writer: Box::new(NoopWriter),
+            metadata: RoomMetadata {
+                online_users: online
+                    .into_iter()
+                    .map(|u| UserInfo {
+                        username: u.to_owned(),
+                        status: String::new(),
+                    })
+                    .collect(),
+                host: Some("host".to_owned()),
+                message_count: 0,
+            },
+            available_commands: vec![],
+            team_access: None,
+        }
+    }
+
+    // Noop implementations for test contexts
+    struct NoopHistory;
+    impl room_protocol::plugin::HistoryAccess for NoopHistory {
+        fn all(&self) -> BoxFuture<'_, anyhow::Result<Vec<room_protocol::Message>>> {
+            Box::pin(async { Ok(vec![]) })
+        }
+        fn tail(&self, _n: usize) -> BoxFuture<'_, anyhow::Result<Vec<room_protocol::Message>>> {
+            Box::pin(async { Ok(vec![]) })
+        }
+        fn since(
+            &self,
+            _message_id: &str,
+        ) -> BoxFuture<'_, anyhow::Result<Vec<room_protocol::Message>>> {
+            Box::pin(async { Ok(vec![]) })
+        }
+        fn count(&self) -> BoxFuture<'_, anyhow::Result<usize>> {
+            Box::pin(async { Ok(0) })
+        }
+    }
+
+    struct NoopWriter;
+    impl room_protocol::plugin::MessageWriter for NoopWriter {
+        fn broadcast(&self, _content: &str) -> BoxFuture<'_, anyhow::Result<()>> {
+            Box::pin(async { Ok(()) })
+        }
+        fn reply_to(&self, _user: &str, _content: &str) -> BoxFuture<'_, anyhow::Result<()>> {
+            Box::pin(async { Ok(()) })
+        }
+        fn emit_event(
+            &self,
+            _event_type: room_protocol::EventType,
+            _content: &str,
+            _params: Option<serde_json::Value>,
+        ) -> BoxFuture<'_, anyhow::Result<()>> {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    #[test]
+    fn spawn_missing_username() {
+        let dir = tempfile::tempdir().unwrap();
+        let plugin = test_plugin(dir.path());
+        let ctx = make_ctx(&plugin, vec!["spawn"], vec![]);
+        let result = plugin.handle_spawn(&ctx);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("usage"));
+    }
+
+    #[test]
+    fn spawn_invalid_username() {
+        let dir = tempfile::tempdir().unwrap();
+        let plugin = test_plugin(dir.path());
+        let ctx = make_ctx(&plugin, vec!["spawn", "--badname"], vec![]);
+        let result = plugin.handle_spawn(&ctx);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("invalid username"));
+    }
+
+    #[test]
+    fn spawn_username_collision_with_online_user() {
+        let dir = tempfile::tempdir().unwrap();
+        let plugin = test_plugin(dir.path());
+        let ctx = make_ctx(&plugin, vec!["spawn", "alice"], vec!["alice", "bob"]);
+        let result = plugin.handle_spawn(&ctx);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("already online"));
+    }
+
+    #[test]
+    fn spawn_username_collision_with_running_agent() {
+        let dir = tempfile::tempdir().unwrap();
+        let plugin = test_plugin(dir.path());
+
+        // Manually insert a fake running agent (use our own PID so it appears alive)
+        {
+            let mut agents = plugin.agents.lock().unwrap();
+            agents.insert(
+                "bot1".to_owned(),
+                SpawnedAgent {
+                    username: "bot1".to_owned(),
+                    pid: std::process::id(),
+                    model: "sonnet".to_owned(),
+                    spawned_at: Utc::now(),
+                    log_path: PathBuf::from("/tmp/test.log"),
+                    room_id: "test-room".to_owned(),
+                },
+            );
+        }
+
+        let ctx = make_ctx(&plugin, vec!["spawn", "bot1"], vec![]);
+        let result = plugin.handle_spawn(&ctx);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("already running"));
+    }
+
+    #[test]
+    fn list_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let plugin = test_plugin(dir.path());
+        assert_eq!(plugin.handle_list(), "no agents spawned");
+    }
+
+    #[test]
+    fn list_with_agents() {
+        let dir = tempfile::tempdir().unwrap();
+        let plugin = test_plugin(dir.path());
+
+        {
+            let mut agents = plugin.agents.lock().unwrap();
+            agents.insert(
+                "bot1".to_owned(),
+                SpawnedAgent {
+                    username: "bot1".to_owned(),
+                    pid: 99999,
+                    model: "opus".to_owned(),
+                    spawned_at: Utc::now(),
+                    log_path: PathBuf::from("/tmp/test.log"),
+                    room_id: "test-room".to_owned(),
+                },
+            );
+        }
+
+        let output = plugin.handle_list();
+        assert!(output.contains("bot1"));
+        assert!(output.contains("opus"));
+        assert!(output.contains("99999"));
+    }
+
+    #[test]
+    fn stop_missing_username() {
+        let dir = tempfile::tempdir().unwrap();
+        let plugin = test_plugin(dir.path());
+        let result = plugin.handle_stop(&["stop".to_owned()]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("usage"));
+    }
+
+    #[test]
+    fn stop_unknown_agent() {
+        let dir = tempfile::tempdir().unwrap();
+        let plugin = test_plugin(dir.path());
+        let result = plugin.handle_stop(&["stop".to_owned(), "nobody".to_owned()]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("no agent named"));
+    }
+
+    #[test]
+    fn persist_and_load_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("agents.json");
+
+        // Create plugin and add an agent
+        let plugin = AgentPlugin::new(
+            state_path.clone(),
+            dir.path().join("room.sock"),
+            dir.path().join("logs"),
+        );
+        {
+            let mut agents = plugin.agents.lock().unwrap();
+            agents.insert(
+                "bot1".to_owned(),
+                SpawnedAgent {
+                    username: "bot1".to_owned(),
+                    pid: std::process::id(), // use own PID so it appears alive
+                    model: "sonnet".to_owned(),
+                    spawned_at: Utc::now(),
+                    log_path: PathBuf::from("/tmp/test.log"),
+                    room_id: "test-room".to_owned(),
+                },
+            );
+        }
+        plugin.persist();
+
+        // Load a new plugin from same state — should find the agent
+        let plugin2 = AgentPlugin::new(
+            state_path,
+            dir.path().join("room.sock"),
+            dir.path().join("logs"),
+        );
+        let agents = plugin2.agents.lock().unwrap();
+        assert!(agents.contains_key("bot1"));
+    }
+
+    #[test]
+    fn prune_dead_agents_on_load() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("agents.json");
+
+        // Write a state file with a dead PID
+        let mut agents = HashMap::new();
+        agents.insert(
+            "dead-bot".to_owned(),
+            SpawnedAgent {
+                username: "dead-bot".to_owned(),
+                pid: 999_999_999, // very unlikely to be alive
+                model: "haiku".to_owned(),
+                spawned_at: Utc::now(),
+                log_path: PathBuf::from("/tmp/test.log"),
+                room_id: "test-room".to_owned(),
+            },
+        );
+        fs::write(&state_path, serde_json::to_string(&agents).unwrap()).unwrap();
+
+        // New plugin should prune the dead agent
+        let plugin = AgentPlugin::new(
+            state_path,
+            dir.path().join("room.sock"),
+            dir.path().join("logs"),
+        );
+        let agents = plugin.agents.lock().unwrap();
+        assert!(agents.is_empty(), "dead agents should be pruned on load");
+    }
+
+    #[test]
+    fn unknown_action_returns_usage() {
+        let dir = tempfile::tempdir().unwrap();
+        let plugin = test_plugin(dir.path());
+        let ctx = make_ctx(&plugin, vec!["frobnicate"], vec![]);
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let result = rt.block_on(plugin.handle(ctx)).unwrap();
+        match result {
+            PluginResult::Reply(msg) => assert!(msg.contains("unknown action")),
+            PluginResult::Broadcast(_) => panic!("expected Reply, got Broadcast"),
+            PluginResult::Handled => panic!("expected Reply, got Handled"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- New crate `room-plugin-agent` implementing `Plugin` trait with `/agent spawn`, `/agent list`, `/agent stop` commands
- Spawns `room-ralph` as a detached process with log capture, validates username uniqueness
- PID persistence at `<room>.agents` JSON, dead agents pruned on startup
- Registered in room-daemon plugin registry (standalone mode; daemon mode deferred)
- 11 unit tests for validation, collision detection, list/stop, persistence

## Files
- **NEW** `crates/room-plugin-agent/Cargo.toml`
- **NEW** `crates/room-plugin-agent/src/lib.rs` — AgentPlugin, SpawnedAgent, spawn/list/stop handlers
- `crates/room-daemon/Cargo.toml` — add room-plugin-agent dependency
- `crates/room-daemon/src/plugin/mod.rs` — register agent plugin, `with_all_plugins` gains `socket_path` param
- `crates/room-daemon/src/plugin/schema.rs` — add agent commands to `all_known_commands()`
- `crates/room-daemon/src/broker/mod.rs` — pass socket_path to with_all_plugins
- `crates/room-daemon/src/broker/state.rs` — pass None for socket_path (daemon mode)

## Design decisions
- `with_all_plugins` takes `Option<&Path>` for socket_path — when `None`, agent plugin is not registered (test contexts, daemon mode pending socket forwarding)
- Process signals use `libc` directly (no nix dependency) for SIGTERM/SIGKILL
- Log files written to `~/.room/logs/agent-<username>-<timestamp>.log`

Closes #688

## Test plan
- [x] 11 unit tests: spawn param validation, username collision (online + running agent), list empty/populated, stop missing/unknown, persist roundtrip, dead prune, unknown action
- [x] All existing tests pass (no regressions)
- [x] Full pre-push checks pass (cargo check, fmt, clippy, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)