### PR TITLE
fix: enable ws_smoke tests in CI by fixing health endpoint assertion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,13 +73,9 @@ jobs:
             cargo nextest run ${{ steps.changed.outputs.packages }}
           fi
       - name: Smoke tests (ignored)
-        # Runs tests marked #[ignore]: ws_smoke (subprocess + WS/REST) and
-        # ensure_daemon (subprocess auto-start). These spawn real `room` processes
-        # and are fast on Linux CI (~100ms each) but excluded from the normal
-        # test run to keep local dev fast.
-        # Non-blocking: smoke tests are inherently flaky (process startup timing)
-        # and should not gate PRs. See #393 for daemon-mode incompatibility.
-        continue-on-error: true
+        # Runs tests marked #[ignore]: ws_smoke (subprocess + WS/REST).
+        # These spawn real `room` processes and are fast on Linux CI (~100ms each)
+        # but excluded from the normal test run to keep local dev fast.
         run: cargo nextest run -p room-cli --run-ignored ignored-only
 
   changelog:

--- a/crates/room-cli/tests/ws_smoke.rs
+++ b/crates/room-cli/tests/ws_smoke.rs
@@ -121,8 +121,13 @@ async fn smoke_rest_health() {
     assert_eq!(resp.status(), 200);
     let body: serde_json::Value = resp.json().await.unwrap();
     assert_eq!(body["status"], "ok");
-    assert_eq!(body["room"], "smoke_health");
     assert_eq!(body["version"], env!("CARGO_PKG_VERSION"));
+    // Daemon health returns a "rooms" array instead of a single "room" field.
+    let rooms = body["rooms"].as_array().expect("expected rooms array");
+    assert!(
+        rooms.iter().any(|r| r["room"] == "smoke_health"),
+        "smoke_health room not found in health response: {body}"
+    );
 
     child.kill().await.ok();
 }


### PR DESCRIPTION
## Summary
- Fix `smoke_rest_health` test: daemon health returns `rooms` array, not single `room` field
- Remove `continue-on-error: true` from CI smoke test step — all 7 tests now pass reliably
- +7 tests effectively added to CI coverage (~0.8s cost)

## Test plan
- [x] All 7 smoke tests pass locally (`cargo test -p room-cli --test ws_smoke -- --ignored`)
- [x] All regular tests pass
- [x] `cargo check` / `cargo fmt` / `cargo clippy -- -D warnings` all clean

Closes #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)