### PR TITLE
docs(prd): add Hive server and frontend PRDs

### DIFF
--- a/docs/prd/hive/README.md
+++ b/docs/prd/hive/README.md
@@ -105,6 +105,8 @@ and other plugin data programmatically without scraping chat text.
 
 | Document | Status | Summary |
 |---|---|---|
+| [prd-hive-server.md](prd-hive-server.md) | Draft | Backend: Rust/axum server, auth, agent lifecycle, room proxy |
+| [prd-hive-frontend.md](prd-hive-frontend.md) | Draft | Frontend: web dashboard (Phase 1), Tauri desktop (Phase 2) |
 | [prd-workspace.md](prd-workspace.md) | Draft | Workspace concept: room grouping, team rosters, cross-room views |
 | [prd-team-provisioning.md](prd-team-provisioning.md) | Draft | Agent team manifests, spawn/stop/scale, billing integration |
 | [prd-agent-discovery.md](prd-agent-discovery.md) | Draft | Expertise indexing, capacity tracking, skill matching |
@@ -135,7 +137,7 @@ initial development:
 | read_line size limit (#470) | Bound incoming message size to prevent OOM | Medium |
 | WS bind address (#455-MED-2) | Default to 127.0.0.1 instead of 0.0.0.0 | Low |
 
-## Decisions made (2026-03-12)
+## Decisions made (2026-03-16, updated from 2026-03-12)
 
 These questions from the original PRDs have been answered by joao:
 

--- a/docs/prd/hive/prd-hive-frontend.md
+++ b/docs/prd/hive/prd-hive-frontend.md
@@ -1,0 +1,148 @@
+# PRD: Hive Frontend (Web Dashboard + Desktop)
+
+**Status:** Draft
+**Author(s):** samantha (based on wall-e UI investigation, r2d2 tech stack)
+**Date:** 2026-03-16
+**Dependencies:** Hive Server (prd-hive-server), room v3.5.1 (shipped)
+**Breaks down:** #803 (UI investigation), #798 (tech stack — frontend portion)
+
+---
+
+## Problem
+
+Room's TUI is terminal-only and single-room focused. There is no graphical interface for managing multiple rooms, monitoring agent teams, viewing task progress, or tracking costs. Non-technical users cannot interact with room-based agent teams.
+
+## Goal
+
+Build a web-based dashboard that provides:
+1. Multi-room workspace view with unified timeline
+2. Agent management UI (spawn, stop, monitor, logs)
+3. Task board visualization
+4. Real-time updates via WebSocket
+
+Phase 2 wraps the same web app in Tauri for desktop features (tray icon, notifications, file system access).
+
+## Non-goals
+
+- Replacing the terminal TUI (it remains for power users)
+- Mobile app (web is responsive enough for tablets)
+- Offline mode
+- Video/voice integration
+
+## Architecture
+
+### Tech stack (decided)
+
+| Layer | Choice | Rationale |
+|---|---|---|
+| Framework | React or Svelte | Component-based, large ecosystem. TBD in spike. |
+| Styling | Tailwind CSS | Utility-first, fast iteration |
+| State management | Zustand or Svelte stores | Lightweight, WS-friendly |
+| WebSocket client | Native WebSocket API | Direct connection to Hive server |
+| Build tool | Vite | Fast HMR, Tauri-compatible |
+| Desktop wrapper | Tauri v2 (Phase 2) | Same web frontend, native webview |
+
+### Layout (three-panel, proven pattern)
+
+```
++------------------+---------------------------+------------------+
+|                  |                           |                  |
+|   LEFT SIDEBAR   |      MAIN CONTENT         |  CONTEXT PANEL   |
+|                  |                           |                  |
+|  Workspace nav   |  Chat / Tasks / Agents    |  Details / Logs  |
+|  Room list       |  (depends on view)        |  Agent info      |
+|  Quick actions   |                           |  Task details    |
+|                  |                           |                  |
++------------------+---------------------------+------------------+
+```
+
+**Top-level tabs:** Rooms | Agents | Tasks | Costs
+
+## Views
+
+### 1. Rooms View (default)
+- Left: workspace tree with room list, unread badges
+- Center: chat timeline for selected room (messages, system events, commands)
+- Right: room info panel (members, statuses, recent activity)
+- Real-time message streaming via WebSocket
+- Inspired by: Slack channels, Discord servers
+
+### 2. Agents View
+- Center: card grid of all agents across workspace
+- Each card shows: name, personality, model, uptime, health indicator (traffic light), current status, iteration count
+- Click card: expand to show logs, cost breakdown, recent messages
+- Actions: spawn (opens wizard), stop, restart
+- Inspired by: Kubernetes Dashboard pods, Railway service cards
+
+### 3. Tasks View
+- Center: kanban board visualization of `/taskboard` data
+- Columns: Open | Claimed | Planned | Approved | In Progress | Done
+- Cards show: task ID, description, assignee, elapsed time, lease status
+- Drag-and-drop assignment (sends `/taskboard assign` command)
+- Inspired by: Linear, GitHub Projects
+
+### 4. Costs View (Phase 2)
+- Center: per-agent and per-team cost breakdown
+- Charts: cost over time, cost by model, cost by agent
+- Budget alerts and limits
+- Inspired by: Cloud billing dashboards (AWS, GCP)
+
+## Real-time patterns
+
+| Pattern | Source | Implementation |
+|---|---|---|
+| Live presence | Discord green dots | Agent health indicators update via WS |
+| Activity feed | GitHub notifications | System events stream in sidebar |
+| Live status | Figma collaborator avatars | Agent status text updates in real-time |
+| Unread counts | Slack channel badges | Per-room message counters |
+
+## Implementation phases
+
+### Phase 1: Web Dashboard MVP
+- Project scaffolding (Vite + React/Svelte + Tailwind)
+- WebSocket connection to Hive server
+- Rooms view: room list, message timeline, member panel
+- Basic agent list (read-only, from `/agent list` data)
+- Login page (connects to Hive server OAuth)
+
+### Phase 2: Interactive Features
+- Agent spawn wizard (personality picker, model selector)
+- Agent stop/restart from UI
+- Task board kanban view
+- Agent log viewer (streaming)
+
+### Phase 3: Tauri Desktop
+- Wrap web app in Tauri shell
+- System tray icon with agent health summary
+- Native notifications for @mentions and task assignments
+- File system access for workspace management
+
+### Phase 4: Advanced
+- Cost dashboard with charts
+- Cross-room unified timeline
+- Agent discovery and assignment UI
+- Team creation wizard
+
+## Component inventory (estimated)
+
+| Component | Description | Priority |
+|---|---|---|
+| `<AppShell>` | Three-panel layout with tab navigation | P0 |
+| `<RoomList>` | Sidebar room tree with unread badges | P0 |
+| `<ChatTimeline>` | Message list with auto-scroll | P0 |
+| `<MemberPanel>` | Room members with status | P0 |
+| `<AgentCard>` | Agent status card with health indicator | P0 |
+| `<AgentGrid>` | Grid layout of agent cards | P0 |
+| `<SpawnWizard>` | Agent spawn form (personality, model) | P1 |
+| `<LogViewer>` | Streaming log viewer for agents | P1 |
+| `<TaskBoard>` | Kanban board for taskboard data | P1 |
+| `<TaskCard>` | Draggable task card | P1 |
+| `<CostChart>` | Cost over time visualization | P2 |
+| `<LoginPage>` | OAuth login flow | P0 |
+
+## Resolved questions
+
+1. **React or Svelte?** TBD — run a 1-day spike to compare DX. Both work with Tauri.
+2. **Same frontend for web and desktop?** Yes — Tauri wraps the same web app. Zero rewrite. Per r2d2 investigation.
+3. **Server-side rendering?** No — SPA with client-side WS. Hive server serves static assets.
+4. **Design system?** Start with Tailwind + headless UI components. Custom design system later.

--- a/docs/prd/hive/prd-hive-server.md
+++ b/docs/prd/hive/prd-hive-server.md
@@ -1,0 +1,114 @@
+# PRD: Hive Server (Backend)
+
+**Status:** Draft
+**Author(s):** samantha (based on r2d2 tech investigation, saphire component map)
+**Date:** 2026-03-16
+**Dependencies:** room v3.5.1 (shipped), room-protocol, axum
+**Breaks down:** #798 (tech stack)
+
+---
+
+## Problem
+
+Room provides the messaging and plugin infrastructure for multi-agent coordination, but there is no application layer to manage workspaces, authenticate humans, orchestrate agent lifecycles, or track costs. Users must manually run CLI commands to spawn agents, manage rooms, and coordinate work.
+
+## Goal
+
+Build the Hive server — a Rust/axum backend that sits between the Hive frontend and the room daemon, providing:
+1. Human authentication (OAuth/API keys mapped to room tokens)
+2. Agent lifecycle management (clone, spawn, monitor, stop)
+3. Workspace grouping (rooms + team rosters)
+4. Real-time room relay via WebSocket
+
+## Non-goals
+
+- Multi-host daemon federation (single daemon, per joao directive)
+- Billing/metering (Phase 2)
+- Agent discovery/expertise indexing (Phase 3)
+- Plugin marketplace implementation (deferred)
+
+## Architecture
+
+```
+Hive Frontend  --HTTP/WS-->  Hive Server  --WS-->  Room Daemon (bundled)
+                                  |
+                                  |-- spawns -->  room-ralph processes
+```
+
+### Crate structure
+
+```
+crates/
+  hive-server/          -- axum HTTP/WS server, main entry point
+    src/
+      main.rs           -- CLI + server startup
+      config.rs         -- TOML/env config (port, room socket, data dir)
+      auth.rs           -- OAuth flow + API key validation
+      rooms.rs          -- Room CRUD proxy (delegates to room daemon)
+      agents.rs         -- Agent spawn/stop/list/logs (wraps room-ralph)
+      ws_relay.rs       -- WebSocket relay: frontend <-> room daemon
+      db.rs             -- SQLite for Hive-specific state (workspaces, teams)
+```
+
+### Tech stack (decided)
+
+| Layer | Choice | Rationale |
+|---|---|---|
+| Language | Rust | Shares room-protocol types, single toolchain |
+| HTTP framework | axum | Already used in room-daemon |
+| Database | SQLite (rusqlite) | Zero-config, embedded, sufficient for single-host |
+| WebSocket | tokio-tungstenite | Already used in room |
+| Auth | OAuth2 (oxide-auth) | Standard flow for web apps |
+| Config | TOML (toml crate) | Consistent with room-ralph |
+
+## Implementation phases
+
+### Phase 1: Skeleton + Room Proxy (MVP)
+- axum server with health endpoint
+- WebSocket relay: proxy frontend WS to room daemon WS
+- REST proxy: `/api/rooms/*` delegates to room daemon REST API
+- Config file (hive.toml): room socket path, HTTP port, data directory
+- No auth (localhost-only, development mode)
+
+### Phase 2: Auth + Agent Management
+- OAuth2 login flow (GitHub provider)
+- API key generation for programmatic access
+- Token mapping: Hive user -> room token (via `room join`)
+- Agent CRUD: spawn/stop/list/logs via room-ralph
+- Agent workspace isolation (uses room's `~/.room/agents/` dirs)
+
+### Phase 3: Workspaces + Teams
+- Workspace CRUD (SQLite): name, rooms, team roster
+- Team manifest parsing (JSON)
+- Batch agent provisioning from manifest
+- Cross-room unified timeline endpoint
+
+## Data model
+
+Hive owns (SQLite):
+- `workspaces`: id, name, created_at
+- `workspace_rooms`: workspace_id, room_id
+- `users`: id, provider, email, room_token
+- `api_keys`: id, user_id, key_hash, scopes
+- `team_manifests`: id, workspace_id, manifest_json
+
+Room owns (unchanged):
+- Messages, tokens, subscriptions, chat files, plugin state
+
+## Room features used
+
+| Feature | API | Purpose |
+|---|---|---|
+| Room create/destroy | REST or UDS | Workspace room lifecycle |
+| User join | `room join` via CLI or REST | Token minting for Hive users |
+| Agent spawn | `room-ralph` CLI | Agent lifecycle |
+| Message relay | WebSocket `/ws/<room_id>` | Real-time frontend updates |
+| Plugin commands | `/taskboard`, `/agent` | Task and agent management |
+| Health check | `GET /api/health` | Monitoring |
+
+## Resolved questions
+
+1. **Single binary or separate?** Single deployable unit — Hive server embeds room daemon or connects to co-located daemon. Per joao directive.
+2. **Backend language?** Rust + axum. Shares room-protocol types. Per r2d2 investigation.
+3. **Database?** SQLite — zero-config, sufficient for single-host deployment.
+4. **Multi-host?** Not planned. Single daemon per joao directive.


### PR DESCRIPTION
## Summary
- Break down #798 (tech stack) and #803 (UI investigation) into implementable PRDs
- `prd-hive-server.md`: Rust/axum backend — auth, agent lifecycle, room proxy, workspace management. Phased: skeleton MVP -> auth+agents -> workspaces+teams
- `prd-hive-frontend.md`: Web dashboard + Tauri desktop — 4 views (Rooms/Agents/Tasks/Costs), three-panel layout, component inventory with priorities. Phased: web MVP -> interactive -> Tauri -> advanced
- Updated README.md PRD index

Docs only, no code changes.