### PR TITLE
feat(cli): add room agent subcommand for oneshot agent management

### DIFF
--- a/crates/room-cli/src/cli.rs
+++ b/crates/room-cli/src/cli.rs
@@ -259,6 +259,22 @@ pub enum Cmd {
         #[arg(long)]
         socket: Option<PathBuf>,
     },
+    /// Manage ralph agents via CLI (spawn, list, stop, logs).
+    ///
+    /// Routes commands through the broker to the AgentPlugin. Requires a running
+    /// daemon with the AgentPlugin registered.
+    Agent {
+        /// Room ID where agents are managed
+        room_id: String,
+        /// Session token from `room join` (required)
+        #[arg(short = 't', long)]
+        token: String,
+        /// Override the broker socket path (default: auto-discover daemon or per-room socket)
+        #[arg(long)]
+        socket: Option<PathBuf>,
+        #[command(subcommand)]
+        action: AgentAction,
+    },
     /// List active rooms with running brokers.
     ///
     /// Scans `/tmp` for `room-*.sock` files and probes each to verify the broker
@@ -309,6 +325,40 @@ pub enum Cmd {
         /// to subsequent commands to target the isolated instance.
         #[arg(long)]
         isolated: bool,
+    },
+}
+
+/// Agent management subcommands.
+#[derive(Subcommand, Debug)]
+pub enum AgentAction {
+    /// Spawn a new ralph agent in the room.
+    Spawn {
+        /// Username for the spawned agent
+        username: String,
+        /// Claude model to use (e.g. sonnet, opus, haiku)
+        #[arg(long)]
+        model: Option<String>,
+        /// GitHub issue number for the agent to work on
+        #[arg(long)]
+        issue: Option<String>,
+        /// Personality name for the agent
+        #[arg(long)]
+        personality: Option<String>,
+    },
+    /// List all agents in the room with their status.
+    List,
+    /// Stop a running agent.
+    Stop {
+        /// Username of the agent to stop
+        username: String,
+    },
+    /// View logs for an agent.
+    Logs {
+        /// Username of the agent
+        username: String,
+        /// Number of lines to show from the end (default: 50)
+        #[arg(long, default_value_t = 50)]
+        tail: usize,
     },
 }
 

--- a/crates/room-cli/src/main.rs
+++ b/crates/room-cli/src/main.rs
@@ -14,7 +14,7 @@ use room_cli::{
     query::{has_narrowing_filter, QueryFilter},
 };
 
-use cli::{Args, Cmd};
+use cli::{AgentAction, Args, Cmd};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -331,6 +331,45 @@ async fn main() -> anyhow::Result<()> {
             socket,
         }) => {
             oneshot::cmd_destroy(&room_id, socket.as_deref(), &token).await?;
+        }
+        Some(Cmd::Agent {
+            room_id,
+            token,
+            socket,
+            action,
+        }) => {
+            if socket.is_none() {
+                oneshot::ensure_daemon_running().await?;
+            }
+            match action {
+                AgentAction::Spawn {
+                    username,
+                    model,
+                    issue,
+                    personality,
+                } => {
+                    oneshot::cmd_agent_spawn(
+                        &room_id,
+                        &token,
+                        &username,
+                        model.as_deref(),
+                        issue.as_deref(),
+                        personality.as_deref(),
+                        socket.as_deref(),
+                    )
+                    .await?;
+                }
+                AgentAction::List => {
+                    oneshot::cmd_agent_list(&room_id, &token, socket.as_deref()).await?;
+                }
+                AgentAction::Stop { username } => {
+                    oneshot::cmd_agent_stop(&room_id, &token, &username, socket.as_deref()).await?;
+                }
+                AgentAction::Logs { username, tail } => {
+                    oneshot::cmd_agent_logs(&room_id, &token, &username, tail, socket.as_deref())
+                        .await?;
+                }
+            }
         }
         Some(Cmd::List) => {
             oneshot::cmd_list().await?;

--- a/crates/room-cli/src/oneshot/agent.rs
+++ b/crates/room-cli/src/oneshot/agent.rs
@@ -1,0 +1,188 @@
+use super::transport::{resolve_socket_target, send_message_with_token_target as transport_send};
+use crate::message::Message;
+
+/// Send an `/agent` command to the broker and print the response.
+///
+/// Builds a command envelope with `cmd: "agent"` and the given params,
+/// sends it via the oneshot transport, and prints the broker's reply.
+async fn send_agent_command(
+    room_id: &str,
+    token: &str,
+    params: Vec<String>,
+    socket: Option<&std::path::Path>,
+) -> anyhow::Result<()> {
+    let target = resolve_socket_target(room_id, socket);
+    let wire = serde_json::json!({"type": "command", "cmd": "agent", "params": params}).to_string();
+    let msg = transport_send(&target, token, &wire).await.map_err(|e| {
+        if e.to_string().contains("invalid token") {
+            anyhow::anyhow!("invalid token — run: room join <username>")
+        } else {
+            e
+        }
+    })?;
+
+    match &msg {
+        Message::System { content, .. } => println!("{content}"),
+        _ => println!("{}", serde_json::to_string(&msg)?),
+    }
+    Ok(())
+}
+
+/// One-shot `room agent spawn` — spawn a ralph agent in the room.
+pub async fn cmd_agent_spawn(
+    room_id: &str,
+    token: &str,
+    username: &str,
+    model: Option<&str>,
+    issue: Option<&str>,
+    personality: Option<&str>,
+    socket: Option<&std::path::Path>,
+) -> anyhow::Result<()> {
+    let mut params = vec!["spawn".to_owned(), username.to_owned()];
+    if let Some(m) = model {
+        params.push("--model".to_owned());
+        params.push(m.to_owned());
+    }
+    if let Some(i) = issue {
+        params.push("--issue".to_owned());
+        params.push(i.to_owned());
+    }
+    if let Some(p) = personality {
+        params.push("--personality".to_owned());
+        params.push(p.to_owned());
+    }
+    send_agent_command(room_id, token, params, socket).await
+}
+
+/// One-shot `room agent list` — list agents in the room.
+pub async fn cmd_agent_list(
+    room_id: &str,
+    token: &str,
+    socket: Option<&std::path::Path>,
+) -> anyhow::Result<()> {
+    send_agent_command(room_id, token, vec!["list".to_owned()], socket).await
+}
+
+/// One-shot `room agent stop` — stop a running agent.
+pub async fn cmd_agent_stop(
+    room_id: &str,
+    token: &str,
+    username: &str,
+    socket: Option<&std::path::Path>,
+) -> anyhow::Result<()> {
+    send_agent_command(
+        room_id,
+        token,
+        vec!["stop".to_owned(), username.to_owned()],
+        socket,
+    )
+    .await
+}
+
+/// One-shot `room agent logs` — view agent logs.
+pub async fn cmd_agent_logs(
+    room_id: &str,
+    token: &str,
+    username: &str,
+    tail: usize,
+    socket: Option<&std::path::Path>,
+) -> anyhow::Result<()> {
+    send_agent_command(
+        room_id,
+        token,
+        vec![
+            "logs".to_owned(),
+            username.to_owned(),
+            "--tail".to_owned(),
+            tail.to_string(),
+        ],
+        socket,
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn agent_spawn_wire_payload() {
+        let params = vec!["spawn".to_owned(), "testbot".to_owned()];
+        let wire =
+            serde_json::json!({"type": "command", "cmd": "agent", "params": params}).to_string();
+        let v: serde_json::Value = serde_json::from_str(&wire).unwrap();
+        assert_eq!(v["type"], "command");
+        assert_eq!(v["cmd"], "agent");
+        let p: Vec<&str> = v["params"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|x| x.as_str().unwrap())
+            .collect();
+        assert_eq!(p, vec!["spawn", "testbot"]);
+    }
+
+    #[test]
+    fn agent_spawn_with_flags_wire_payload() {
+        let mut params = vec!["spawn".to_owned(), "mybot".to_owned()];
+        params.push("--model".to_owned());
+        params.push("sonnet".to_owned());
+        params.push("--issue".to_owned());
+        params.push("42".to_owned());
+        let wire =
+            serde_json::json!({"type": "command", "cmd": "agent", "params": params}).to_string();
+        let v: serde_json::Value = serde_json::from_str(&wire).unwrap();
+        let p: Vec<&str> = v["params"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|x| x.as_str().unwrap())
+            .collect();
+        assert_eq!(
+            p,
+            vec!["spawn", "mybot", "--model", "sonnet", "--issue", "42"]
+        );
+    }
+
+    #[test]
+    fn agent_list_wire_payload() {
+        let wire =
+            serde_json::json!({"type": "command", "cmd": "agent", "params": ["list"]}).to_string();
+        let v: serde_json::Value = serde_json::from_str(&wire).unwrap();
+        assert_eq!(v["cmd"], "agent");
+        assert_eq!(v["params"][0], "list");
+    }
+
+    #[test]
+    fn agent_stop_wire_payload() {
+        let wire =
+            serde_json::json!({"type": "command", "cmd": "agent", "params": ["stop", "bot1"]})
+                .to_string();
+        let v: serde_json::Value = serde_json::from_str(&wire).unwrap();
+        assert_eq!(v["cmd"], "agent");
+        let p: Vec<&str> = v["params"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|x| x.as_str().unwrap())
+            .collect();
+        assert_eq!(p, vec!["stop", "bot1"]);
+    }
+
+    #[test]
+    fn agent_logs_wire_payload() {
+        let wire = serde_json::json!({
+            "type": "command",
+            "cmd": "agent",
+            "params": ["logs", "bot1", "--tail", "100"]
+        })
+        .to_string();
+        let v: serde_json::Value = serde_json::from_str(&wire).unwrap();
+        assert_eq!(v["cmd"], "agent");
+        let p: Vec<&str> = v["params"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|x| x.as_str().unwrap())
+            .collect();
+        assert_eq!(p, vec!["logs", "bot1", "--tail", "100"]);
+    }
+}

--- a/crates/room-cli/src/oneshot/mod.rs
+++ b/crates/room-cli/src/oneshot/mod.rs
@@ -1,3 +1,4 @@
+pub mod agent;
 pub mod list;
 pub mod poll;
 pub mod subscribe;
@@ -5,6 +6,7 @@ pub mod token;
 pub mod transport;
 pub mod who;
 
+pub use agent::{cmd_agent_list, cmd_agent_logs, cmd_agent_spawn, cmd_agent_stop};
 pub use list::{cmd_list, discover_daemon_rooms, discover_joined_rooms};
 pub use poll::{
     cmd_poll, cmd_poll_multi, cmd_pull, cmd_query, cmd_watch, poll_messages, poll_messages_multi,


### PR DESCRIPTION
## Summary
- Add `room agent` top-level CLI subcommand with `spawn`, `list`, `stop`, `logs` actions
- Each action builds a `/agent` command envelope and routes through oneshot transport to the AgentPlugin
- Supports `--model`, `--issue`, `--personality` flags on spawn and `--tail` on logs
- 5 unit tests for wire payload construction

Closes #695

## Files
- **NEW** `crates/room-cli/src/oneshot/agent.rs` — oneshot command handlers
- `crates/room-cli/src/cli.rs` — `Agent` variant + `AgentAction` enum
- `crates/room-cli/src/main.rs` — dispatch arm
- `crates/room-cli/src/oneshot/mod.rs` — module + re-exports

## Test plan
- [x] `cargo check` passes
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test` — all tests pass
- [ ] Manual: `room agent list myroom -t TOKEN` returns agent list from broker

🤖 Generated with [Claude Code](https://claude.com/claude-code)