### PR TITLE
feat: structured plugin responses with machine-readable data (#697)

### DIFF
--- a/crates/room-cli/src/tui/mod.rs
+++ b/crates/room-cli/src/tui/mod.rs
@@ -160,6 +160,7 @@ mod tests {
             ts: Utc::now(),
             content: content.into(),
             seq: None,
+            data: None,
         }
     }
 

--- a/crates/room-daemon/src/broker/commands/plugin.rs
+++ b/crates/room-daemon/src/broker/commands/plugin.rs
@@ -2,7 +2,7 @@ use std::panic::AssertUnwindSafe;
 use std::time::Duration;
 
 use futures_util::FutureExt;
-use room_protocol::{make_system, Message};
+use room_protocol::{make_system, make_system_with_data, Message};
 
 use crate::broker::{fanout::broadcast_and_persist, state::RoomState};
 use crate::plugin::{snapshot_metadata, ChatWriter, CommandContext, HistoryReader, PluginResult};
@@ -109,10 +109,10 @@ pub(super) async fn run_plugin_with_catch(
                 .or_else(|| panic_info.downcast_ref::<&str>().copied())
                 .unwrap_or("unknown panic");
             eprintln!("[broker] plugin '{}' panicked: {msg}", plugin.name());
-            Ok(PluginResult::Reply(format!(
-                "plugin '{}' panicked: {msg}",
-                plugin.name()
-            )))
+            Ok(PluginResult::Reply(
+                format!("plugin '{}' panicked: {msg}", plugin.name()),
+                None,
+            ))
         }
         Err(_elapsed) => {
             eprintln!(
@@ -120,11 +120,14 @@ pub(super) async fn run_plugin_with_catch(
                 plugin.name(),
                 PLUGIN_TIMEOUT.as_secs()
             );
-            Ok(PluginResult::Reply(format!(
-                "plugin '{}' timed out after {}s",
-                plugin.name(),
-                PLUGIN_TIMEOUT.as_secs()
-            )))
+            Ok(PluginResult::Reply(
+                format!(
+                    "plugin '{}' timed out after {}s",
+                    plugin.name(),
+                    PLUGIN_TIMEOUT.as_secs()
+                ),
+                None,
+            ))
         }
     }
 }
@@ -141,7 +144,7 @@ pub(super) async fn translate_plugin_result(
     cross_room: Option<(&str, &str)>,
 ) -> anyhow::Result<CommandResult> {
     Ok(match result {
-        PluginResult::Reply(text) => {
+        PluginResult::Reply(text, data) => {
             let reply_text = match cross_room {
                 Some((_, target)) => format!("[→{target}] {text}"),
                 None => text,
@@ -150,12 +153,20 @@ pub(super) async fn translate_plugin_result(
                 Some((source, _)) => source,
                 None => &state.room_id,
             };
-            let sys = make_system(reply_room, &format!("plugin:{plugin_name}"), reply_text);
+            let plugin_user = format!("plugin:{plugin_name}");
+            let sys = match data {
+                Some(d) => make_system_with_data(reply_room, &plugin_user, reply_text, d),
+                None => make_system(reply_room, &plugin_user, reply_text),
+            };
             let json = serde_json::to_string(&sys)?;
             CommandResult::Reply(json)
         }
-        PluginResult::Broadcast(text) => {
-            let sys = make_system(&state.room_id, &format!("plugin:{plugin_name}"), text);
+        PluginResult::Broadcast(text, data) => {
+            let plugin_user = format!("plugin:{plugin_name}");
+            let sys = match data {
+                Some(d) => make_system_with_data(&state.room_id, &plugin_user, text, d),
+                None => make_system(&state.room_id, &plugin_user, text),
+            };
             let seq_msg =
                 broadcast_and_persist(&sys, &state.clients, &state.chat_path, &state.seq_counter)
                     .await?;

--- a/crates/room-daemon/src/broker/commands/tests.rs
+++ b/crates/room-daemon/src/broker/commands/tests.rs
@@ -1897,7 +1897,7 @@ mod tests {
             }
 
             fn handle(&self, _ctx: CommandContext) -> BoxFuture<'_, anyhow::Result<PluginResult>> {
-                Box::pin(async { Ok(PluginResult::Reply("hello".to_owned())) })
+                Box::pin(async { Ok(PluginResult::Reply("hello".to_owned(), None)) })
             }
         }
 
@@ -1949,7 +1949,7 @@ mod tests {
                 Box::pin(async {
                     // Sleep longer than PLUGIN_TIMEOUT
                     tokio::time::sleep(std::time::Duration::from_secs(60)).await;
-                    Ok(PluginResult::Reply("should not reach".to_owned()))
+                    Ok(PluginResult::Reply("should not reach".to_owned(), None))
                 })
             }
         }

--- a/crates/room-daemon/src/plugin/mod.rs
+++ b/crates/room-daemon/src/plugin/mod.rs
@@ -221,7 +221,7 @@ mod tests {
         }
 
         fn handle(&self, _ctx: CommandContext) -> BoxFuture<'_, anyhow::Result<PluginResult>> {
-            Box::pin(async { Ok(PluginResult::Reply("dummy".to_owned())) })
+            Box::pin(async { Ok(PluginResult::Reply("dummy".to_owned(), None)) })
         }
     }
 

--- a/crates/room-daemon/src/plugin/queue.rs
+++ b/crates/room-daemon/src/plugin/queue.rs
@@ -109,9 +109,10 @@ impl Plugin for QueuePlugin {
                 "list" => self.handle_list(&ctx).await,
                 "remove" => self.handle_remove(&rest).await,
                 "pop" => self.handle_pop(&ctx.sender).await,
-                _ => Ok(PluginResult::Reply(format!(
-                    "queue: unknown action '{action}'. use add, list, remove, or pop"
-                ))),
+                _ => Ok(PluginResult::Reply(
+                    format!("queue: unknown action '{action}'. use add, list, remove, or pop"),
+                    None,
+                )),
             }
         })
     }
@@ -122,6 +123,7 @@ impl QueuePlugin {
         if rest.is_empty() {
             return Ok(PluginResult::Reply(
                 "queue add: missing task description".to_owned(),
+                None,
             ));
         }
 
@@ -142,16 +144,20 @@ impl QueuePlugin {
         append_item(&self.queue_path, &item)?;
         let count = self.queue.lock().await.len();
 
-        Ok(PluginResult::Broadcast(format!(
-            "queue: {sender} added \"{description}\" (#{count} in backlog)"
-        )))
+        Ok(PluginResult::Broadcast(
+            format!("queue: {sender} added \"{description}\" (#{count} in backlog)"),
+            None,
+        ))
     }
 
     async fn handle_list(&self, _ctx: &CommandContext) -> anyhow::Result<PluginResult> {
         let queue = self.queue.lock().await;
 
         if queue.is_empty() {
-            return Ok(PluginResult::Reply("queue: backlog is empty".to_owned()));
+            return Ok(PluginResult::Reply(
+                "queue: backlog is empty".to_owned(),
+                None,
+            ));
         }
 
         let mut lines = Vec::with_capacity(queue.len() + 1);
@@ -166,7 +172,7 @@ impl QueuePlugin {
             ));
         }
 
-        Ok(PluginResult::Reply(lines.join("\n")))
+        Ok(PluginResult::Reply(lines.join("\n"), None))
     }
 
     async fn handle_remove(&self, rest: &[&str]) -> anyhow::Result<PluginResult> {
@@ -176,6 +182,7 @@ impl QueuePlugin {
             _ => {
                 return Ok(PluginResult::Reply(
                     "queue remove: provide a valid 1-based index".to_owned(),
+                    None,
                 ));
             }
         };
@@ -183,20 +190,23 @@ impl QueuePlugin {
         let removed = {
             let mut queue = self.queue.lock().await;
             if index > queue.len() {
-                return Ok(PluginResult::Reply(format!(
-                    "queue remove: index {index} out of range (queue has {} item(s))",
-                    queue.len()
-                )));
+                return Ok(PluginResult::Reply(
+                    format!(
+                        "queue remove: index {index} out of range (queue has {} item(s))",
+                        queue.len()
+                    ),
+                    None,
+                ));
             }
             queue.remove(index - 1)
         };
 
         self.rewrite_queue().await?;
 
-        Ok(PluginResult::Broadcast(format!(
-            "queue: removed \"{}\" (was #{index})",
-            removed.description
-        )))
+        Ok(PluginResult::Broadcast(
+            format!("queue: removed \"{}\" (was #{index})", removed.description),
+            None,
+        ))
     }
 
     async fn handle_pop(&self, sender: &str) -> anyhow::Result<PluginResult> {
@@ -205,6 +215,7 @@ impl QueuePlugin {
             if queue.is_empty() {
                 return Ok(PluginResult::Reply(
                     "queue pop: backlog is empty, nothing to pop".to_owned(),
+                    None,
                 ));
             }
             queue.remove(0)
@@ -212,10 +223,10 @@ impl QueuePlugin {
 
         self.rewrite_queue().await?;
 
-        Ok(PluginResult::Broadcast(format!(
-            "{sender} popped from queue: \"{}\"",
-            popped.description
-        )))
+        Ok(PluginResult::Broadcast(
+            format!("{sender} popped from queue: \"{}\"", popped.description),
+            None,
+        ))
     }
 
     /// Rewrite the entire queue file from the in-memory state.
@@ -474,7 +485,7 @@ mod tests {
 
         let result = plugin.handle(ctx).await.unwrap();
         match &result {
-            PluginResult::Broadcast(msg) => {
+            PluginResult::Broadcast(msg, None) => {
                 assert!(msg.contains("fix the bug"), "broadcast should mention task");
                 assert!(msg.contains("alice"), "broadcast should mention sender");
                 assert!(msg.contains("#1"), "broadcast should show queue position");
@@ -512,7 +523,7 @@ mod tests {
 
         let result = plugin.handle(ctx).await.unwrap();
         match result {
-            PluginResult::Reply(msg) => assert!(msg.contains("missing task description")),
+            PluginResult::Reply(msg, None) => assert!(msg.contains("missing task description")),
             _ => panic!("expected Reply"),
         }
     }
@@ -534,7 +545,7 @@ mod tests {
 
         let result = plugin.handle(ctx).await.unwrap();
         match result {
-            PluginResult::Reply(msg) => assert!(msg.contains("empty")),
+            PluginResult::Reply(msg, None) => assert!(msg.contains("empty")),
             _ => panic!("expected Reply"),
         }
     }
@@ -565,7 +576,7 @@ mod tests {
         );
         let result = plugin.handle(ctx).await.unwrap();
         match result {
-            PluginResult::Reply(msg) => {
+            PluginResult::Reply(msg, None) => {
                 assert!(msg.contains("2 item(s)"));
                 assert!(msg.contains("1. first task"));
                 assert!(msg.contains("2. second task"));
@@ -605,7 +616,7 @@ mod tests {
         );
         let result = plugin.handle(ctx).await.unwrap();
         match &result {
-            PluginResult::Broadcast(msg) => {
+            PluginResult::Broadcast(msg, None) => {
                 assert!(
                     msg.contains("first"),
                     "broadcast should mention removed item"
@@ -644,7 +655,7 @@ mod tests {
         );
         let result = plugin.handle(ctx).await.unwrap();
         match result {
-            PluginResult::Reply(msg) => assert!(msg.contains("out of range")),
+            PluginResult::Reply(msg, None) => assert!(msg.contains("out of range")),
             _ => panic!("expected Reply"),
         }
     }
@@ -666,7 +677,7 @@ mod tests {
         );
         let result = plugin.handle(ctx).await.unwrap();
         match result {
-            PluginResult::Reply(msg) => assert!(msg.contains("valid 1-based index")),
+            PluginResult::Reply(msg, None) => assert!(msg.contains("valid 1-based index")),
             _ => panic!("expected Reply"),
         }
     }
@@ -688,7 +699,7 @@ mod tests {
         );
         let result = plugin.handle(ctx).await.unwrap();
         match result {
-            PluginResult::Reply(msg) => assert!(msg.contains("valid 1-based index")),
+            PluginResult::Reply(msg, None) => assert!(msg.contains("valid 1-based index")),
             _ => panic!("expected Reply"),
         }
     }
@@ -721,7 +732,7 @@ mod tests {
         );
         let result = plugin.handle(ctx).await.unwrap();
         match &result {
-            PluginResult::Broadcast(msg) => {
+            PluginResult::Broadcast(msg, None) => {
                 assert!(msg.contains("alice"), "broadcast should mention popper");
                 assert!(msg.contains("urgent fix"), "broadcast should mention task");
             }
@@ -756,7 +767,7 @@ mod tests {
         );
         let result = plugin.handle(ctx).await.unwrap();
         match result {
-            PluginResult::Reply(msg) => assert!(msg.contains("empty")),
+            PluginResult::Reply(msg, None) => assert!(msg.contains("empty")),
             _ => panic!("expected Reply"),
         }
     }
@@ -799,7 +810,7 @@ mod tests {
         );
         let result = plugin.handle(ctx).await.unwrap();
         match &result {
-            PluginResult::Broadcast(msg) => assert!(msg.contains("first")),
+            PluginResult::Broadcast(msg, None) => assert!(msg.contains("first")),
             _ => panic!("expected Broadcast"),
         }
 
@@ -807,7 +818,7 @@ mod tests {
         let ctx = make_test_ctx("queue", vec!["pop"], "bob", chat_tmp.path(), &clients, &seq);
         let result = plugin.handle(ctx).await.unwrap();
         match &result {
-            PluginResult::Broadcast(msg) => assert!(msg.contains("second")),
+            PluginResult::Broadcast(msg, None) => assert!(msg.contains("second")),
             _ => panic!("expected Broadcast"),
         }
 
@@ -832,7 +843,7 @@ mod tests {
         );
         let result = plugin.handle(ctx).await.unwrap();
         match result {
-            PluginResult::Reply(msg) => assert!(msg.contains("unknown action")),
+            PluginResult::Reply(msg, None) => assert!(msg.contains("unknown action")),
             _ => panic!("expected Reply"),
         }
     }

--- a/crates/room-plugin-agent/src/lib.rs
+++ b/crates/room-plugin-agent/src/lib.rs
@@ -132,7 +132,7 @@ impl AgentPlugin {
         }
     }
 
-    fn handle_spawn(&self, ctx: &CommandContext) -> Result<String, String> {
+    fn handle_spawn(&self, ctx: &CommandContext) -> Result<(String, serde_json::Value), String> {
         let params = &ctx.params;
         if params.len() < 2 {
             return Err(
@@ -273,15 +273,24 @@ impl AgentPlugin {
         } else {
             format!(", personality: {personality}")
         };
-        Ok(format!(
-            "agent {username} spawned (pid {pid}, model: {model}{personality_info})"
-        ))
+        let text =
+            format!("agent {username} spawned (pid {pid}, model: {model}{personality_info})");
+        let data = serde_json::json!({
+            "action": "spawn",
+            "username": username,
+            "pid": pid,
+            "model": model,
+            "personality": personality,
+            "log_path": log_path.to_string_lossy(),
+        });
+        Ok((text, data))
     }
 
-    fn handle_list(&self) -> String {
+    fn handle_list(&self) -> (String, serde_json::Value) {
         let agents = self.agents.lock().unwrap();
         if agents.is_empty() {
-            return "no agents spawned".to_owned();
+            let data = serde_json::json!({ "action": "list", "agents": [] });
+            return ("no agents spawned".to_owned(), data);
         }
 
         let mut lines =
@@ -306,6 +315,7 @@ impl AgentPlugin {
         let now = Utc::now();
         let mut entries: Vec<_> = agents.values().collect();
         entries.sort_by_key(|a| a.spawned_at);
+        let mut agent_data: Vec<serde_json::Value> = Vec::new();
 
         for agent in entries {
             let uptime = format_duration(now - agent.spawned_at);
@@ -328,9 +338,18 @@ impl AgentPlugin {
                 "{:<12} | {:<5} | {:<11} | {:<6} | {:<7} | {}",
                 agent.username, agent.pid, personality_display, agent.model, uptime, status,
             ));
+            agent_data.push(serde_json::json!({
+                "username": agent.username,
+                "pid": agent.pid,
+                "model": agent.model,
+                "personality": agent.personality,
+                "uptime_secs": (now - agent.spawned_at).num_seconds(),
+                "status": status,
+            }));
         }
 
-        lines.join("\n")
+        let data = serde_json::json!({ "action": "list", "agents": agent_data });
+        (lines.join("\n"), data)
     }
 
     /// Handle `/spawn <personality> [--name <username>]`.
@@ -479,7 +498,7 @@ impl AgentPlugin {
         ))
     }
 
-    fn handle_stop(&self, ctx: &CommandContext) -> Result<String, String> {
+    fn handle_stop(&self, ctx: &CommandContext) -> Result<(String, serde_json::Value), String> {
         if ctx.params.len() < 2 {
             return Err("usage: /agent stop <username>".to_owned());
         }
@@ -528,15 +547,28 @@ impl AgentPlugin {
         }
         self.persist();
 
+        let data = serde_json::json!({
+            "action": "stop",
+            "username": username,
+            "pid": agent.pid,
+            "was_alive": was_alive,
+            "stopped_by": ctx.sender,
+        });
         if was_alive {
-            Ok(format!(
-                "agent {} stopped by {} (was pid {})",
-                username, ctx.sender, agent.pid
+            Ok((
+                format!(
+                    "agent {} stopped by {} (was pid {})",
+                    username, ctx.sender, agent.pid
+                ),
+                data,
             ))
         } else {
-            Ok(format!(
-                "agent {} removed (already exited, was pid {})",
-                username, agent.pid
+            Ok((
+                format!(
+                    "agent {} removed (already exited, was pid {})",
+                    username, agent.pid
+                ),
+                data,
             ))
         }
     }
@@ -616,8 +648,8 @@ impl Plugin for AgentPlugin {
             // `/spawn <personality>` is dispatched here with command == "spawn".
             if ctx.command == "spawn" {
                 return match self.handle_spawn_personality(&ctx) {
-                    Ok(msg) => Ok(PluginResult::Broadcast(msg)),
-                    Err(e) => Ok(PluginResult::Reply(e)),
+                    Ok(msg) => Ok(PluginResult::Broadcast(msg, None)),
+                    Err(e) => Ok(PluginResult::Reply(e, None)),
                 };
             }
 
@@ -626,20 +658,24 @@ impl Plugin for AgentPlugin {
 
             match action {
                 "spawn" => match self.handle_spawn(&ctx) {
-                    Ok(msg) => Ok(PluginResult::Broadcast(msg)),
-                    Err(e) => Ok(PluginResult::Reply(e)),
+                    Ok((msg, data)) => Ok(PluginResult::Broadcast(msg, Some(data))),
+                    Err(e) => Ok(PluginResult::Reply(e, None)),
                 },
-                "list" => Ok(PluginResult::Reply(self.handle_list())),
+                "list" => {
+                    let (text, data) = self.handle_list();
+                    Ok(PluginResult::Reply(text, Some(data)))
+                }
                 "stop" => match self.handle_stop(&ctx) {
-                    Ok(msg) => Ok(PluginResult::Broadcast(msg)),
-                    Err(e) => Ok(PluginResult::Reply(e)),
+                    Ok((msg, data)) => Ok(PluginResult::Broadcast(msg, Some(data))),
+                    Err(e) => Ok(PluginResult::Reply(e, None)),
                 },
                 "logs" => match self.handle_logs(&ctx) {
-                    Ok(msg) => Ok(PluginResult::Reply(msg)),
-                    Err(e) => Ok(PluginResult::Reply(e)),
+                    Ok(msg) => Ok(PluginResult::Reply(msg, None)),
+                    Err(e) => Ok(PluginResult::Reply(e, None)),
                 },
                 _ => Ok(PluginResult::Reply(
                     "unknown action. usage: /agent spawn|list|stop|logs".to_owned(),
+                    None,
                 )),
             }
         })
@@ -841,7 +877,7 @@ mod tests {
     fn list_empty() {
         let dir = tempfile::tempdir().unwrap();
         let plugin = test_plugin(dir.path());
-        assert_eq!(plugin.handle_list(), "no agents spawned");
+        assert_eq!(plugin.handle_list().0, "no agents spawned");
     }
 
     #[test]
@@ -865,7 +901,7 @@ mod tests {
             );
         }
 
-        let output = plugin.handle_list();
+        let (output, _data) = plugin.handle_list();
         assert!(output.contains("bot1"));
         assert!(output.contains("opus"));
         assert!(output.contains("99999"));
@@ -946,7 +982,7 @@ mod tests {
         let ctx = make_ctx(&plugin, vec!["stop", "dead-bot"], vec![]);
         let result = plugin.handle_stop(&ctx);
         assert!(result.is_ok());
-        let msg = result.unwrap();
+        let (msg, _data) = result.unwrap();
         assert!(msg.contains("already exited"));
         assert!(msg.contains("removed"));
 
@@ -1390,8 +1426,8 @@ mod tests {
             .unwrap();
         let result = rt.block_on(plugin.handle(ctx)).unwrap();
         match result {
-            PluginResult::Reply(msg) => assert!(msg.contains("unknown action")),
-            PluginResult::Broadcast(_) => panic!("expected Reply, got Broadcast"),
+            PluginResult::Reply(msg, _) => assert!(msg.contains("unknown action")),
+            PluginResult::Broadcast(..) => panic!("expected Reply, got Broadcast"),
             PluginResult::Handled => panic!("expected Reply, got Handled"),
         }
     }
@@ -1419,7 +1455,7 @@ mod tests {
             );
         }
 
-        let output = plugin.handle_list();
+        let (output, _data) = plugin.handle_list();
         let header = output.lines().next().unwrap();
         assert!(
             header.contains("personality"),
@@ -1449,7 +1485,7 @@ mod tests {
             );
         }
 
-        let output = plugin.handle_list();
+        let (output, _data) = plugin.handle_list();
         // The personality column should show "-" for empty personality.
         let data_line = output.lines().nth(1).unwrap();
         assert!(
@@ -1479,7 +1515,7 @@ mod tests {
             );
         }
 
-        let output = plugin.handle_list();
+        let (output, _data) = plugin.handle_list();
         assert!(
             output.contains("running"),
             "alive process should show 'running'"
@@ -1507,7 +1543,7 @@ mod tests {
             );
         }
 
-        let output = plugin.handle_list();
+        let (output, _data) = plugin.handle_list();
         assert!(
             output.contains("exited (unknown)"),
             "dead process without child handle should show 'exited (unknown)'"
@@ -1539,7 +1575,7 @@ mod tests {
             exit_codes.insert("bot1".to_owned(), Some(0));
         }
 
-        let output = plugin.handle_list();
+        let (output, _data) = plugin.handle_list();
         assert!(
             output.contains("exited (0)"),
             "recorded exit code should appear in output"
@@ -1572,7 +1608,7 @@ mod tests {
             exit_codes.insert("bot1".to_owned(), None);
         }
 
-        let output = plugin.handle_list();
+        let (output, _data) = plugin.handle_list();
         assert!(
             output.contains("exited (signal)"),
             "signal death should show 'exited (signal)'"
@@ -1613,7 +1649,7 @@ mod tests {
             );
         }
 
-        let output = plugin.handle_list();
+        let (output, _data) = plugin.handle_list();
         let lines: Vec<&str> = output.lines().collect();
         // Skip header (line 0), first data line should be "first", second "second".
         assert!(
@@ -1651,7 +1687,7 @@ mod tests {
             exit_codes.insert("reviewer-a1".to_owned(), Some(0));
         }
 
-        let output = plugin.handle_list();
+        let (output, _data) = plugin.handle_list();
         assert!(output.contains("reviewer-a1"));
         assert!(output.contains("reviewer"));
         assert!(output.contains("sonnet"));
@@ -1693,5 +1729,78 @@ mod tests {
         );
         let agents = plugin2.agents.lock().unwrap();
         assert_eq!(agents["bot1"].personality, "coder");
+    }
+
+    // ── structured data tests (#697) ─────────────────────────────────────
+
+    #[test]
+    fn list_data_contains_agents_array() {
+        let dir = tempfile::tempdir().unwrap();
+        let plugin = test_plugin(dir.path());
+
+        {
+            let mut agents = plugin.agents.lock().unwrap();
+            agents.insert(
+                "bot1".to_owned(),
+                SpawnedAgent {
+                    username: "bot1".to_owned(),
+                    pid: std::process::id(),
+                    model: "opus".to_owned(),
+                    personality: "coder".to_owned(),
+                    spawned_at: Utc::now(),
+                    log_path: PathBuf::from("/tmp/test.log"),
+                    room_id: "test-room".to_owned(),
+                },
+            );
+        }
+
+        let (_text, data) = plugin.handle_list();
+        assert_eq!(data["action"], "list");
+        let agents = data["agents"].as_array().expect("agents should be array");
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0]["username"], "bot1");
+        assert_eq!(agents[0]["model"], "opus");
+        assert_eq!(agents[0]["personality"], "coder");
+        assert_eq!(agents[0]["status"], "running");
+    }
+
+    #[test]
+    fn list_empty_data_has_empty_agents() {
+        let dir = tempfile::tempdir().unwrap();
+        let plugin = test_plugin(dir.path());
+
+        let (_text, data) = plugin.handle_list();
+        assert_eq!(data["action"], "list");
+        let agents = data["agents"].as_array().expect("agents should be array");
+        assert!(agents.is_empty());
+    }
+
+    #[test]
+    fn stop_data_includes_action_and_username() {
+        let dir = tempfile::tempdir().unwrap();
+        let plugin = test_plugin(dir.path());
+
+        {
+            let mut agents = plugin.agents.lock().unwrap();
+            agents.insert(
+                "bot1".to_owned(),
+                SpawnedAgent {
+                    username: "bot1".to_owned(),
+                    pid: 999_999_999,
+                    model: "sonnet".to_owned(),
+                    personality: String::new(),
+                    spawned_at: Utc::now(),
+                    log_path: PathBuf::from("/tmp/test.log"),
+                    room_id: "test-room".to_owned(),
+                },
+            );
+        }
+
+        let ctx = make_ctx(&plugin, vec!["stop", "bot1"], vec![]);
+        let (text, data) = plugin.handle_stop(&ctx).unwrap();
+        assert!(text.contains("bot1"));
+        assert_eq!(data["action"], "stop");
+        assert_eq!(data["username"], "bot1");
+        assert_eq!(data["was_alive"], false);
     }
 }

--- a/crates/room-plugin-taskboard/src/lib.rs
+++ b/crates/room-plugin-taskboard/src/lib.rs
@@ -165,9 +165,9 @@ impl Plugin for TaskboardPlugin {
                 if let Some(et) = event_type {
                     let _ = ctx.writer.emit_event(et, &result, None).await;
                 }
-                Ok(PluginResult::Broadcast(result))
+                Ok(PluginResult::Broadcast(result, None))
             } else {
-                Ok(PluginResult::Reply(result))
+                Ok(PluginResult::Reply(result, None))
             }
         })
     }

--- a/crates/room-protocol/src/lib.rs
+++ b/crates/room-protocol/src/lib.rs
@@ -375,6 +375,9 @@ pub enum Message {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         seq: Option<u64>,
         content: String,
+        /// Optional machine-readable data for programmatic consumers.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        data: Option<serde_json::Value>,
     },
     /// A private direct message. Delivered only to sender, recipient, and the
     /// broker host. Always written to the chat history file.
@@ -608,6 +611,24 @@ pub fn make_system(room: &str, user: &str, content: impl Into<String>) -> Messag
         ts: Utc::now(),
         content: content.into(),
         seq: None,
+        data: None,
+    }
+}
+
+pub fn make_system_with_data(
+    room: &str,
+    user: &str,
+    content: impl Into<String>,
+    data: serde_json::Value,
+) -> Message {
+    Message::System {
+        id: new_id(),
+        room: room.to_owned(),
+        user: user.to_owned(),
+        ts: Utc::now(),
+        content: content.into(),
+        seq: None,
+        data: Some(data),
     }
 }
 
@@ -848,10 +869,70 @@ mod tests {
             ts: fixed_ts(),
             content: "5 users online".into(),
             seq: None,
+            data: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         let back: Message = serde_json::from_str(&json).unwrap();
         assert_eq!(msg, back);
+    }
+
+    #[test]
+    fn system_with_data_round_trips() {
+        let data = serde_json::json!({
+            "action": "spawn",
+            "username": "bot1",
+            "pid": 12345,
+        });
+        let msg = Message::System {
+            id: fixed_id(),
+            room: "r".into(),
+            user: "plugin:agent".into(),
+            ts: fixed_ts(),
+            content: "agent bot1 spawned".into(),
+            seq: None,
+            data: Some(data),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let back: Message = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, back);
+        // Verify data field is present in JSON
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["data"]["action"], "spawn");
+        assert_eq!(v["data"]["pid"], 12345);
+    }
+
+    #[test]
+    fn system_without_data_omits_field() {
+        let msg = Message::System {
+            id: fixed_id(),
+            room: "r".into(),
+            user: "broker".into(),
+            ts: fixed_ts(),
+            content: "hello".into(),
+            seq: None,
+            data: None,
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        // data field should not appear when None
+        assert!(!json.contains("\"data\""));
+        // Should still deserialize fine
+        let back: Message = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, back);
+    }
+
+    #[test]
+    fn system_data_backward_compat_no_data_field() {
+        // Old messages without a data field should deserialize with data: None
+        let json = r#"{"type":"system","id":"00000000-0000-0000-0000-000000000001","room":"r","user":"broker","ts":"2025-01-01T00:00:00Z","content":"hello"}"#;
+        let msg: Message = serde_json::from_str(json).unwrap();
+        if let Message::System { data, .. } = &msg {
+            assert!(
+                data.is_none(),
+                "missing data field should deserialize as None"
+            );
+        } else {
+            panic!("expected System");
+        }
     }
 
     // ── JSON shape tests ─────────────────────────────────────────────────────

--- a/crates/room-protocol/src/plugin.rs
+++ b/crates/room-protocol/src/plugin.rs
@@ -183,9 +183,11 @@ pub struct CommandContext {
 /// What the broker should do after a plugin handles a command.
 pub enum PluginResult {
     /// Send a private reply only to the invoker.
-    Reply(String),
+    /// Second element is optional machine-readable data for programmatic consumers.
+    Reply(String, Option<serde_json::Value>),
     /// Broadcast a message to the entire room.
-    Broadcast(String),
+    /// Second element is optional machine-readable data for programmatic consumers.
+    Broadcast(String, Option<serde_json::Value>),
     /// Command handled silently (side effects already done via [`MessageWriter`]).
     Handled,
 }


### PR DESCRIPTION
## Summary
- Add optional `data` field to `Message::System` for machine-readable structured data alongside human-readable `content`
- Extend `PluginResult::Reply`/`Broadcast` to carry optional `serde_json::Value` data through the plugin pipeline
- Populate structured data in AgentPlugin responses (spawn, list, stop) for programmatic consumers (Hive, scripts, other agents)
- Backward compatible: `data` field uses `serde(default)` and `skip_serializing_if` — omitted from JSON when `None`

## Wire format change checklist
- [x] Applied in `cmd_poll` (serde default handles new field)
- [x] Applied in `cmd_poll_multi` (serde default)
- [x] Applied in `cmd_pull` (serde default)
- [x] Applied in `cmd_query` / `cmd_query_new` / `cmd_query_history` (serde default)
- [x] Applied in `cmd_watch` (serde default)
- [x] Not a new command — no `builtin_command_infos()` / `RESERVED_COMMANDS` change needed
- [x] Protocol-level tests added

## Files modified
- `crates/room-protocol/src/lib.rs` — `Message::System` data field, `make_system_with_data()`, 3 new tests
- `crates/room-protocol/src/plugin.rs` — `PluginResult::Reply/Broadcast` carry `Option<Value>`
- `crates/room-daemon/src/broker/commands/plugin.rs` — `translate_plugin_result()` passes data through
- `crates/room-daemon/src/broker/commands/tests.rs` — updated test plugins
- `crates/room-daemon/src/plugin/mod.rs` — updated test plugin
- `crates/room-daemon/src/plugin/queue.rs` — all PluginResult calls updated with `None` data
- `crates/room-plugin-agent/src/lib.rs` — spawn/list/stop return structured data, 3 new tests
- `crates/room-plugin-taskboard/src/lib.rs` — PluginResult calls updated with `None` data
- `crates/room-cli/src/tui/mod.rs` — test `make_system` updated

## Test plan
- [x] 3 new protocol tests: `system_with_data_round_trips`, `system_without_data_omits_field`, `system_data_backward_compat_no_data_field`
- [x] 3 new agent tests: `list_data_contains_agents_array`, `list_empty_data_has_empty_agents`, `stop_data_includes_action_and_username`
- [x] All pre-push checks pass (check, fmt, clippy, test)

Closes #697

🤖 Generated with [Claude Code](https://claude.com/claude-code)