### PR TITLE
feat(agent): per-agent workspace isolation for /spawn

### DIFF
--- a/crates/room-plugin-agent/CHANGELOG.md
+++ b/crates/room-plugin-agent/CHANGELOG.md
@@ -6,6 +6,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Per-agent workspace isolation: `/spawn` creates `~/.room/agents/<name>/` and sets it
+  as the working directory for the spawned process. Agents no longer share the host's
+  cwd. (#771)
+
 ### Fixed
 
 - `/agent stop` now kills the entire process group (ralph + all child claude

--- a/crates/room-plugin-agent/src/lib.rs
+++ b/crates/room-plugin-agent/src/lib.rs
@@ -14,6 +14,18 @@ use room_protocol::plugin::{
 };
 use room_protocol::Message;
 
+/// Returns the workspace directory for a spawned agent: `~/.room/agents/<name>/`.
+///
+/// Each agent gets its own isolated working directory to prevent cwd collisions
+/// between multiple spawned agents and the host process.
+fn agent_workspace_dir(agent_name: &str) -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_owned());
+    PathBuf::from(home)
+        .join(".room")
+        .join("agents")
+        .join(agent_name)
+}
+
 // ── C ABI entry points for cdylib loading ─────────────────────────────────
 
 /// JSON configuration for the agent plugin when loaded dynamically.
@@ -307,9 +319,19 @@ impl AgentPlugin {
             cmd.arg("--personality").arg(&personality);
         }
 
+        // Create per-agent workspace directory for isolation
+        let workspace = agent_workspace_dir(username);
+        fs::create_dir_all(&workspace).map_err(|e| {
+            format!(
+                "failed to create agent workspace {}: {e}",
+                workspace.display()
+            )
+        })?;
+
         cmd.stdin(Stdio::null())
             .stdout(Stdio::from(log_file))
-            .stderr(Stdio::from(stderr_file));
+            .stderr(Stdio::from(stderr_file))
+            .current_dir(&workspace);
         set_process_group(&mut cmd);
 
         let child = cmd
@@ -573,9 +595,19 @@ impl AgentPlugin {
             cmd.arg("--personality").arg(&template_path);
         }
 
+        // Create per-agent workspace directory for isolation
+        let workspace = agent_workspace_dir(&username);
+        fs::create_dir_all(&workspace).map_err(|e| {
+            format!(
+                "failed to create agent workspace {}: {e}",
+                workspace.display()
+            )
+        })?;
+
         cmd.stdin(Stdio::null())
             .stdout(Stdio::from(log_file))
-            .stderr(Stdio::from(stderr_file));
+            .stderr(Stdio::from(stderr_file))
+            .current_dir(&workspace);
         set_process_group(&mut cmd);
 
         let child = cmd


### PR DESCRIPTION
## Summary
- Each spawned agent now gets its own workspace at `~/.room/agents/<name>/`
- Both `handle_spawn` and `handle_spawn_personality` set `current_dir` on the child process
- Agents no longer share the host's working directory

## Test plan
- [x] Compiles clean, clippy clean, formatted
- [x] CHANGELOG in first commit
- [ ] Manual: `/spawn coder`, verify agent cwd is `~/.room/agents/coder-<name>/`

Closes #771
