### PR TITLE
fix: resume seq numbering from chat history on broker restart

### DIFF
--- a/crates/room-daemon/src/broker/mod.rs
+++ b/crates/room-daemon/src/broker/mod.rs
@@ -153,7 +153,9 @@ impl Broker {
             chat_path: Arc::new(self.chat_path.clone()),
             room_id: Arc::new(self.room_id.clone()),
             shutdown: Arc::new(shutdown_tx),
-            seq_counter: Arc::new(AtomicU64::new(0)),
+            seq_counter: Arc::new(AtomicU64::new(crate::history::max_seq_from_history(
+                &self.chat_path,
+            ))),
             plugin_registry: Arc::new(registry),
             config: None,
             cross_room_resolver: std::sync::OnceLock::new(),

--- a/crates/room-daemon/src/broker/state.rs
+++ b/crates/room-daemon/src/broker/state.rs
@@ -127,6 +127,7 @@ impl RoomState {
             .map_err(|e| format!("plugin error: {e}"))?;
 
         let (shutdown_tx, _) = watch::channel(false);
+        let initial_seq = crate::history::max_seq_from_history(&chat_path);
 
         Ok(Arc::new(Self {
             clients: Arc::new(Mutex::new(HashMap::new())),
@@ -145,7 +146,7 @@ impl RoomState {
             chat_path: Arc::new(chat_path),
             room_id: Arc::new(room_id),
             shutdown: Arc::new(shutdown_tx),
-            seq_counter: Arc::new(AtomicU64::new(0)),
+            seq_counter: Arc::new(AtomicU64::new(initial_seq)),
             plugin_registry: Arc::new(plugins),
             config,
             cross_room_resolver: OnceLock::new(),

--- a/crates/room-daemon/src/history.rs
+++ b/crates/room-daemon/src/history.rs
@@ -43,6 +43,33 @@ pub async fn tail(path: &Path, n: usize) -> anyhow::Result<Vec<Message>> {
     Ok(all[start..].to_vec())
 }
 
+/// Return the highest `seq` value from persisted messages, or 0 if the file
+/// is empty or does not exist.
+///
+/// Used on broker startup to resume sequence numbering from the last persisted
+/// message, preventing seq resets across broker restarts (bug #721).
+pub fn max_seq_from_history(path: &Path) -> u64 {
+    let raw = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(_) => return 0,
+    };
+    let mut max = 0u64;
+    for line in raw.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Ok(msg) = serde_json::from_str::<Message>(trimmed) {
+            if let Some(seq) = msg.seq() {
+                if seq > max {
+                    max = seq;
+                }
+            }
+        }
+    }
+    max
+}
+
 /// Append a single message as a JSON line to the NDJSON file.
 ///
 /// Uses `spawn_blocking` + `std::fs::OpenOptions` directly to avoid the
@@ -157,6 +184,52 @@ mod tests {
 
         let loaded = load(path).await.unwrap();
         assert_eq!(loaded.len(), 5);
+    }
+
+    #[test]
+    fn max_seq_nonexistent_file_returns_zero() {
+        let path = PathBuf::from("/tmp/__room_test_no_such_file_seq.chat");
+        assert_eq!(max_seq_from_history(&path), 0);
+    }
+
+    #[test]
+    fn max_seq_empty_file_returns_zero() {
+        let tmp = NamedTempFile::new().unwrap();
+        assert_eq!(max_seq_from_history(tmp.path()), 0);
+    }
+
+    #[tokio::test]
+    async fn max_seq_returns_highest_seq() {
+        let tmp = NamedTempFile::new().unwrap();
+        let path = tmp.path();
+
+        // Write messages with seq values via broadcast simulation
+        let mut m1 = make_message("r", "alice", "first");
+        m1.set_seq(5);
+        let mut m2 = make_message("r", "bob", "second");
+        m2.set_seq(10);
+        let mut m3 = make_message("r", "carol", "third");
+        m3.set_seq(7);
+
+        append(path, &m1).await.unwrap();
+        append(path, &m2).await.unwrap();
+        append(path, &m3).await.unwrap();
+
+        assert_eq!(max_seq_from_history(path), 10);
+    }
+
+    #[tokio::test]
+    async fn max_seq_messages_without_seq_returns_zero() {
+        let tmp = NamedTempFile::new().unwrap();
+        let path = tmp.path();
+
+        // Messages without set_seq have seq=None
+        append(path, &make_message("r", "alice", "no seq"))
+            .await
+            .unwrap();
+        append(path, &make_join("r", "bob")).await.unwrap();
+
+        assert_eq!(max_seq_from_history(path), 0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Add `max_seq_from_history()` helper that scans the chat file for the highest seq value
- Seed `seq_counter` from this value in both `RoomState::new()` and the legacy `Broker` path
- Prevents sequence number resets across broker restarts, fixing cursor-based polling

## Test plan
- [x] 4 new unit tests for `max_seq_from_history` (nonexistent file, empty file, mixed seq, no-seq messages)
- [x] All existing tests pass (no behavioral change for fresh rooms)
- [x] `cargo check` / `cargo fmt` / `cargo clippy -- -D warnings` / `cargo test` all green

Closes #721

🤖 Generated with [Claude Code](https://claude.com/claude-code)