### PR TITLE
fix(agent): spawned agents now respond to messages

### DIFF
--- a/crates/room-plugin-agent/CHANGELOG.md
+++ b/crates/room-plugin-agent/CHANGELOG.md
@@ -6,6 +6,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `/spawn` now passes `--personality` instead of `--prompt` to room-ralph, preserving
+  the default system context (room send/poll commands and token). Previously, the
+  personality template text was passed as `--prompt` (which expects a file path),
+  causing the agent to lose all room communication instructions. (#770)
+
 ## [3.5.0] - 2026-03-15
 
 ### Added

--- a/crates/room-plugin-agent/src/lib.rs
+++ b/crates/room-plugin-agent/src/lib.rs
@@ -560,9 +560,17 @@ impl AgentPlugin {
             }
         }
 
-        // Apply prompt
+        // Apply personality template as a file — room-ralph's --personality flag
+        // reads the file and prepends its contents to the default system context
+        // (which includes room send/poll commands and the token). Using --prompt
+        // would REPLACE the default context entirely, breaking room communication.
         if !personality.prompt.template.is_empty() {
-            cmd.arg("--prompt").arg(&personality.prompt.template);
+            let template_path =
+                self.log_dir.join(format!("{username}-personality.txt"));
+            if let Err(e) = std::fs::write(&template_path, &personality.prompt.template) {
+                return Err(format!("failed to write personality template: {e}"));
+            }
+            cmd.arg("--personality").arg(&template_path);
         }
 
         cmd.stdin(Stdio::null())

--- a/crates/room-ralph/src/prompt.rs
+++ b/crates/room-ralph/src/prompt.rs
@@ -30,8 +30,12 @@ pub fn build_prompt(config: &PromptConfig<'_>, messages: &[Message]) -> String {
 
     // System context
     if let Some(custom) = config.custom_prompt_file {
-        if let Ok(content) = std::fs::read_to_string(custom) {
-            prompt.push_str(&content);
+        match std::fs::read_to_string(custom) {
+            Ok(content) => prompt.push_str(&content),
+            Err(e) => eprintln!(
+                "[ralph] warning: cannot read custom prompt {}: {e}",
+                custom.display()
+            ),
         }
     } else {
         prompt.push_str(&format!(


### PR DESCRIPTION
## Summary
- Fix `/spawn` passing personality template text as `--prompt` (expects file path) instead of `--personality` (prepends to default context)
- Root cause: agents lost all room CLI instructions (send/poll/watch), token, and room ID — making them unable to communicate
- Write personality template to a temp file in the agent log directory and pass via `--personality`
- Add warning in prompt.rs when custom prompt file fails to read (was previously silent)

## Test plan
- [x] Both crates compile clean
- [x] `--personality <file>` preserves default system context (verified by reading prompt.rs logic)
- [ ] Manual verification: `/spawn coder`, send `@coder-<name> hello`, agent responds (requires running broker — CI will validate compilation, manual test by joao)

Closes #770
