### PR TITLE
ci: adopt cargo-nextest for faster test parallelism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,21 +19,23 @@ jobs:
           components: rustfmt, clippy
       - uses: mozilla-actions/sccache-action@v0.0.7
       - uses: Swatinem/rust-cache@v2
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
       - name: Check formatting
         run: cargo fmt --check
       - name: Clippy
         run: cargo clippy -- -D warnings
       - name: Tests
-        run: cargo test
+        run: cargo nextest run
       - name: Smoke tests (ignored)
         # Runs tests marked #[ignore]: ws_smoke (subprocess + WS/REST) and
         # ensure_daemon (subprocess auto-start). These spawn real `room` processes
         # and are fast on Linux CI (~100ms each) but excluded from the normal
-        # `cargo test` run to keep local dev fast.
+        # test run to keep local dev fast.
         # Non-blocking: smoke tests are inherently flaky (process startup timing)
         # and should not gate PRs. See #393 for daemon-mode incompatibility.
         continue-on-error: true
-        run: cargo test -p room-cli -- --ignored
+        run: cargo nextest run -p room-cli --run-ignored ignored-only
 
   changelog:
     name: Changelog

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -40,8 +40,14 @@ step "cargo clippy -- -D warnings"
 cargo clippy -- -D warnings 2>&1 || fail "cargo clippy"
 pass "cargo clippy"
 
-step "cargo test"
-cargo test 2>&1 || fail "cargo test"
-pass "cargo test"
+if command -v cargo-nextest &>/dev/null; then
+  step "cargo nextest run"
+  cargo nextest run 2>&1 || fail "cargo nextest run"
+  pass "cargo nextest run"
+else
+  step "cargo test"
+  cargo test 2>&1 || fail "cargo test"
+  pass "cargo test"
+fi
 
 printf '\n%s%s[pre-push] All checks passed.%s\n' "$GREEN" "$BOLD" "$RESET"


### PR DESCRIPTION
## Summary
- Install `cargo-nextest` in CI via `taiki-e/install-action@nextest`
- Replace `cargo test` with `cargo nextest run` for ~20-40% test speedup
- Update smoke tests to use `--run-ignored ignored-only` (nextest syntax)
- Update `scripts/pre-push.sh` to use nextest with fallback to `cargo test`

Closes #732

## Test plan
- [x] CI workflow syntax validated
- [x] pre-push.sh fallback logic tested (nextest not installed locally)
- [ ] CI run will validate nextest works on ubuntu-latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)