### PR TITLE
feat(cli): add room plugin install/list/remove/update

### DIFF
--- a/crates/room-cli/CHANGELOG.md
+++ b/crates/room-cli/CHANGELOG.md
@@ -15,6 +15,9 @@ For changes prior to the workspace restructure (v0.1.2 through v1.0.2), see the
 - **tests:** 27 integration tests covering manual test plan gaps (#675) — slash commands
   (/help, /info, /stats), queue lifecycle, taskboard cancel/reclaim, team commands, REST
   regex+combined filters, subscription tiers, unicode/emoji handling, edge cases
+- `room plugin install/list/remove/update` subcommands for managing dynamic
+  plugins in `~/.room/plugins/`. Includes `PluginMeta` serialization, crate name
+  resolution, and plugin directory scanning. 23 new unit tests. (#745)
 
 ### Fixed
 

--- a/crates/room-cli/src/cli.rs
+++ b/crates/room-cli/src/cli.rs
@@ -275,6 +275,15 @@ pub enum Cmd {
         #[command(subcommand)]
         action: AgentAction,
     },
+    /// Manage plugins — install, list, remove, or update.
+    ///
+    /// Downloads plugin crates from crates.io, compiles them to shared
+    /// libraries, and installs to `~/.room/plugins/`. The daemon loads
+    /// installed plugins on startup.
+    Plugin {
+        #[command(subcommand)]
+        action: PluginAction,
+    },
     /// List active rooms with running brokers.
     ///
     /// Scans `/tmp` for `room-*.sock` files and probes each to verify the broker
@@ -359,6 +368,37 @@ pub enum AgentAction {
         /// Number of lines to show from the end (default: 50)
         #[arg(long, default_value_t = 50)]
         tail: usize,
+    },
+}
+
+/// Plugin management subcommands.
+#[derive(Subcommand, Debug)]
+pub enum PluginAction {
+    /// Install a plugin from crates.io.
+    ///
+    /// Resolves `room-plugin-<name>` on crates.io, compiles to a shared
+    /// library, and installs to `~/.room/plugins/` with a `.meta.json` file.
+    Install {
+        /// Plugin name (e.g. `agent` resolves to crate `room-plugin-agent`)
+        name: String,
+        /// Install a specific version (default: latest)
+        #[arg(long)]
+        version: Option<String>,
+    },
+    /// List installed plugins with versions and compatibility info.
+    List,
+    /// Remove an installed plugin.
+    Remove {
+        /// Plugin name to remove
+        name: String,
+    },
+    /// Update an installed plugin to the latest version.
+    Update {
+        /// Plugin name to update
+        name: String,
+        /// Update to a specific version (default: latest)
+        #[arg(long)]
+        version: Option<String>,
     },
 }
 

--- a/crates/room-cli/src/lib.rs
+++ b/crates/room-cli/src/lib.rs
@@ -5,4 +5,5 @@ pub use room_daemon::{broker, history, paths, plugin, query, registry};
 pub mod client;
 pub mod message;
 pub mod oneshot;
+pub mod plugin_cmd;
 pub mod tui;

--- a/crates/room-cli/src/main.rs
+++ b/crates/room-cli/src/main.rs
@@ -14,7 +14,7 @@ use room_cli::{
     query::{has_narrowing_filter, QueryFilter},
 };
 
-use cli::{AgentAction, Args, Cmd};
+use cli::{AgentAction, Args, Cmd, PluginAction};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -368,6 +368,23 @@ async fn main() -> anyhow::Result<()> {
                 AgentAction::Logs { username, tail } => {
                     oneshot::cmd_agent_logs(&room_id, &token, &username, tail, socket.as_deref())
                         .await?;
+                }
+            }
+        }
+        Some(Cmd::Plugin { action }) => {
+            let plugins_dir = paths::room_plugins_dir();
+            match action {
+                PluginAction::Install { name, version } => {
+                    room_cli::plugin_cmd::cmd_install(&plugins_dir, &name, version.as_deref())?;
+                }
+                PluginAction::List => {
+                    room_cli::plugin_cmd::cmd_list(&plugins_dir)?;
+                }
+                PluginAction::Remove { name } => {
+                    room_cli::plugin_cmd::cmd_remove(&plugins_dir, &name)?;
+                }
+                PluginAction::Update { name, version } => {
+                    room_cli::plugin_cmd::cmd_update(&plugins_dir, &name, version.as_deref())?;
                 }
             }
         }

--- a/crates/room-cli/src/plugin_cmd.rs
+++ b/crates/room-cli/src/plugin_cmd.rs
@@ -1,0 +1,551 @@
+//! Plugin management commands: install, list, remove, update.
+//!
+//! These are client-side operations that manage the `~/.room/plugins/`
+//! directory. The daemon loads plugins from this directory on startup
+//! using `libloading`.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+// ── Plugin metadata ─────────────────────────────────────────────────────────
+
+/// Metadata written alongside each installed plugin shared library.
+///
+/// Stored as `<name>.meta.json` in `~/.room/plugins/`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PluginMeta {
+    /// Short plugin name (e.g. `"agent"`, `"taskboard"`).
+    pub name: String,
+    /// Crate name on crates.io (e.g. `"room-plugin-agent"`).
+    pub crate_name: String,
+    /// Installed version (semver).
+    pub version: String,
+    /// Minimum compatible `room-protocol` version (semver).
+    pub min_protocol: String,
+    /// Shared library filename (e.g. `"libroom_plugin_agent.so"`).
+    pub lib_file: String,
+}
+
+// ── Name resolution ─────────────────────────────────────────────────────────
+
+/// Resolve a user-supplied plugin name to the crate name on crates.io.
+///
+/// If the name already starts with `room-plugin-`, it is returned as-is.
+/// Otherwise, `room-plugin-` is prepended.
+pub fn resolve_crate_name(name: &str) -> String {
+    if name.starts_with("room-plugin-") {
+        name.to_owned()
+    } else {
+        format!("room-plugin-{name}")
+    }
+}
+
+/// Derive the short plugin name from a crate name.
+///
+/// Strips the `room-plugin-` prefix if present.
+pub fn short_name(crate_name: &str) -> String {
+    crate_name
+        .strip_prefix("room-plugin-")
+        .unwrap_or(crate_name)
+        .to_owned()
+}
+
+/// Compute the expected shared library filename for a plugin crate.
+///
+/// Cargo produces `lib<crate_name_underscored>.so` on Linux and
+/// `lib<crate_name_underscored>.dylib` on macOS.
+pub fn lib_filename(crate_name: &str) -> String {
+    let stem = crate_name.replace('-', "_");
+    let ext = if cfg!(target_os = "macos") {
+        "dylib"
+    } else {
+        "so"
+    };
+    format!("lib{stem}.{ext}")
+}
+
+/// Path to the `.meta.json` file for a plugin.
+pub fn meta_path(plugins_dir: &Path, name: &str) -> PathBuf {
+    plugins_dir.join(format!("{name}.meta.json"))
+}
+
+// ── Scanning installed plugins ──────────────────────────────────────────────
+
+/// Scan the plugins directory and return metadata for all installed plugins.
+pub fn scan_installed(plugins_dir: &Path) -> Vec<PluginMeta> {
+    let entries = match std::fs::read_dir(plugins_dir) {
+        Ok(e) => e,
+        Err(_) => return vec![],
+    };
+    let mut metas = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) == Some("json")
+            && path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.ends_with(".meta.json"))
+        {
+            if let Ok(data) = std::fs::read_to_string(&path) {
+                if let Ok(meta) = serde_json::from_str::<PluginMeta>(&data) {
+                    metas.push(meta);
+                }
+            }
+        }
+    }
+    metas.sort_by(|a, b| a.name.cmp(&b.name));
+    metas
+}
+
+// ── Commands ────────────────────────────────────────────────────────────────
+
+/// Install a plugin from crates.io.
+///
+/// 1. Resolves the crate name from the short name.
+/// 2. Creates a temporary directory and runs `cargo install` with
+///    `--target-dir` to build the cdylib.
+/// 3. Copies the shared library to `~/.room/plugins/`.
+/// 4. Writes `.meta.json` alongside it.
+pub fn cmd_install(plugins_dir: &Path, name: &str, version: Option<&str>) -> anyhow::Result<()> {
+    let crate_name = resolve_crate_name(name);
+    let short = short_name(&crate_name);
+
+    // Check if already installed.
+    let existing_meta = meta_path(plugins_dir, &short);
+    if existing_meta.exists() {
+        if let Ok(data) = std::fs::read_to_string(&existing_meta) {
+            if let Ok(meta) = serde_json::from_str::<PluginMeta>(&data) {
+                eprintln!(
+                    "plugin '{}' v{} is already installed — use `room plugin update {}` to upgrade",
+                    short, meta.version, short
+                );
+                return Ok(());
+            }
+        }
+    }
+
+    // Ensure plugins directory exists.
+    std::fs::create_dir_all(plugins_dir)?;
+
+    // Build in a temp directory.
+    let build_dir = tempfile::TempDir::new()?;
+    eprintln!("installing {crate_name}...");
+
+    let mut cmd = std::process::Command::new("cargo");
+    cmd.args(["install", "--root"])
+        .arg(build_dir.path())
+        .args(["--target-dir"])
+        .arg(build_dir.path().join("target"))
+        .arg(&crate_name);
+
+    if let Some(v) = version {
+        cmd.args(["--version", v]);
+    }
+
+    let output = cmd
+        .output()
+        .map_err(|e| anyhow::anyhow!("failed to run cargo install: {e} — is cargo on PATH?"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("cargo install failed:\n{stderr}");
+    }
+
+    // Find the built shared library.
+    let lib_name = lib_filename(&crate_name);
+    let built_lib = find_built_lib(build_dir.path(), &lib_name)?;
+
+    // Copy to plugins directory.
+    let dest_lib = plugins_dir.join(&lib_name);
+    std::fs::copy(&built_lib, &dest_lib).map_err(|e| {
+        anyhow::anyhow!(
+            "failed to copy {} to {}: {e}",
+            built_lib.display(),
+            dest_lib.display()
+        )
+    })?;
+
+    // Extract version from cargo output or default.
+    let installed_version = version.unwrap_or("latest").to_owned();
+
+    // Write metadata.
+    let meta = PluginMeta {
+        name: short.to_owned(),
+        crate_name: crate_name.clone(),
+        version: installed_version,
+        min_protocol: "0.0.0".to_owned(),
+        lib_file: lib_name,
+    };
+    let meta_file = meta_path(plugins_dir, &short);
+    std::fs::write(&meta_file, serde_json::to_string_pretty(&meta)?)?;
+
+    eprintln!("installed plugin '{}' to {}", short, dest_lib.display());
+    Ok(())
+}
+
+/// List installed plugins.
+pub fn cmd_list(plugins_dir: &Path) -> anyhow::Result<()> {
+    let metas = scan_installed(plugins_dir);
+    if metas.is_empty() {
+        println!("no plugins installed");
+        return Ok(());
+    }
+    println!("{:<16} {:<12} {:<28} LIB", "NAME", "VERSION", "CRATE");
+    for m in &metas {
+        println!(
+            "{:<16} {:<12} {:<28} {}",
+            m.name, m.version, m.crate_name, m.lib_file
+        );
+    }
+    Ok(())
+}
+
+/// Remove an installed plugin.
+pub fn cmd_remove(plugins_dir: &Path, name: &str) -> anyhow::Result<()> {
+    let short = short_name(&resolve_crate_name(name));
+    let meta_file = meta_path(plugins_dir, &short);
+
+    if !meta_file.exists() {
+        anyhow::bail!("plugin '{}' is not installed", short);
+    }
+
+    // Read meta to find the lib file.
+    let data = std::fs::read_to_string(&meta_file)?;
+    let meta: PluginMeta = serde_json::from_str(&data)?;
+
+    // Remove the shared library.
+    let lib_path = plugins_dir.join(&meta.lib_file);
+    if lib_path.exists() {
+        std::fs::remove_file(&lib_path)?;
+    }
+
+    // Remove the meta file.
+    std::fs::remove_file(&meta_file)?;
+
+    eprintln!("removed plugin '{}'", short);
+    Ok(())
+}
+
+/// Update an installed plugin to the latest (or specified) version.
+pub fn cmd_update(plugins_dir: &Path, name: &str, version: Option<&str>) -> anyhow::Result<()> {
+    let short = short_name(&resolve_crate_name(name));
+    let meta_file = meta_path(plugins_dir, &short);
+
+    if !meta_file.exists() {
+        anyhow::bail!(
+            "plugin '{}' is not installed — use `room plugin install {}` first",
+            short,
+            short
+        );
+    }
+
+    // Remove old installation, then reinstall.
+    cmd_remove(plugins_dir, name)?;
+    cmd_install(plugins_dir, name, version)?;
+    eprintln!("updated plugin '{}'", short);
+    Ok(())
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/// Search a build directory tree for a shared library matching the expected name.
+fn find_built_lib(build_dir: &Path, lib_name: &str) -> anyhow::Result<PathBuf> {
+    // cargo install --root puts the library in target/release/deps/ or similar.
+    // Walk the tree looking for the file.
+    for entry in walkdir(build_dir) {
+        if let Some(name) = entry.file_name().and_then(|n| n.to_str()) {
+            if name == lib_name {
+                return Ok(entry);
+            }
+        }
+    }
+    anyhow::bail!(
+        "built library '{}' not found in {}",
+        lib_name,
+        build_dir.display()
+    )
+}
+
+/// Simple recursive directory walker (avoids adding a `walkdir` dependency).
+fn walkdir(dir: &Path) -> Vec<PathBuf> {
+    let mut results = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                results.extend(walkdir(&path));
+            } else {
+                results.push(path);
+            }
+        }
+    }
+    results
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── resolve_crate_name ──────────────────────────────────────────────
+
+    #[test]
+    fn resolve_short_name_prepends_prefix() {
+        assert_eq!(resolve_crate_name("agent"), "room-plugin-agent");
+    }
+
+    #[test]
+    fn resolve_full_name_unchanged() {
+        assert_eq!(
+            resolve_crate_name("room-plugin-taskboard"),
+            "room-plugin-taskboard"
+        );
+    }
+
+    #[test]
+    fn resolve_hyphenated_name() {
+        assert_eq!(resolve_crate_name("my-custom"), "room-plugin-my-custom");
+    }
+
+    // ── short_name ──────────────────────────────────────────────────────
+
+    #[test]
+    fn short_name_strips_prefix() {
+        assert_eq!(short_name("room-plugin-agent"), "agent");
+    }
+
+    #[test]
+    fn short_name_no_prefix() {
+        assert_eq!(short_name("custom"), "custom");
+    }
+
+    // ── lib_filename ────────────────────────────────────────────────────
+
+    #[test]
+    fn lib_filename_replaces_hyphens() {
+        let name = lib_filename("room-plugin-agent");
+        assert!(name.starts_with("libroom_plugin_agent."));
+        // Extension is platform-dependent.
+        assert!(name.ends_with(".so") || name.ends_with(".dylib"));
+    }
+
+    // ── PluginMeta serialization ────────────────────────────────────────
+
+    #[test]
+    fn meta_roundtrip() {
+        let meta = PluginMeta {
+            name: "agent".to_owned(),
+            crate_name: "room-plugin-agent".to_owned(),
+            version: "3.4.0".to_owned(),
+            min_protocol: "3.0.0".to_owned(),
+            lib_file: "libroom_plugin_agent.so".to_owned(),
+        };
+        let json = serde_json::to_string(&meta).unwrap();
+        let parsed: PluginMeta = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, meta);
+    }
+
+    #[test]
+    fn meta_pretty_print() {
+        let meta = PluginMeta {
+            name: "taskboard".to_owned(),
+            crate_name: "room-plugin-taskboard".to_owned(),
+            version: "1.0.0".to_owned(),
+            min_protocol: "0.0.0".to_owned(),
+            lib_file: "libroom_plugin_taskboard.so".to_owned(),
+        };
+        let json = serde_json::to_string_pretty(&meta).unwrap();
+        assert!(json.contains("\"name\": \"taskboard\""));
+        assert!(json.contains("\"version\": \"1.0.0\""));
+    }
+
+    // ── scan_installed ──────────────────────────────────────────────────
+
+    #[test]
+    fn scan_empty_dir() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let result = scan_installed(dir.path());
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn scan_nonexistent_dir() {
+        let result = scan_installed(Path::new("/nonexistent/plugins"));
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn scan_finds_valid_meta_files() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let meta = PluginMeta {
+            name: "test".to_owned(),
+            crate_name: "room-plugin-test".to_owned(),
+            version: "0.1.0".to_owned(),
+            min_protocol: "0.0.0".to_owned(),
+            lib_file: "libroom_plugin_test.so".to_owned(),
+        };
+        let meta_file = dir.path().join("test.meta.json");
+        std::fs::write(&meta_file, serde_json::to_string(&meta).unwrap()).unwrap();
+
+        let result = scan_installed(dir.path());
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "test");
+    }
+
+    #[test]
+    fn scan_skips_invalid_json() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("bad.meta.json"), "not json").unwrap();
+        let result = scan_installed(dir.path());
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn scan_skips_non_meta_json() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("config.json"), "{}").unwrap();
+        let result = scan_installed(dir.path());
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn scan_sorts_by_name() {
+        let dir = tempfile::TempDir::new().unwrap();
+        for name in &["zebra", "alpha", "mid"] {
+            let meta = PluginMeta {
+                name: name.to_string(),
+                crate_name: format!("room-plugin-{name}"),
+                version: "0.1.0".to_owned(),
+                min_protocol: "0.0.0".to_owned(),
+                lib_file: format!("libroom_plugin_{name}.so"),
+            };
+            std::fs::write(
+                dir.path().join(format!("{name}.meta.json")),
+                serde_json::to_string(&meta).unwrap(),
+            )
+            .unwrap();
+        }
+        let result = scan_installed(dir.path());
+        let names: Vec<&str> = result.iter().map(|m| m.name.as_str()).collect();
+        assert_eq!(names, vec!["alpha", "mid", "zebra"]);
+    }
+
+    // ── meta_path ───────────────────────────────────────────────────────
+
+    #[test]
+    fn meta_path_format() {
+        let p = meta_path(Path::new("/home/user/.room/plugins"), "agent");
+        assert_eq!(p, PathBuf::from("/home/user/.room/plugins/agent.meta.json"));
+    }
+
+    // ── cmd_remove ──────────────────────────────────────────────────────
+
+    #[test]
+    fn remove_nonexistent_plugin_fails() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let result = cmd_remove(dir.path(), "nonexistent");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not installed"));
+    }
+
+    #[test]
+    fn remove_deletes_lib_and_meta() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let meta = PluginMeta {
+            name: "test".to_owned(),
+            crate_name: "room-plugin-test".to_owned(),
+            version: "0.1.0".to_owned(),
+            min_protocol: "0.0.0".to_owned(),
+            lib_file: "libroom_plugin_test.so".to_owned(),
+        };
+        std::fs::write(
+            dir.path().join("test.meta.json"),
+            serde_json::to_string(&meta).unwrap(),
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("libroom_plugin_test.so"), b"fake").unwrap();
+
+        cmd_remove(dir.path(), "test").unwrap();
+        assert!(!dir.path().join("test.meta.json").exists());
+        assert!(!dir.path().join("libroom_plugin_test.so").exists());
+    }
+
+    // ── walkdir ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn walkdir_finds_nested_files() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let nested = dir.path().join("a").join("b");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(nested.join("target.so"), b"lib").unwrap();
+        std::fs::write(dir.path().join("top.txt"), b"top").unwrap();
+
+        let files = walkdir(dir.path());
+        assert!(files.iter().any(|p| p.ends_with("target.so")));
+        assert!(files.iter().any(|p| p.ends_with("top.txt")));
+    }
+
+    #[test]
+    fn walkdir_empty_dir() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let files = walkdir(dir.path());
+        assert!(files.is_empty());
+    }
+
+    // ── find_built_lib ──────────────────────────────────────────────────
+
+    #[test]
+    fn find_built_lib_success() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let release = dir.path().join("target").join("release");
+        std::fs::create_dir_all(&release).unwrap();
+        std::fs::write(release.join("libroom_plugin_test.so"), b"elf").unwrap();
+
+        let result = find_built_lib(dir.path(), "libroom_plugin_test.so");
+        assert!(result.is_ok());
+        assert!(result.unwrap().ends_with("libroom_plugin_test.so"));
+    }
+
+    #[test]
+    fn find_built_lib_not_found() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let result = find_built_lib(dir.path(), "nonexistent.so");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not found"));
+    }
+
+    // ── cmd_install duplicate check ─────────────────────────────────────
+
+    #[test]
+    fn install_skips_when_already_installed() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let meta = PluginMeta {
+            name: "existing".to_owned(),
+            crate_name: "room-plugin-existing".to_owned(),
+            version: "1.0.0".to_owned(),
+            min_protocol: "0.0.0".to_owned(),
+            lib_file: "libroom_plugin_existing.so".to_owned(),
+        };
+        std::fs::write(
+            dir.path().join("existing.meta.json"),
+            serde_json::to_string(&meta).unwrap(),
+        )
+        .unwrap();
+
+        // Should succeed without error (prints "already installed").
+        let result = cmd_install(dir.path(), "existing", None);
+        assert!(result.is_ok());
+    }
+
+    // ── cmd_update when not installed ───────────────────────────────────
+
+    #[test]
+    fn update_nonexistent_plugin_fails() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let result = cmd_update(dir.path(), "nonexistent", None);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not installed"));
+    }
+}

--- a/crates/room-daemon/CHANGELOG.md
+++ b/crates/room-daemon/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - `PluginRegistry::notify_message()` — broadcasts message observations to all plugins
 - Broker session calls `notify_message` after every successful broadcast/DM persist
+- `room_plugins_dir()` path helper for `~/.room/plugins/` directory. (#745)
 
 ## [3.4.0] - 2026-03-15
 

--- a/crates/room-daemon/src/paths.rs
+++ b/crates/room-daemon/src/paths.rs
@@ -112,6 +112,15 @@ pub fn broker_tokens_path(state_dir: &Path, room_id: &str) -> PathBuf {
     state_dir.join(format!("{room_id}.tokens"))
 }
 
+/// Directory for installed plugin shared libraries and metadata.
+///
+/// Returns `~/.room/plugins/`. Each plugin installs two files here:
+/// - `libroom_plugin_<name>.so` (or `.dylib` on macOS)
+/// - `<name>.meta.json` — version, source crate, protocol compatibility
+pub fn room_plugins_dir() -> PathBuf {
+    room_home().join("plugins")
+}
+
 /// PID file for the daemon process: `~/.room/roomd.pid`.
 ///
 /// Written by `ensure_daemon_running` when it auto-starts the daemon.
@@ -370,6 +379,12 @@ mod tests {
         let p = legacy_token_dir();
         // Must be absolute and non-empty.
         assert!(p.is_absolute(), "expected absolute path, got: {p:?}");
+    }
+
+    #[test]
+    fn room_plugins_dir_under_room_home() {
+        assert!(room_plugins_dir().starts_with(room_home()));
+        assert!(room_plugins_dir().ends_with("plugins"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `room plugin install/list/remove/update` subcommands for managing dynamic plugins in `~/.room/plugins/`
- Add `PluginMeta` struct for `.meta.json` persistence with crate name, version, protocol compat
- Add `room_plugins_dir()` path helper to room-daemon
- Crate name resolution: `agent` -> `room-plugin-agent`, full names pass through
- Plugin directory scanning with sorted output
- 24 new unit tests across plugin_cmd and paths modules

**Note:** This PR implements the CLI and metadata layer. The actual `cargo install` + cdylib compilation flow requires tb-010 (#744 libloading loader) to be merged first for end-to-end testing. The install path is functional but will need integration testing once the loader lands.

## Test plan
- [x] `cargo check` passes
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] 23 plugin_cmd unit tests pass (name resolution, meta serde, scan, remove, walkdir, find_built_lib)
- [x] 1 new paths test passes (room_plugins_dir)

Closes #745