### PR TITLE
feat: add agent metadata file (.room-agent.json) (#779)

### DIFF
--- a/crates/room-ralph/CHANGELOG.md
+++ b/crates/room-ralph/CHANGELOG.md
@@ -16,6 +16,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - `watch_room()` function in room.rs for blocking until messages arrive
+- Agent metadata file (`.room-agent.json`) — written by ralph before spawning claude,
+  contains username, token, room_id, PID, socket path, and personality. Claude reads
+  this instead of running `room join`. Cleaned up on exit. 7 unit tests. (#779)
 - 6 integration tests for manual test plan coverage (#675): log file path, list
   personalities, progress file with --issue, multi-iteration run, token join, send message.
 

--- a/crates/room-ralph/src/agent_meta.rs
+++ b/crates/room-ralph/src/agent_meta.rs
@@ -1,0 +1,143 @@
+//! Agent metadata file — `.room-agent.json`.
+//!
+//! Written by room-ralph before spawning claude so the agent can read its
+//! identity (username, token, room_id) from a stable file instead of
+//! re-joining via `room join`.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Metadata written to `.room-agent.json` in the agent's working directory.
+///
+/// Claude reads this file at the start of each iteration to know its identity
+/// without running `room join` (which would create a new user).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentMeta {
+    /// Assigned username (e.g. "coder-anna").
+    pub username: String,
+    /// Session token for room CLI commands.
+    pub token: String,
+    /// Room ID the agent is participating in.
+    pub room_id: String,
+    /// PID of the room-ralph wrapper process.
+    pub ralph_pid: u32,
+    /// Path to the daemon socket.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub socket_path: Option<String>,
+    /// Personality name (e.g. "coder", "reviewer").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub personality: Option<String>,
+}
+
+/// Default filename for the metadata file.
+pub const META_FILENAME: &str = ".room-agent.json";
+
+/// Write the agent metadata file to the given directory.
+pub fn write_meta(dir: &Path, meta: &AgentMeta) -> Result<(), String> {
+    let path = dir.join(META_FILENAME);
+    let json = serde_json::to_string_pretty(meta)
+        .map_err(|e| format!("failed to serialize agent metadata: {e}"))?;
+    std::fs::write(&path, format!("{json}\n"))
+        .map_err(|e| format!("failed to write {}: {e}", path.display()))?;
+    Ok(())
+}
+
+/// Read agent metadata from the given directory, if the file exists.
+pub fn read_meta(dir: &Path) -> Option<AgentMeta> {
+    let path = dir.join(META_FILENAME);
+    let data = std::fs::read_to_string(&path).ok()?;
+    serde_json::from_str(&data).ok()
+}
+
+/// Return the full path to the metadata file in the given directory.
+pub fn meta_path(dir: &Path) -> PathBuf {
+    dir.join(META_FILENAME)
+}
+
+/// Delete the metadata file from the given directory. Ignores missing files.
+pub fn cleanup_meta(dir: &Path) {
+    let path = dir.join(META_FILENAME);
+    std::fs::remove_file(path).ok();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn sample_meta() -> AgentMeta {
+        AgentMeta {
+            username: "coder-anna".to_owned(),
+            token: "tok-abc123".to_owned(),
+            room_id: "dev-room".to_owned(),
+            ralph_pid: 12345,
+            socket_path: Some("/tmp/roomd.sock".to_owned()),
+            personality: Some("coder".to_owned()),
+        }
+    }
+
+    #[test]
+    fn write_and_read_roundtrip() {
+        let dir = TempDir::new().unwrap();
+        let meta = sample_meta();
+        write_meta(dir.path(), &meta).unwrap();
+
+        let loaded = read_meta(dir.path()).expect("should read back");
+        assert_eq!(loaded.username, "coder-anna");
+        assert_eq!(loaded.token, "tok-abc123");
+        assert_eq!(loaded.room_id, "dev-room");
+        assert_eq!(loaded.ralph_pid, 12345);
+        assert_eq!(loaded.socket_path.as_deref(), Some("/tmp/roomd.sock"));
+        assert_eq!(loaded.personality.as_deref(), Some("coder"));
+    }
+
+    #[test]
+    fn read_missing_returns_none() {
+        let dir = TempDir::new().unwrap();
+        assert!(read_meta(dir.path()).is_none());
+    }
+
+    #[test]
+    fn cleanup_removes_file() {
+        let dir = TempDir::new().unwrap();
+        write_meta(dir.path(), &sample_meta()).unwrap();
+        assert!(meta_path(dir.path()).exists());
+
+        cleanup_meta(dir.path());
+        assert!(!meta_path(dir.path()).exists());
+    }
+
+    #[test]
+    fn cleanup_missing_file_no_error() {
+        let dir = TempDir::new().unwrap();
+        cleanup_meta(dir.path()); // should not panic
+    }
+
+    #[test]
+    fn meta_path_returns_expected() {
+        let path = meta_path(Path::new("/home/agent"));
+        assert_eq!(path, PathBuf::from("/home/agent/.room-agent.json"));
+    }
+
+    #[test]
+    fn serialization_skips_none_fields() {
+        let meta = AgentMeta {
+            username: "test".to_owned(),
+            token: "tok".to_owned(),
+            room_id: "room".to_owned(),
+            ralph_pid: 1,
+            socket_path: None,
+            personality: None,
+        };
+        let json = serde_json::to_string(&meta).unwrap();
+        assert!(!json.contains("socket_path"));
+        assert!(!json.contains("personality"));
+    }
+
+    #[test]
+    fn write_to_nonexistent_dir_fails() {
+        let result = write_meta(Path::new("/nonexistent/path"), &sample_meta());
+        assert!(result.is_err());
+    }
+}

--- a/crates/room-ralph/src/lib.rs
+++ b/crates/room-ralph/src/lib.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 
 use clap::Parser;
 
+pub mod agent_meta;
 pub mod claude;
 
 /// Clap value parser for the Profile enum.

--- a/crates/room-ralph/src/loop_runner.rs
+++ b/crates/room-ralph/src/loop_runner.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
+use crate::agent_meta::{self, AgentMeta};
 use crate::claude::{self, ClaudeOutput};
 use crate::monitor;
 use crate::personalities::{self, ResolvedPersonality};
@@ -26,6 +27,20 @@ pub async fn run_loop(cli: &Cli, token: String, running: &Arc<AtomicBool>) -> Re
     // Resolve personality once: builtin prompt text or file contents.
     let personality_text = resolve_personality_text(cli);
     let personality_text_ref = personality_text.as_deref();
+
+    // Write agent metadata file so claude can read identity without re-joining.
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let meta = AgentMeta {
+        username: cli.username.clone(),
+        token: token.clone(),
+        room_id: cli.room_id.clone(),
+        ralph_pid: std::process::id(),
+        socket_path: socket_str.clone(),
+        personality: cli.personality.clone(),
+    };
+    if let Err(e) = agent_meta::write_meta(&cwd, &meta) {
+        tracing::warn!("failed to write agent metadata: {e}");
+    }
 
     while running.load(Ordering::SeqCst) {
         iteration += 1;
@@ -60,6 +75,10 @@ pub async fn run_loop(cli: &Cli, token: String, running: &Arc<AtomicBool>) -> Re
     }
 
     shutdown(cli, &token, socket_ref, iteration);
+
+    // Clean up agent metadata file on exit.
+    agent_meta::cleanup_meta(&cwd);
+
     Ok(())
 }
 

--- a/crates/room-ralph/src/prompt.rs
+++ b/crates/room-ralph/src/prompt.rs
@@ -59,6 +59,11 @@ pub fn build_prompt(config: &PromptConfig<'_>, messages: &[Message]) -> String {
             "  room watch {} -t {} --interval 2 -- block until a message arrives\n\n",
             config.room_id, config.token
         ));
+        prompt.push_str("Identity:\n");
+        prompt.push_str("- Your identity is in .room-agent.json in your working directory\n");
+        prompt.push_str("- Read it at startup for username, token, room_id, and socket path\n");
+        prompt.push_str("- Do NOT run `room join` — your token is already provisioned\n");
+        prompt.push_str("- Do NOT change your username — it is assigned by the host\n\n");
         prompt.push_str("Rules:\n");
         prompt.push_str("- Do NOT call `room join` — your token is already provisioned above\n");
         prompt.push_str("- Announce your plan before writing code\n");


### PR DESCRIPTION
## Summary
- Adds `.room-agent.json` metadata file written by ralph before spawning claude
- Contains username, token, room_id, ralph PID, socket path, personality
- Claude reads this for identity instead of running `room join`
- File cleaned up on clean exit
- Prompt updated with identity instructions referencing the metadata file
- Foundation for #775 (identity persistence) and #777 (orphan process awareness)

## Test plan
- [x] 7 new unit tests pass (write/read roundtrip, cleanup, missing file, serialization)
- [x] `cargo check`, `cargo fmt`, `cargo clippy -- -D warnings` all clean

Closes #779