### PR TITLE
refactor: remove single-room broker fallback from production paths

### DIFF
--- a/crates/room-cli/src/cli.rs
+++ b/crates/room-cli/src/cli.rs
@@ -11,7 +11,7 @@ pub enum Cmd {
     /// Returns the existing token if the username is already registered.
     Join {
         username: String,
-        /// Override the broker socket path (default: auto-discover daemon or per-room socket)
+        /// Override the daemon socket path (default: auto-discover)
         #[arg(long)]
         socket: Option<PathBuf>,
     },
@@ -27,7 +27,7 @@ pub enum Cmd {
         /// Recipient username for a direct message
         #[arg(long)]
         to: Option<String>,
-        /// Override the broker socket path (default: auto-discover daemon or per-room socket)
+        /// Override the daemon socket path (default: auto-discover)
         #[arg(long)]
         socket: Option<PathBuf>,
         /// Message content; all remaining tokens are joined with spaces
@@ -186,7 +186,7 @@ pub enum Cmd {
         /// status_changed, review_requested.
         #[arg(long)]
         events: Option<String>,
-        /// Override the broker socket path (default: auto-discover daemon or per-room socket)
+        /// Override the daemon socket path (default: auto-discover)
         #[arg(long)]
         socket: Option<PathBuf>,
     },
@@ -202,7 +202,7 @@ pub enum Cmd {
         /// Print raw JSON instead of human-readable text
         #[arg(long)]
         json: bool,
-        /// Override the broker socket path (default: auto-discover daemon or per-room socket)
+        /// Override the daemon socket path (default: auto-discover)
         #[arg(long)]
         socket: Option<PathBuf>,
     },
@@ -217,7 +217,7 @@ pub enum Cmd {
         /// Session token from `room join` (required)
         #[arg(short = 't', long)]
         token: String,
-        /// Override the broker socket path (default: auto-discover daemon or per-room socket)
+        /// Override the daemon socket path (default: auto-discover)
         #[arg(long)]
         socket: Option<PathBuf>,
         /// Message content; all remaining tokens are joined with spaces
@@ -269,7 +269,7 @@ pub enum Cmd {
         /// Session token from `room join` (required)
         #[arg(short = 't', long)]
         token: String,
-        /// Override the broker socket path (default: auto-discover daemon or per-room socket)
+        /// Override the daemon socket path (default: auto-discover)
         #[arg(long)]
         socket: Option<PathBuf>,
         #[command(subcommand)]

--- a/crates/room-cli/src/oneshot/transport.rs
+++ b/crates/room-cli/src/oneshot/transport.rs
@@ -11,12 +11,12 @@ use crate::message::Message;
 
 /// Resolved connection target for a broker.
 ///
-/// When `daemon_room` is `Some(room_id)`, the client is connecting to the
-/// multi-room daemon (`roomd`) and must prepend `ROOM:<room_id>:` before every
-/// handshake token so the daemon can route the connection to the correct room.
+/// All connections go through the multi-room daemon (`roomd`). The client
+/// prepends `ROOM:<room_id>:` before every handshake token so the daemon can
+/// route the connection to the correct room.
 ///
-/// When `daemon_room` is `None`, the client is connecting to a single-room
-/// broker socket and sends handshake tokens directly (e.g. `TOKEN:<uuid>`).
+/// `daemon_room` is always `Some(room_id)` in production. `None` is only used
+/// by test fixtures that connect directly to a standalone `Broker` instance.
 #[derive(Debug, Clone)]
 pub struct SocketTarget {
     /// Path to the UDS socket.
@@ -42,43 +42,16 @@ impl SocketTarget {
 
 /// Resolve the effective socket target for a given room.
 ///
-/// Resolution order:
-/// 1. If `explicit` is given, use it. If the path is not the per-room socket
-///    for this room, assume it is a daemon socket and use the `ROOM:` prefix.
-/// 2. Otherwise (auto-discovery): try the platform-native daemon socket first
-///    (`room_socket_path()`); fall back to the per-room socket if the daemon
-///    socket does not exist.
+/// All rooms are managed by the daemon. If `explicit` is given, use it as the
+/// daemon socket path; otherwise use the platform-native daemon socket
+/// (`effective_socket_path()`).
 pub fn resolve_socket_target(room_id: &str, explicit: Option<&Path>) -> SocketTarget {
-    let per_room = crate::paths::room_single_socket_path(room_id);
-    // ROOM_SOCKET env var overrides the default daemon socket path.
-    let daemon = crate::paths::effective_socket_path(None);
-
-    if let Some(path) = explicit {
-        // If the caller gave us the per-room socket path, use per-room mode.
-        // Any other explicit path is treated as a daemon socket.
-        if path == per_room {
-            return SocketTarget {
-                path: path.to_owned(),
-                daemon_room: None,
-            };
-        }
-        return SocketTarget {
-            path: path.to_owned(),
-            daemon_room: Some(room_id.to_owned()),
-        };
-    }
-
-    // Auto-discovery: prefer daemon if it is running.
-    if daemon.exists() {
-        SocketTarget {
-            path: daemon,
-            daemon_room: Some(room_id.to_owned()),
-        }
-    } else {
-        SocketTarget {
-            path: per_room,
-            daemon_room: None,
-        }
+    let path = explicit
+        .map(|p| p.to_owned())
+        .unwrap_or_else(|| crate::paths::effective_socket_path(None));
+    SocketTarget {
+        path,
+        daemon_room: Some(room_id.to_owned()),
     }
 }
 
@@ -596,18 +569,7 @@ mod tests {
     // ── resolve_socket_target ─────────────────────────────────────────────────
 
     #[test]
-    fn resolve_explicit_per_room_socket_is_not_daemon() {
-        let per_room = crate::paths::room_single_socket_path("myroom");
-        let target = resolve_socket_target("myroom", Some(&per_room));
-        assert_eq!(target.path, per_room);
-        assert!(
-            target.daemon_room.is_none(),
-            "per-room socket should not set daemon_room"
-        );
-    }
-
-    #[test]
-    fn resolve_explicit_daemon_socket_is_daemon() {
+    fn resolve_explicit_socket_is_daemon() {
         let daemon_sock = PathBuf::from("/tmp/roomd.sock");
         let target = resolve_socket_target("myroom", Some(&daemon_sock));
         assert_eq!(target.path, daemon_sock);
@@ -623,17 +585,10 @@ mod tests {
     }
 
     #[test]
-    fn resolve_auto_no_daemon_falls_back_to_per_room() {
-        // When no daemon socket exists (we check the real daemon path, which
-        // is unlikely to exist during CI), auto-discovery should fall back.
-        // We can only test this if the daemon socket is NOT running.
-        let daemon_path = crate::paths::room_socket_path();
-        if !daemon_path.exists() {
-            let target = resolve_socket_target("myroom", None);
-            assert_eq!(target.path, crate::paths::room_single_socket_path("myroom"));
-            assert!(target.daemon_room.is_none());
-        }
-        // If daemon IS running, skip (we can't test both branches in one call).
+    fn resolve_auto_uses_daemon_socket() {
+        let target = resolve_socket_target("myroom", None);
+        // Should always use daemon socket path with daemon_room set
+        assert_eq!(target.daemon_room.as_deref(), Some("myroom"));
     }
 
     // ── resolve_daemon_binary ────────────────────────────────────────────────

--- a/crates/room-daemon/src/paths.rs
+++ b/crates/room-daemon/src/paths.rs
@@ -70,7 +70,10 @@ pub fn effective_socket_path(explicit: Option<&std::path::Path>) -> PathBuf {
     room_socket_path()
 }
 
-/// Platform-native socket path for a single-room broker.
+/// Socket path for a standalone single-room broker (test fixtures only).
+///
+/// Production code uses the daemon socket (`effective_socket_path`). This
+/// function exists for `TestBroker` in integration tests.
 pub fn room_single_socket_path(room_id: &str) -> PathBuf {
     runtime_dir().join(format!("room-{room_id}.sock"))
 }

--- a/crates/room-daemon/src/plugin/mod.rs
+++ b/crates/room-daemon/src/plugin/mod.rs
@@ -82,18 +82,8 @@ impl PluginRegistry {
         // Derive agent plugin paths from the chat path.
         let agent_state_path = chat_path.with_extension("agents");
         let agent_log_dir = chat_path.parent().unwrap_or(chat_path).join("agent-logs");
-        let room_id = chat_path
-            .file_stem()
-            .unwrap_or_default()
-            .to_string_lossy()
-            .into_owned();
-        // Use the daemon socket if it exists, otherwise fall back to single-room socket.
-        let daemon_socket = crate::paths::room_socket_path();
-        let agent_socket_path = if daemon_socket.exists() {
-            daemon_socket
-        } else {
-            crate::paths::room_single_socket_path(&room_id)
-        };
+        // All rooms run through the daemon — use the daemon socket.
+        let agent_socket_path = crate::paths::effective_socket_path(None);
         registry.register(Box::new(room_plugin_agent::AgentPlugin::new(
             agent_state_path,
             agent_socket_path,


### PR DESCRIPTION
## Summary
- Remove per-room socket fallback from `resolve_socket_target` — all rooms now route through daemon socket exclusively
- Fix agent plugin socket resolution that was using `room_single_socket_path` instead of daemon socket (root cause of agent spawn crash)
- Update docs/comments to clarify daemon-only architecture
- `Broker`/`TestBroker` kept for test isolation (not backward compat)

Net -52 lines.

Closes #724

## Test plan
- [x] `cargo check` passes
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test` — all tests pass
- [ ] Manual: `/spawn coder` should use daemon socket correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)