### PR TITLE
refactor: DRY handle_team join/leave with team_mutate helper

### DIFF
--- a/crates/room-daemon/src/broker/commands/team.rs
+++ b/crates/room-daemon/src/broker/commands/team.rs
@@ -1,8 +1,72 @@
 use room_protocol::make_system;
+use tokio::sync::Mutex;
 
 use crate::broker::{fanout::broadcast_and_persist, state::RoomState};
+use crate::registry::UserRegistry;
 
 use super::CommandResult;
+
+/// Operation-specific text for [`team_mutate`].
+struct MutateLabels {
+    usage: &'static str,
+    success_verb: &'static str,
+    noop_msg: &'static str,
+}
+
+/// Shared helper for `/team join` and `/team leave`.
+///
+/// Both arms follow the same pattern: extract team_name, resolve target_user,
+/// lock the registry, call the mutation, and translate the result. The only
+/// differences are the usage string, the registry method, the success verb,
+/// and the "no-op" message — all passed via [`MutateLabels`] and `op`.
+async fn team_mutate<F>(
+    params: &[String],
+    username: &str,
+    state: &RoomState,
+    registry_lock: &Mutex<UserRegistry>,
+    labels: MutateLabels,
+    op: F,
+) -> anyhow::Result<CommandResult>
+where
+    F: FnOnce(&mut UserRegistry, &str, &str) -> Result<bool, String>,
+{
+    let team_name = match params.get(1) {
+        Some(t) => t.as_str(),
+        None => {
+            let sys = make_system(&state.room_id, "broker", labels.usage.to_owned());
+            let json = serde_json::to_string(&sys)?;
+            return Ok(CommandResult::Reply(json));
+        }
+    };
+    let target_user = params.get(2).map(|s| s.as_str()).unwrap_or(username);
+    let mut reg = registry_lock.lock().await;
+    match op(&mut reg, team_name, target_user) {
+        Ok(true) => {
+            drop(reg);
+            let content = format!("{target_user} {} team {team_name}", labels.success_verb);
+            let sys = make_system(&state.room_id, "broker", content);
+            let seq_msg =
+                broadcast_and_persist(&sys, &state.clients, &state.chat_path, &state.seq_counter)
+                    .await?;
+            let json = serde_json::to_string(&seq_msg)?;
+            Ok(CommandResult::HandledWithReply(json))
+        }
+        Ok(false) => {
+            let sys = make_system(
+                &state.room_id,
+                "broker",
+                format!("{target_user} {} {team_name}", labels.noop_msg),
+            );
+            let json = serde_json::to_string(&sys)?;
+            Ok(CommandResult::Reply(json))
+        }
+        Err(e) => {
+            let sys = make_system(&state.room_id, "broker", format!("error: {e}"));
+            let json = serde_json::to_string(&sys)?;
+            Ok(CommandResult::Reply(json))
+        }
+    }
+}
 
 /// Handle `/team <action> [args...]` — manage daemon-level teams.
 ///
@@ -32,96 +96,34 @@ pub(super) async fn handle_team(
 
     match action {
         "join" => {
-            let team_name = match params.get(1) {
-                Some(t) => t.as_str(),
-                None => {
-                    let sys = make_system(
-                        &state.room_id,
-                        "broker",
-                        "usage: /team join <team> [user]".to_owned(),
-                    );
-                    let json = serde_json::to_string(&sys)?;
-                    return Ok(CommandResult::Reply(json));
-                }
-            };
-            let target_user = params.get(2).map(|s| s.as_str()).unwrap_or(username);
-            let mut reg = registry_lock.lock().await;
-            match reg.join_team(team_name, target_user) {
-                Ok(true) => {
-                    drop(reg);
-                    let content = format!("{target_user} joined team {team_name}");
-                    let sys = make_system(&state.room_id, "broker", content);
-                    let seq_msg = broadcast_and_persist(
-                        &sys,
-                        &state.clients,
-                        &state.chat_path,
-                        &state.seq_counter,
-                    )
-                    .await?;
-                    let json = serde_json::to_string(&seq_msg)?;
-                    Ok(CommandResult::HandledWithReply(json))
-                }
-                Ok(false) => {
-                    let sys = make_system(
-                        &state.room_id,
-                        "broker",
-                        format!("{target_user} is already in team {team_name}"),
-                    );
-                    let json = serde_json::to_string(&sys)?;
-                    Ok(CommandResult::Reply(json))
-                }
-                Err(e) => {
-                    let sys = make_system(&state.room_id, "broker", format!("error: {e}"));
-                    let json = serde_json::to_string(&sys)?;
-                    Ok(CommandResult::Reply(json))
-                }
-            }
+            team_mutate(
+                params,
+                username,
+                state,
+                registry_lock,
+                MutateLabels {
+                    usage: "usage: /team join <team> [user]",
+                    success_verb: "joined",
+                    noop_msg: "is already in team",
+                },
+                |reg, team, user| reg.join_team(team, user),
+            )
+            .await
         }
         "leave" => {
-            let team_name = match params.get(1) {
-                Some(t) => t.as_str(),
-                None => {
-                    let sys = make_system(
-                        &state.room_id,
-                        "broker",
-                        "usage: /team leave <team> [user]".to_owned(),
-                    );
-                    let json = serde_json::to_string(&sys)?;
-                    return Ok(CommandResult::Reply(json));
-                }
-            };
-            let target_user = params.get(2).map(|s| s.as_str()).unwrap_or(username);
-            let mut reg = registry_lock.lock().await;
-            match reg.leave_team(team_name, target_user) {
-                Ok(true) => {
-                    drop(reg);
-                    let content = format!("{target_user} left team {team_name}");
-                    let sys = make_system(&state.room_id, "broker", content);
-                    let seq_msg = broadcast_and_persist(
-                        &sys,
-                        &state.clients,
-                        &state.chat_path,
-                        &state.seq_counter,
-                    )
-                    .await?;
-                    let json = serde_json::to_string(&seq_msg)?;
-                    Ok(CommandResult::HandledWithReply(json))
-                }
-                Ok(false) => {
-                    let sys = make_system(
-                        &state.room_id,
-                        "broker",
-                        format!("{target_user} is not in team {team_name}"),
-                    );
-                    let json = serde_json::to_string(&sys)?;
-                    Ok(CommandResult::Reply(json))
-                }
-                Err(e) => {
-                    let sys = make_system(&state.room_id, "broker", format!("error: {e}"));
-                    let json = serde_json::to_string(&sys)?;
-                    Ok(CommandResult::Reply(json))
-                }
-            }
+            team_mutate(
+                params,
+                username,
+                state,
+                registry_lock,
+                MutateLabels {
+                    usage: "usage: /team leave <team> [user]",
+                    success_verb: "left",
+                    noop_msg: "is not in team",
+                },
+                |reg, team, user| reg.leave_team(team, user),
+            )
+            .await
         }
         "list" => {
             let reg = registry_lock.lock().await;


### PR DESCRIPTION
## Summary
- Extract shared `team_mutate()` function and `MutateLabels` struct to deduplicate the nearly identical join/leave arms in `handle_team()`
- Both arms followed the same pattern (extract team_name, resolve target_user, lock registry, call mutation, translate result) with only the usage text, success verb, noop message, and registry method differing
- Pure refactor — no behavioral changes

## Test plan
- [x] All existing tests pass (no new tests needed — behavior unchanged)
- [x] `cargo check` / `cargo fmt` / `cargo clippy -- -D warnings` / `cargo test` all green

Closes #677

🤖 Generated with [Claude Code](https://claude.com/claude-code)
