### PR TITLE
fix(ralph): pass ROOM_TOKEN to claude subprocess (#726)

### DIFF
--- a/crates/room-ralph/src/claude.rs
+++ b/crates/room-ralph/src/claude.rs
@@ -258,6 +258,13 @@ fn build_claude_command(
     for var in STRIPPED_ENV_VARS {
         cmd.env_remove(var);
     }
+    // Pass the pre-provisioned token so claude's CLAUDE.md instructions
+    // can skip `room join` and use the token directly.
+    if let Ok(token) = std::env::var(crate::room::ROOM_TOKEN_ENV) {
+        if !token.is_empty() {
+            cmd.env(crate::room::ROOM_TOKEN_ENV, &token);
+        }
+    }
     cmd.args(["-p", "--model", model, "--output-format", "json"]);
     for dir in add_dirs {
         cmd.args(["--add-dir", &dir.display().to_string()]);

--- a/crates/room-ralph/src/prompt.rs
+++ b/crates/room-ralph/src/prompt.rs
@@ -56,6 +56,7 @@ pub fn build_prompt(config: &PromptConfig<'_>, messages: &[Message]) -> String {
             config.room_id, config.token
         ));
         prompt.push_str("Rules:\n");
+        prompt.push_str("- Do NOT call `room join` — your token is already provisioned above\n");
         prompt.push_str("- Announce your plan before writing code\n");
         prompt.push_str("- One concern per PR\n");
         prompt.push_str("- Run scripts/pre-push.sh before pushing\n");


### PR DESCRIPTION
## Summary
- Forward `ROOM_TOKEN` env var to the `claude -p` subprocess in `build_claude_command()` so CLAUDE.md code can use the pre-provisioned token instead of calling `room join`
- Add explicit "do NOT call `room join`" rule to ralph's default prompt

## Root cause
Spawned agents joined with wrong usernames because the claude subprocess independently called `room join` via CLAUDE.md instructions, picking its own name instead of using the username ralph registered.

## Test plan
- [x] All 177 room-ralph tests pass
- [x] Pre-push checks pass
- [ ] Manual: spawn agent via `/spawn coder`, verify it uses the assigned username

Closes #726

🤖 Generated with [Claude Code](https://claude.com/claude-code)