### PR TITLE
feat(cli): show builtin plugins in room plugin list

### DIFF
--- a/crates/room-cli/CHANGELOG.md
+++ b/crates/room-cli/CHANGELOG.md
@@ -12,6 +12,8 @@ For changes prior to the workspace restructure (v0.1.2 through v1.0.2), see the
 
 ### Added
 
+- `room plugin list` now shows builtin plugins (agent, taskboard, queue, stats) as `[builtin]`
+  entries alongside external plugins (#774)
 - 5 integration tests for persistence and cross-transport visibility (Section 4+5 of #675 manual test plan)
 - 6 integration tests for auth/error edge cases from manual test plan (#675):
   bare username compat, path traversal rejection, JSON injection preservation,

--- a/crates/room-cli/src/plugin_cmd.rs
+++ b/crates/room-cli/src/plugin_cmd.rs
@@ -8,6 +8,22 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
+// ── Builtin plugin metadata ─────────────────────────────────────────────────
+
+/// Statically compiled plugins shipped with the room binary.
+///
+/// These are always available regardless of what is installed in
+/// `~/.room/plugins/`. Displayed as `[builtin]` in `room plugin list`.
+pub const BUILTIN_PLUGINS: &[(&str, &str)] = &[
+    ("agent", "Agent spawn/stop/list/logs, /spawn personalities"),
+    ("queue", "FIFO message queue (push/pop/peek/list/clear)"),
+    ("stats", "Room statistics (message counts, uptime)"),
+    (
+        "taskboard",
+        "Task lifecycle management (post/claim/plan/approve/finish)",
+    ),
+];
+
 // ── Plugin metadata ─────────────────────────────────────────────────────────
 
 /// Metadata written alongside each installed plugin shared library.
@@ -184,20 +200,32 @@ pub fn cmd_install(plugins_dir: &Path, name: &str, version: Option<&str>) -> any
     Ok(())
 }
 
-/// List installed plugins.
+/// List all plugins — builtins first, then installed external plugins.
 pub fn cmd_list(plugins_dir: &Path) -> anyhow::Result<()> {
-    let metas = scan_installed(plugins_dir);
-    if metas.is_empty() {
-        println!("no plugins installed");
-        return Ok(());
-    }
-    println!("{:<16} {:<12} {:<28} LIB", "NAME", "VERSION", "CRATE");
-    for m in &metas {
+    let externals = scan_installed(plugins_dir);
+
+    println!(
+        "{:<16} {:<12} {:<10} {}",
+        "NAME", "VERSION", "SOURCE", "DESCRIPTION"
+    );
+
+    // Builtins — always shown
+    let version = env!("CARGO_PKG_VERSION");
+    for (name, description) in BUILTIN_PLUGINS {
         println!(
-            "{:<16} {:<12} {:<28} {}",
-            m.name, m.version, m.crate_name, m.lib_file
+            "{:<16} {:<12} {:<10} {}",
+            name, version, "[builtin]", description
         );
     }
+
+    // External plugins from ~/.room/plugins/
+    for m in &externals {
+        println!(
+            "{:<16} {:<12} {:<10} {}",
+            m.name, m.version, "[external]", m.crate_name
+        );
+    }
+
     Ok(())
 }
 
@@ -547,5 +575,29 @@ mod tests {
         let result = cmd_update(dir.path(), "nonexistent", None);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("not installed"));
+    }
+
+    // ── builtin plugins ─────────────────────────────────────────────────
+
+    #[test]
+    fn builtin_plugins_has_four_entries() {
+        assert_eq!(BUILTIN_PLUGINS.len(), 4);
+    }
+
+    #[test]
+    fn builtin_plugins_includes_expected_names() {
+        let names: Vec<&str> = BUILTIN_PLUGINS.iter().map(|(n, _)| *n).collect();
+        assert!(names.contains(&"agent"));
+        assert!(names.contains(&"taskboard"));
+        assert!(names.contains(&"queue"));
+        assert!(names.contains(&"stats"));
+    }
+
+    #[test]
+    fn builtin_plugins_sorted_alphabetically() {
+        let names: Vec<&str> = BUILTIN_PLUGINS.iter().map(|(n, _)| *n).collect();
+        let mut sorted = names.clone();
+        sorted.sort();
+        assert_eq!(names, sorted);
     }
 }


### PR DESCRIPTION
## Summary

- Add BUILTIN_PLUGINS constant listing the 4 statically compiled plugins (agent, taskboard, queue, stats) with descriptions
- Update room plugin list to always show builtins as [builtin] entries before external [external] plugins
- Unified table format: NAME, VERSION, SOURCE, DESCRIPTION
- 3 new tests: count, expected names, alphabetical ordering

## Test plan

- [x] All 26 plugin_cmd tests pass (23 existing + 3 new)
- [x] Full workspace compiles clean
- [x] cargo fmt clean

Closes #774