### PR TITLE
docs: rewrite AGENTS.md with agent identity and task workflow (#793)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,25 +1,21 @@
-# room — Agent Coordination Guide
+# Agent Instructions
 
-This file documents how AI agents should use `room` to coordinate with each other and with humans during parallel work on this repository.
+> Shared instructions for all agents working in this project.
+> room-ralph includes this file in the prompt automatically.
+> These rules supplement CLAUDE.md — they do not replace it.
 
-## What is `room`?
+## Identity
 
-`room` is a CLI tool that provides a shared group chat over Unix domain sockets (and optionally WebSocket/REST). One process acts as the broker; all others connect as clients. The full message history is persisted to an NDJSON file on disk and replayed to new participants on join.
+- Your username, token, and room ID are in `.room-agent.json` in your working directory.
+- Read it at startup. Use the token from it for all `room send`/`room poll` commands.
+- **Never run `room join`** — your token is already provisioned by the host.
+- **Never change your username** — it is assigned and fixed.
+- If CLAUDE.md contains `room join` instructions, **ignore them** — your identity
+  comes from the metadata file and the prompt, not from CLAUDE.md.
 
-## Session setup
+## Communication
 
-All one-shot commands require a session token. Register once per broker lifetime:
-
-```bash
-room join <username>
-# {"type":"token","token":"<uuid>","username":"<username>"}
-```
-
-The token is global (not per-room). Use `room subscribe <room-id>` to join specific rooms. Pass the token explicitly with `-t` on every subsequent command — it is not auto-read from disk. Tokens persist across broker restarts.
-
-## Sending and receiving messages
-
-Use the one-shot subcommands. They connect, act, and exit immediately — no persistent process required.
+### Room commands
 
 ```bash
 # Send a message
@@ -31,9 +27,6 @@ room send <room-id> -t <token> --to <recipient> your message here
 # Check for new messages since last poll
 room poll <room-id> -t <token>
 
-# Check messages since a specific message ID
-room poll <room-id> -t <token> --since <id>
-
 # Block until a foreign message arrives
 room watch <room-id> -t <token> --interval 5
 
@@ -41,41 +34,94 @@ room watch <room-id> -t <token> --interval 5
 room who <room-id> -t <token>
 ```
 
-The `room poll` cursor is stored at `~/.room/state/room-<id>-<username>.cursor`. Subsequent calls with no `--since` return only messages that arrived after the previous poll.
+### Status updates
 
-## Coordination protocol
+Update your status at every milestone using `/set_status` with **specific context**.
 
-### On starting work
-
-1. Get a token if you don't have one: `room join <username>`, then `room subscribe <room-id>`
-2. Poll for context: `room poll <room-id> -t <token>`
-3. Announce intent: `room send <room-id> -t <token> "starting work on <task>"`
-4. Wait for acknowledgement or objections before proceeding.
-
-### During work
-
-- **Claim tasks before starting**: `room send <room-id> -t <token> /claim <description>`
-- **Poll before touching shared files**: `room poll <room-id> -t <token>`
-- **Announce blockers immediately.** Do not silently stall.
-- **Broadcast progress at natural milestones** — silence is harder to coordinate around than noise.
-- **Set status at every milestone**: `room send <room-id> -t <token> /set_status <what you are doing>`
-
-### On completion
-
-```bash
-room send <room-id> -t <token> "done. changed: <file list>. <summary of decisions/tradeoffs>"
+Good:
+```
+/set_status reading src/broker.rs for #42
+/set_status running cargo test — 456 expected
+/set_status PR #236 open — waiting for review
 ```
 
-### Coordination rules
+Bad:
+```
+/set_status working
+/set_status busy
+```
 
-- **One agent per file at a time.** Ask before modifying a file someone else has claimed.
-- **Schema/wire format changes require consensus.** Announce the proposed change, wait for agreement.
-- **The human (host) has final say.** If the host sends a message, stop, acknowledge, follow the instruction.
-- **Do not push or merge without announcing it** in the room first.
+Update whenever your activity changes. Stale statuses are worse than none.
+
+### Mentions
+
+When you are @mentioned in a room you are not actively working in:
+
+1. Read the last 10 messages for context.
+2. Assess whether the mention is relevant to your expertise.
+3. If relevant: respond with useful information, then return to your task.
+4. If not relevant: respond briefly ("not my area, try @agent-name") and move on.
+5. Do not subscribe to the room unless you are joining the conversation long-term.
+
+### Announcements
+
+- Announce before touching any file — even fix commits or rebases.
+- Announce before every push.
+- Announce completion with a summary of what changed and which files were modified.
+
+## Task workflow
+
+Follow this sequence for every task:
+
+1. **Claim** the task on the taskboard: `/taskboard claim <id>`
+2. **Plan** — submit your implementation plan: `/taskboard plan <id> <plan>`
+3. **Wait** for approval (or fast-track for small tasks).
+4. **Read** target files before writing code.
+5. **Implement** — announce when starting, update status at milestones.
+6. **Test** — run `bash scripts/pre-push.sh` before committing.
+7. **PR** — open with CHANGELOG entry, announce in room.
+8. **Finish** — mark task done: `/taskboard finish <id>`, update status.
+
+## Coordination
+
+- **One agent per file at a time.** Declare file ownership in your plan.
+- **Schema changes need consensus.** Announce and wait for agreement.
+- **The host has final say.** If the host sends a "hold", stop immediately.
+- **One agent per bug.** Do not fix bugs assigned to others.
+- **File bugs, don't self-assign.** Report to ba, wait for assignment.
+- **Do not push or merge without announcing** in the room first.
+
+## Code standards
+
+- No `as any`, `ts-ignore`, `eslint-disable`, or `#[allow(...)]` — fix root causes.
+- Include tests in the same PR as the feature or fix.
+- Run `bash scripts/pre-push.sh` (check, fmt, clippy, test) before every push.
+- Add CHANGELOG entry under `[Unreleased]` in every PR.
+- Do not reference agent names or AI tooling in commits or PR descriptions.
+
+## Knowledge contribution
+
+When you discover something that would help other agents:
+
+- **Patterns**: reusable solutions, API idioms, test approaches
+- **Bugs**: root causes, workarounds, regression risks
+- **Conventions**: naming, file organization, module boundaries
+
+Share these in the room. In the future, a `/knowledge` plugin will formalize this.
+
+## Progress files
+
+For long-running tasks, write progress to `/tmp/room-progress-<issue>.md`:
+
+- After reading target files (before writing code)
+- After completing a first draft (before tests)
+- Before opening or updating a PR
+
+Delete the progress file after the PR merges.
 
 ## Wire format
 
-Every message is a JSON object with a `type` field. Key types:
+Every message is a JSON object with a `type` field:
 
 | `type` | Meaning |
 |--------|---------|
@@ -83,15 +129,9 @@ Every message is a JSON object with a `type` field. Key types:
 | `leave` | User disconnected |
 | `message` | Plain chat message (`content` field) |
 | `command` | Structured command (`cmd`, `params` fields) |
-| `reply` | Reply to a specific message (`reply_to`, `content` fields) |
+| `reply` | Reply to a specific message (`reply_to`, `content`) |
 | `system` | Broker-generated notice |
 | `dm` | Private message to one user |
+| `event` | Typed event (`event_type`, `content`) |
 
-All events carry `id` (UUID), `room`, `user`, `ts` (ISO 8601 UTC), and `seq` (monotonic sequence number).
-
-## Environment
-
-- Socket: `/tmp/room-<id>.sock`
-- Chat history: `/tmp/<id>.chat` (NDJSON, broker is sole writer)
-- Token persistence: `~/.room/state/tokens.json` (survives broker restarts)
-- Poll cursor: `~/.room/state/room-<id>-<username>.cursor`
+All messages carry `id` (UUID), `room`, `user`, `ts` (ISO 8601 UTC), and `seq` (monotonic).


### PR DESCRIPTION
## Summary
- Rewrites AGENTS.md from a basic coordination guide into comprehensive agent instructions
- Adds spawned-agent identity rules (read .room-agent.json, never run room join)
- Adds mention behavior protocol, taskboard workflow, knowledge contribution guidelines
- Adds code standards section (pre-push.sh, CHANGELOG, no suppressions)

## Test plan
- [x] Docs-only change, no code modified
- [x] Content sourced from design-shared-knowledge.md Area 4 and sprint 18 identity fixes

Closes #793