### PR TITLE
docs: fix workspace structure, test baseline, and README index

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -530,8 +530,12 @@ Cargo.toml                — virtual workspace root (no [package])
 Cargo.lock                — shared across all workspace members
 crates/
   room-protocol/          — wire format types (lib, package: room-protocol)
-  room-cli/               — broker + TUI + oneshot (bin: room, package: room-cli)
+  room-cli/               — CLI + TUI (bin: room, package: room-cli)
+  room-daemon/            — broker + plugins + WS/REST (lib, package: room-daemon)
   room-ralph/             — agent wrapper (bin: room-ralph, package: room-ralph)
+  room-plugin-agent/      — agent spawn/stop/list plugin (lib, package: room-plugin-agent)
+  room-plugin-taskboard/  — task lifecycle plugin (lib, package: room-plugin-taskboard)
+  room-plugin-hello/      — sample external plugin (lib+cdylib, package: room-plugin-hello)
 scripts/                  — shell scripts (pre-push, tests, legacy ralph wrapper)
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ The README covers installation and basic usage. This folder contains deep-dive d
 | [agent-coordination.md](agent-coordination.md) | Multi-agent protocol: announce/claim/poll/watch loop |
 | [broker-internals.md](broker-internals.md) | Architecture deep-dive: socket, fanout, persistence, shutdown |
 | [dms.md](dms.md) | Direct message delivery semantics and edge cases |
-| [plugin.md](plugin.md) | Claude Code plugin setup and slash commands |
+| [plugin.md](plugin.md) | Plugin system: builtin plugins, dynamic loading, Plugin trait |
 | [tips.md](tips.md) | Tips, tricks, and best practices |
 | [deployment.md](deployment.md) | Self-hosting, socket paths, and configuration |
 | [testing.md](testing.md) | Writing integration tests against a live broker |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -196,17 +196,22 @@ async fn my_feature_works() {
 
 ## Test baseline
 
-**Current: 1517 Rust tests + 107 shell tests** (as of v3.1.0)
+**Current: ~1700+ Rust tests + 107 shell tests** (as of v3.5.1)
 
 | Crate | Unit | Integration | Total |
 |-------|------|-------------|-------|
-| room-protocol | 116 | — | 116 |
-| room-daemon | — | — | (counted via room-cli) |
-| room-plugin-taskboard | — | — | (counted via room-cli) |
-| room-cli | 888 | 195 | 1083 |
-| room-ralph | 164 | 10 | 174 |
+| room-protocol | 136 | — | 136 |
+| room-daemon | (counted via room-cli integration tests) | — | — |
+| room-plugin-taskboard | 96 | — | 96 |
+| room-plugin-agent | 102 | — | 102 |
+| room-plugin-hello | 8 | — | 8 |
+| room-cli | ~530+ | ~300+ | ~830+ |
+| room-ralph | ~180 | 10 | ~190 |
 
 Shell tests: 48 (test-context-monitor.sh) + 59 (test-ralph-room.sh) = 107.
+
+Note: exact counts vary as integration tests are added across sprints. Run
+`cargo test` for the authoritative count.
 
 The test count must never decrease without explicit justification. Every PR
 that adds or changes functionality must include tests.


### PR DESCRIPTION
## Summary

- CLAUDE.md: update workspace structure to list all 7 crates (was missing room-daemon, room-plugin-agent, room-plugin-taskboard, room-plugin-hello)
- testing.md: update test baseline to ~1700+ for v3.5.1, add rows for new crates
- docs/README.md: update plugin.md description to reflect dynamic loading

Note: remaining docs fixes (#800 commands.md missing CLI sections, #801 CLAUDE.md file paths) are larger changes best done as follow-up PRs.

## Test plan

- [x] No code changes — docs only
- [x] Verified crate list matches actual `crates/` directory

Addresses #799, #802, #804, #805