### PR TITLE
fix(ralph): add room subscribe call after joining (#725)

### DIFF
--- a/crates/room-ralph/src/loop_runner.rs
+++ b/crates/room-ralph/src/loop_runner.rs
@@ -103,6 +103,9 @@ fn rejoin_and_poll(
         Ok(result) => {
             tracing::info!("re-joined as '{}' with new token", result.username);
             *token = result.token;
+            if let Err(e) = room::subscribe_room(&cli.room_id, token, socket_ref) {
+                tracing::warn!("failed to subscribe after re-join: {}", e);
+            }
             room::poll_messages(&cli.room_id, token, socket_ref).unwrap_or_default()
         }
         Err(join_err) => {

--- a/crates/room-ralph/src/main.rs
+++ b/crates/room-ralph/src/main.rs
@@ -205,6 +205,11 @@ async fn main() -> ExitCode {
         cli.username = join_result.username;
     }
 
+    // Subscribe to the room so poll/watch deliver messages
+    if let Err(e) = room::subscribe_room(&cli.room_id, &token, socket_ref) {
+        tracing::warn!("failed to subscribe to room: {}", e);
+    }
+
     let announce = {
         let mut parts = vec![format!(
             "online (room-ralph, model={}, iter limit={}",

--- a/crates/room-ralph/src/room.rs
+++ b/crates/room-ralph/src/room.rs
@@ -169,6 +169,31 @@ fn is_username_taken(error: &str) -> bool {
         && (lower.contains("already in use") || lower.contains("already taken"))
 }
 
+/// Subscribe to a room so that `room poll` and `room watch` deliver messages.
+///
+/// Runs `room subscribe <room_id> -t <token>`.
+/// If `socket` is provided, passes `--socket <path>` to the `room` command.
+///
+/// This must be called after `join_room()` — joining only registers the user
+/// globally and issues a token, but does not subscribe to any specific room.
+pub fn subscribe_room(room_id: &str, token: &str, socket: Option<&str>) -> Result<(), String> {
+    let mut cmd = Command::new("room");
+    cmd.args(["subscribe", room_id, "-t", token]);
+    if let Some(s) = socket {
+        cmd.args(["--socket", s]);
+    }
+    let output = cmd
+        .output()
+        .map_err(|e| format!("failed to run `room subscribe`: {e}"))?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(format!("room subscribe failed: {stderr}"))
+    }
+}
+
 /// Send a message to the room.
 ///
 /// Runs `room send <room_id> -t <token> <message>`.


### PR DESCRIPTION
## Summary
- Add `subscribe_room()` function to `room.rs` that runs `room subscribe <room_id> -t <token>`
- Call it after `join_room()` in `main.rs` (initial join) and `loop_runner.rs` (re-join on token expiry)
- Passes `--socket` when available

## Root cause
`room-ralph` called `room join` to register and get a token, but never called `room subscribe` to subscribe to the room. Without subscription, `room poll` and `room watch` never delivered messages to spawned agents.

## Test plan
- [x] All 177 room-ralph tests pass (167 unit + 10 integration)
- [x] Pre-push checks pass (check, fmt, clippy, test)
- [ ] Manual: spawn agent via `/spawn coder`, verify it receives messages

Closes #725

🤖 Generated with [Claude Code](https://claude.com/claude-code)