### PR TITLE
docs: add 22 frontend user stories for Hive dashboard

### DIFF
--- a/docs/prd/hive/stories/frontend/fe-001-app-shell-layout.md
+++ b/docs/prd/hive/stories/frontend/fe-001-app-shell-layout.md
@@ -1,0 +1,26 @@
+# [FE-001] App Shell with Three-Panel Layout and Tab Navigation
+
+**As a** Hive user
+**I want to** see a three-panel layout with top-level tab navigation
+**So that** I can navigate between Rooms, Agents, Tasks, and Costs views without losing context
+
+## Acceptance Criteria
+- [ ] The `<AppShell>` component renders three panels: left sidebar (fixed-width, collapsible), main content (fluid), and context panel (fixed-width, collapsible)
+- [ ] Top-level tab bar renders four tabs: Rooms, Agents, Tasks, Costs
+- [ ] Clicking a tab switches the main content area to the corresponding view without a full page reload
+- [ ] The active tab is visually highlighted and the URL path updates to reflect the current view (e.g., `/rooms`, `/agents`, `/tasks`, `/costs`)
+- [ ] The layout is responsive: on viewports below 768px, the sidebar collapses to an icon rail and the context panel is hidden (accessible via overlay)
+- [ ] Panel widths are adjustable via drag handles between panels, and the chosen widths persist across page reloads (localStorage)
+- [ ] Keyboard shortcut Ctrl+1/2/3/4 switches between tabs
+
+## Phase
+Phase 1: Web Dashboard MVP
+
+## Priority
+P0
+
+## Components
+- AppShell
+
+## Notes
+The three-panel layout follows the pattern described in the PRD (left sidebar, main content, context panel). Tailwind CSS handles responsive breakpoints. The sidebar and context panel collapse states should be stored in Zustand/Svelte store and persisted to localStorage.

--- a/docs/prd/hive/stories/frontend/fe-002-login-page.md
+++ b/docs/prd/hive/stories/frontend/fe-002-login-page.md
@@ -1,0 +1,27 @@
+# [FE-002] Login Page with Connection to Hive Server
+
+**As a** user
+**I want to** authenticate with the Hive server through a login page
+**So that** I can access my workspaces and rooms securely
+
+## Acceptance Criteria
+- [ ] The `<LoginPage>` component renders a login form with server URL input and OAuth login button
+- [ ] Unauthenticated users are redirected to the login page; authenticated users are redirected away from it
+- [ ] OAuth flow opens the provider's consent screen, handles the callback, and stores the resulting token securely (httpOnly cookie or in-memory; not plain localStorage)
+- [ ] The login page displays clear error messages for connection failures (server unreachable, invalid credentials, expired token)
+- [ ] A loading spinner is shown during the OAuth handshake and token exchange
+- [ ] After successful login, the user is redirected to the Rooms view (default landing)
+- [ ] A "Remember server URL" option persists the last-used server address for faster reconnection
+- [ ] Logout clears the stored token and returns the user to the login page
+
+## Phase
+Phase 1: Web Dashboard MVP
+
+## Priority
+P0
+
+## Components
+- LoginPage
+
+## Notes
+The PRD specifies OAuth login to the Hive server. The exact OAuth provider (GitHub, custom) depends on the Hive Server PRD. The frontend must handle the redirect-based OAuth flow and token refresh. Server URL input is necessary because Hive is self-hosted.

--- a/docs/prd/hive/stories/frontend/fe-003-room-list-sidebar.md
+++ b/docs/prd/hive/stories/frontend/fe-003-room-list-sidebar.md
@@ -1,0 +1,27 @@
+# [FE-003] Room List Sidebar with Workspace Grouping
+
+**As a** user
+**I want to** see all rooms in the left sidebar grouped by workspace
+**So that** I can quickly navigate between rooms and find the one I need
+
+## Acceptance Criteria
+- [ ] The `<RoomList>` component renders inside the left sidebar panel and fetches the list of rooms from the Hive server API
+- [ ] Rooms are grouped under collapsible workspace headings; each workspace section can be expanded or collapsed independently
+- [ ] Clicking a room name selects it and loads its chat timeline in the main content area
+- [ ] The currently selected room is visually highlighted with a distinct background color
+- [ ] Each room entry displays the room name and a truncated preview of the last message (sender + first ~40 characters)
+- [ ] Rooms within a workspace are sorted by most-recent activity (most recent at top)
+- [ ] A search/filter input at the top of the sidebar filters rooms by name in real-time (client-side filtering)
+- [ ] Empty state: when no rooms exist, a helpful message is displayed with a link to create a room (if authorized)
+
+## Phase
+Phase 1: Web Dashboard MVP
+
+## Priority
+P0
+
+## Components
+- RoomList
+
+## Notes
+Workspace grouping follows the hierarchy defined in prd-workspace.md. The room list updates in real-time as new rooms are created or destroyed (via WebSocket events from the Hive server). Unread badges are deferred to FE-013.

--- a/docs/prd/hive/stories/frontend/fe-004-chat-timeline.md
+++ b/docs/prd/hive/stories/frontend/fe-004-chat-timeline.md
@@ -1,0 +1,27 @@
+# [FE-004] Chat Timeline with Real-Time Message Streaming via WebSocket
+
+**As a** user
+**I want to** see a real-time chat timeline for the selected room
+**So that** I can follow conversations and system events as they happen
+
+## Acceptance Criteria
+- [ ] The `<ChatTimeline>` component renders all message types from the room wire format: `message`, `join`, `leave`, `system`, `command`, `reply`, `direct_message`, and `event`
+- [ ] New messages arriving via WebSocket are appended to the timeline instantly without requiring a manual refresh
+- [ ] The timeline auto-scrolls to the latest message when the user is already at the bottom; if the user has scrolled up, a "new messages" pill appears at the bottom instead of force-scrolling
+- [ ] Each message displays: sender username, timestamp (relative, e.g., "2m ago"), and content; system messages and events use a distinct visual style (muted, no avatar)
+- [ ] @mentions of the current user are highlighted within message text
+- [ ] On initial room selection, the timeline loads the most recent N messages (history backfill from the REST poll endpoint) and supports upward scroll to load older messages (pagination)
+- [ ] Direct messages are visually distinct (e.g., italicized, with a DM badge) and only shown to the sender and recipient
+- [ ] Reply messages display a quoted excerpt of the parent message above the reply content
+
+## Phase
+Phase 1: Web Dashboard MVP
+
+## Priority
+P0
+
+## Components
+- ChatTimeline
+
+## Notes
+The wire format is defined in room-protocol (see CLAUDE.md codebase overview). The WebSocket connection is managed by FE-007. History backfill uses the REST `/api/<room_id>/poll` endpoint. Message rendering should handle markdown-like formatting if the content contains code blocks or inline code.

--- a/docs/prd/hive/stories/frontend/fe-005-member-panel.md
+++ b/docs/prd/hive/stories/frontend/fe-005-member-panel.md
@@ -1,0 +1,27 @@
+# [FE-005] Member Panel Showing Room Participants with Status
+
+**As a** user
+**I want to** see a list of all participants in the current room with their live status
+**So that** I can understand who is present, what they are working on, and whether agents are healthy
+
+## Acceptance Criteria
+- [ ] The `<MemberPanel>` component renders in the right context panel when the Rooms view is active
+- [ ] All current room members are listed, each showing: username, online/offline indicator, and current status text (from `/set_status`)
+- [ ] Members are sorted into two groups: "Online" (connected) and "Offline" (disconnected but previously joined), with online members listed first
+- [ ] Agent members display a bot icon to distinguish them from human users
+- [ ] Status text updates in real-time as agents and users change their status via WebSocket events
+- [ ] Online presence indicators (green dot = connected, gray dot = disconnected) update within 5 seconds of a join/leave event
+- [ ] Clicking a member name opens a mini-profile popover with: username, current status, time since last message, and a "Send DM" action
+- [ ] The panel displays a member count header (e.g., "Members (12)") that updates dynamically
+
+## Phase
+Phase 1: Web Dashboard MVP
+
+## Priority
+P0
+
+## Components
+- MemberPanel
+
+## Notes
+Presence data comes from WebSocket join/leave events and the `/who` command response. Agent health indicators (traffic light) are part of the Agents view (FE-006) and are not duplicated here, but the online/offline dot serves as a lightweight proxy. Status text corresponds to the `/set_status` slash command output.

--- a/docs/prd/hive/stories/frontend/fe-006-basic-agent-list.md
+++ b/docs/prd/hive/stories/frontend/fe-006-basic-agent-list.md
@@ -1,0 +1,28 @@
+# [FE-006] Basic Agent List (Read-Only)
+
+**As a** user
+**I want to** see a grid of all agents across the workspace with their current status
+**So that** I can monitor agent health and activity at a glance
+
+## Acceptance Criteria
+- [ ] The Agents tab renders an `<AgentGrid>` component containing `<AgentCard>` components for each agent
+- [ ] Each `<AgentCard>` displays: agent name, personality label, model name, uptime duration, health indicator (green/yellow/red traffic light), current status text, and iteration count
+- [ ] Agent data is fetched from the Hive server's `/agent list` equivalent endpoint on tab activation and refreshed via WebSocket events
+- [ ] Health indicators reflect agent state: green = running and responsive, yellow = high context usage or restarting, red = crashed or unreachable
+- [ ] Cards are laid out in a responsive grid: 3 columns on large screens, 2 on medium, 1 on small
+- [ ] A summary bar above the grid shows total agent count and breakdown by health status (e.g., "12 agents: 9 healthy, 2 warning, 1 error")
+- [ ] Clicking an agent card selects it and opens the context panel with expanded details: recent messages sent by the agent, room assignments, and full status history
+- [ ] Empty state: when no agents are running, display a message indicating no active agents (spawn wizard link deferred to FE-008)
+
+## Phase
+Phase 1: Web Dashboard MVP
+
+## Priority
+P0
+
+## Components
+- AgentCard
+- AgentGrid
+
+## Notes
+This is a read-only view in Phase 1. Agent management actions (spawn, stop, restart) are added in Phase 2 (FE-008, FE-009). The traffic light health indicator pattern is inspired by Kubernetes Dashboard pod status. Agent data source depends on the Hive server agent registry API.

--- a/docs/prd/hive/stories/frontend/fe-007-websocket-connection.md
+++ b/docs/prd/hive/stories/frontend/fe-007-websocket-connection.md
@@ -1,0 +1,27 @@
+# [FE-007] WebSocket Connection Management
+
+**As a** user
+**I want to** have a reliable WebSocket connection to the Hive server that handles disconnections gracefully
+**So that** I receive real-time updates without manual intervention when network issues occur
+
+## Acceptance Criteria
+- [ ] The WebSocket client connects to the Hive server using the native WebSocket API on successful authentication, using the `SESSION:<token>` handshake protocol
+- [ ] On unexpected disconnection, the client automatically attempts reconnection with exponential backoff (1s, 2s, 4s, 8s, capped at 30s) and a jitter factor to avoid thundering herd
+- [ ] A connection status indicator is visible in the app shell (e.g., top bar): green = connected, yellow = reconnecting, red = disconnected
+- [ ] During reconnection, a non-blocking banner informs the user ("Reconnecting...") without obscuring the UI
+- [ ] After successful reconnection, the client fetches missed messages via the REST poll endpoint (using the last-seen message ID as cursor) and merges them into the timeline without duplicates
+- [ ] WebSocket errors (invalid token, server rejection, protocol errors) are logged to the browser console and surfaced to the user with actionable messages (e.g., "Session expired, please log in again")
+- [ ] The connection is cleanly closed on logout or page unload (sends proper WebSocket close frame)
+- [ ] Heartbeat/ping frames are sent at a configurable interval (default 30s) to detect dead connections before the TCP timeout
+
+## Phase
+Phase 1: Web Dashboard MVP
+
+## Priority
+P0
+
+## Components
+- AppShell (connection indicator)
+
+## Notes
+This is a cross-cutting concern that underpins all real-time features. The WebSocket connection state should live in the global store (Zustand/Svelte store) so any component can read connection status. The handshake protocol is documented in CLAUDE.md under "WebSocket endpoint". The `SESSION:<token>` handshake validates the token and enters interactive mode. Reconnection must re-authenticate using the stored token.

--- a/docs/prd/hive/stories/frontend/fe-008-spawn-wizard.md
+++ b/docs/prd/hive/stories/frontend/fe-008-spawn-wizard.md
@@ -1,0 +1,27 @@
+# [FE-008] Agent Spawn Wizard
+
+**As a** workspace admin
+**I want to** spawn a new agent through a guided wizard UI
+**So that** I can deploy agents without using the terminal CLI
+
+## Acceptance Criteria
+- [ ] The `<SpawnWizard>` component is accessible from the Agents view via a "Spawn Agent" button and opens as a modal dialog
+- [ ] Step 1 — Identity: user enters agent username, selects a personality from a dropdown (populated from available personality definitions), and optionally provides a custom prompt override
+- [ ] Step 2 — Configuration: user selects the model (e.g., claude-sonnet, claude-opus), target room(s) to join, and optional tool restrictions (allowed/disallowed tools)
+- [ ] Step 3 — Review: a summary of all selections is displayed before confirmation, with the ability to go back and edit any step
+- [ ] On confirmation, the wizard sends a spawn request to the Hive server API and displays a progress indicator until the agent reports as healthy
+- [ ] Validation errors are shown inline: duplicate username, invalid room selection, missing required fields
+- [ ] The wizard can be cancelled at any step without side effects
+- [ ] After successful spawn, the new agent appears in the `<AgentGrid>` with a "Starting..." status that transitions to healthy once the agent's first heartbeat arrives
+
+## Phase
+Phase 2: Interactive Features
+
+## Priority
+P1
+
+## Components
+- SpawnWizard
+
+## Notes
+Personality definitions come from the personality system (see prd-personality.md). Model options come from the Hive server's available models endpoint. The spawn request maps to the `/agent spawn` command or equivalent Hive server API. The wizard should prevent spawning agents with names that collide with existing usernames in the workspace.

--- a/docs/prd/hive/stories/frontend/fe-009-agent-stop-restart.md
+++ b/docs/prd/hive/stories/frontend/fe-009-agent-stop-restart.md
@@ -1,0 +1,28 @@
+# [FE-009] Agent Stop/Restart from UI
+
+**As a** workspace admin
+**I want to** stop or restart agents directly from the dashboard
+**So that** I can manage agent lifecycle without switching to the terminal
+
+## Acceptance Criteria
+- [ ] Each `<AgentCard>` in the Agents view displays a context menu (kebab icon or right-click) with "Stop" and "Restart" actions
+- [ ] The "Stop" action shows a confirmation dialog ("Stop agent X? This will terminate its current task.") before sending the stop command to the Hive server
+- [ ] The "Restart" action shows a confirmation dialog and sends a restart command; the card transitions through "Stopping..." then "Starting..." states with visual feedback
+- [ ] While an action is in progress, the corresponding menu items are disabled and the card shows a spinner overlay to prevent duplicate commands
+- [ ] After a successful stop, the agent card transitions to a "Stopped" state (gray, distinct from error red) and the grid repositions it to the end
+- [ ] After a successful restart, the agent card returns to healthy state once the first heartbeat arrives; if the agent fails to start within 60 seconds, the card shows an error state with the failure reason
+- [ ] Bulk actions: a "Select All" checkbox enables stopping or restarting multiple agents at once via a toolbar action
+- [ ] Stop/restart actions are only available to users with admin permissions; non-admin users see the actions as disabled with a tooltip explaining the restriction
+
+## Phase
+Phase 2: Interactive Features
+
+## Priority
+P1
+
+## Components
+- AgentCard
+- AgentGrid
+
+## Notes
+Stop and restart map to Hive server API endpoints that manage agent processes. The agent process lifecycle is managed by room-ralph on the backend. The UI should optimistically update the card state and reconcile with the actual state from WebSocket events.

--- a/docs/prd/hive/stories/frontend/fe-010-agent-log-viewer.md
+++ b/docs/prd/hive/stories/frontend/fe-010-agent-log-viewer.md
@@ -1,0 +1,27 @@
+# [FE-010] Agent Log Viewer (Streaming)
+
+**As a** workspace admin
+**I want to** view an agent's logs in real-time within the dashboard
+**So that** I can diagnose issues without SSH-ing into the server or tailing log files
+
+## Acceptance Criteria
+- [ ] The `<LogViewer>` component opens in the context panel (right panel) when an agent card is clicked and the "Logs" tab is selected
+- [ ] Logs stream in real-time via a dedicated WebSocket channel or multiplexed over the existing connection, appending new lines as they arrive
+- [ ] Each log line displays: timestamp, log level (color-coded: gray=debug, white=info, yellow=warn, red=error), and the log message
+- [ ] The viewer auto-scrolls to the latest log line when the user is at the bottom; manual scroll-up pauses auto-scroll and shows a "Jump to bottom" button
+- [ ] A log level filter dropdown allows toggling visibility of debug/info/warn/error levels independently
+- [ ] A text search box filters log lines client-side, highlighting matching terms in the visible output
+- [ ] The viewer supports loading historical logs (last N lines) on initial open, with upward scroll to load more
+- [ ] A "Copy All" button copies the currently visible (filtered) log lines to the clipboard
+
+## Phase
+Phase 2: Interactive Features
+
+## Priority
+P1
+
+## Components
+- LogViewer
+
+## Notes
+Log data source depends on the Hive server's agent log streaming API. Logs may come from room-ralph's stdout/stderr or a structured logging endpoint. The viewer should handle high-throughput log streams (100+ lines/second) without dropping frames -- consider virtualized rendering for the log list. ANSI color codes in raw logs should be stripped or converted to CSS classes.

--- a/docs/prd/hive/stories/frontend/fe-011-task-board-kanban.md
+++ b/docs/prd/hive/stories/frontend/fe-011-task-board-kanban.md
@@ -1,0 +1,28 @@
+# [FE-011] Task Board Kanban View with Columns
+
+**As a** user
+**I want to** see all tasks visualized as a kanban board with status columns
+**So that** I can understand task progress across the team at a glance
+
+## Acceptance Criteria
+- [ ] The Tasks tab renders a `<TaskBoard>` component with columns: Open, Claimed, Planned, Approved, In Progress, Done
+- [ ] Each column displays `<TaskCard>` components for tasks in that status, ordered by creation time (newest at top)
+- [ ] Each `<TaskCard>` shows: task ID, description (truncated to 2 lines), assignee avatar/username (if claimed), elapsed time since creation, and lease status indicator (green = active lease, orange = lease expiring soon, red = lease expired)
+- [ ] Column headers display the count of tasks in each column (e.g., "Open (3)")
+- [ ] Task data is fetched from the Hive server's taskboard API on tab activation and updated in real-time via WebSocket events (TaskPosted, TaskClaimed, TaskFinished, etc.)
+- [ ] Clicking a task card opens a detail view in the context panel showing: full description, assignee, implementation plan (if submitted), status history, and timestamps for each transition
+- [ ] Cancelled tasks are excluded from the board by default but can be shown via a "Show cancelled" toggle
+- [ ] The board handles empty columns gracefully with a subtle placeholder message
+
+## Phase
+Phase 2: Interactive Features
+
+## Priority
+P1
+
+## Components
+- TaskBoard
+- TaskCard
+
+## Notes
+The kanban columns map to the taskboard lifecycle: Open -> Claimed -> Planned -> Approved -> Finished. "In Progress" maps to the Approved status (agent is actively working). The EventType enum in room-protocol includes TaskPosted, TaskClaimed, etc. for real-time updates. Drag-and-drop interaction is covered separately in FE-012.

--- a/docs/prd/hive/stories/frontend/fe-012-draggable-task-cards.md
+++ b/docs/prd/hive/stories/frontend/fe-012-draggable-task-cards.md
@@ -1,0 +1,28 @@
+# [FE-012] Draggable Task Cards for Assignment
+
+**As a** workspace admin or host
+**I want to** drag task cards between kanban columns to change their status or assign them
+**So that** I can manage task workflow without typing slash commands
+
+## Acceptance Criteria
+- [ ] Task cards in the `<TaskBoard>` are draggable using pointer (mouse/touch) input with a visual drag preview showing the card in a semi-transparent lifted state
+- [ ] Dropping a card onto the "Claimed" column prompts for an assignee (dropdown of active workspace members) and sends a `/taskboard assign <task-id> <username>` command to the server
+- [ ] Dropping a card onto the "Done" column sends a `/taskboard finish <task-id>` command; only the current assignee or host can perform this action
+- [ ] Invalid drops (e.g., skipping required statuses, unauthorized user) snap the card back to its original column with a toast notification explaining why the action was rejected
+- [ ] Drag handles are visible on hover to indicate draggability; cards also support a right-click context menu with the same status transition actions as alternatives to drag-and-drop
+- [ ] The board applies optimistic updates during the drop (card moves immediately) and reverts if the server rejects the command
+- [ ] Keyboard accessibility: cards can be selected with Enter/Space and moved between columns with arrow keys, confirming with Enter
+- [ ] Drag-and-drop is disabled for users without admin/host permissions; they see the board as read-only
+
+## Phase
+Phase 2: Interactive Features
+
+## Priority
+P1
+
+## Components
+- TaskBoard
+- TaskCard
+
+## Notes
+Drag-and-drop should use a library compatible with the chosen framework (e.g., @dnd-kit for React, svelte-dnd-action for Svelte). The valid status transitions follow the taskboard lifecycle: Open -> Claimed -> Planned -> Approved -> Finished, with release back to Open. Not all transitions are valid via drag (e.g., "plan" requires text input, so dragging to Planned should open an inline form).

--- a/docs/prd/hive/stories/frontend/fe-013-unread-badges.md
+++ b/docs/prd/hive/stories/frontend/fe-013-unread-badges.md
@@ -1,0 +1,27 @@
+# [FE-013] Unread Message Badges per Room
+
+**As a** user
+**I want to** see unread message counts on each room in the sidebar
+**So that** I know which rooms have new activity without checking each one individually
+
+## Acceptance Criteria
+- [ ] Each room entry in the `<RoomList>` displays an unread badge (numeric count) when there are messages the user has not seen
+- [ ] The unread count increments in real-time as new messages arrive via WebSocket for rooms the user is not currently viewing
+- [ ] Selecting a room resets its unread count to zero and updates the read cursor (last-seen message ID) in the client store
+- [ ] Badges use a compact format: exact count for 1-99, "99+" for higher counts
+- [ ] Rooms with unread messages are visually promoted: bold room name and the badge uses an accent color (e.g., blue pill)
+- [ ] @mentions of the current user in unread messages trigger a distinct badge style (e.g., red instead of blue) to indicate direct attention needed
+- [ ] The total unread count across all rooms is displayed in the browser tab title (e.g., "(5) Hive") and updates dynamically
+- [ ] Unread state persists across page reloads by storing the per-room read cursor in localStorage
+
+## Phase
+Phase 2: Interactive Features
+
+## Priority
+P1
+
+## Components
+- RoomList
+
+## Notes
+The read cursor per room tracks the last message ID the user has seen. This is purely client-side state in Phase 1/2; server-side read receipts could be added later. The badge rendering should match the "Slack channel badges" pattern referenced in the PRD's real-time patterns table.

--- a/docs/prd/hive/stories/frontend/fe-014-message-input-command-palette.md
+++ b/docs/prd/hive/stories/frontend/fe-014-message-input-command-palette.md
@@ -1,0 +1,27 @@
+# [FE-014] Message Input with Command Palette for Slash Commands
+
+**As a** user
+**I want to** send messages and execute slash commands from a rich input field
+**So that** I can interact with rooms and agents without switching to the terminal
+
+## Acceptance Criteria
+- [ ] A message input bar is rendered at the bottom of the chat timeline in the Rooms view, with a text area that supports multi-line input (Shift+Enter for newline, Enter to send)
+- [ ] Typing `/` at the start of the input triggers a command palette popup listing available slash commands (sourced from `builtin_command_infos()` and plugin commands)
+- [ ] The command palette filters results as the user types (e.g., `/task` shows `/taskboard post`, `/taskboard list`, etc.) and supports keyboard navigation (arrow keys + Enter to select)
+- [ ] Selecting a command from the palette auto-fills it into the input and shows parameter hints (name, type, required/optional) inline below the input field
+- [ ] Messages are sent via the WebSocket connection and echo back through the normal message flow (no local injection to prevent desyncs)
+- [ ] The input supports @mention autocomplete: typing `@` shows a filterable list of room members; selecting one inserts the username and highlights it
+- [ ] Input history: up/down arrow keys cycle through previously sent messages (last 50, stored in sessionStorage)
+- [ ] The send button is disabled and the input shows a subtle loading state while a command is being processed
+
+## Phase
+Phase 2: Interactive Features
+
+## Priority
+P1
+
+## Components
+- ChatTimeline (input area)
+
+## Notes
+The command palette mirrors the TUI's `CommandPalette` widget behavior but adapted for a graphical interface. Command metadata (parameter schemas) comes from the `ParamSchema`/`ParamType` types in the plugin system. The palette should be keyboard-first but also work with mouse/touch clicks.

--- a/docs/prd/hive/stories/frontend/fe-015-tauri-shell.md
+++ b/docs/prd/hive/stories/frontend/fe-015-tauri-shell.md
@@ -1,0 +1,27 @@
+# [FE-015] Tauri Shell Wrapping the Web App
+
+**As a** desktop user
+**I want to** run Hive as a native desktop application
+**So that** I get a dedicated window, OS-level integration, and faster startup without opening a browser
+
+## Acceptance Criteria
+- [ ] The existing web frontend builds and runs inside a Tauri v2 webview with zero code changes to the web application layer
+- [ ] The Tauri app window opens at a configurable default size (1280x800) with proper minimum size constraints (800x600) and remembers its last position/size across launches
+- [ ] The app registers a custom protocol handler (`hive://`) so that clicking room links in other applications opens the desktop app to the correct room
+- [ ] The Tauri build produces distributable binaries for macOS (.dmg), Windows (.msi), and Linux (.AppImage/.deb) via the Tauri bundler
+- [ ] The app displays a native title bar with the Hive icon and room/workspace name; on macOS, traffic light buttons are properly positioned
+- [ ] Dev mode (`tauri dev`) provides hot module replacement with the same Vite HMR experience as the web version
+- [ ] The app can be opened from the command line: `hive-desktop` launches the app, `hive-desktop --url <server>` pre-fills the server URL on the login page
+- [ ] Application auto-update checks for new versions on startup and prompts the user to install (using Tauri's updater plugin)
+
+## Phase
+Phase 3: Tauri Desktop
+
+## Priority
+P1
+
+## Components
+- AppShell
+
+## Notes
+Per the PRD, Tauri v2 wraps the same web frontend with zero rewrite. The Tauri configuration (tauri.conf.json) needs to allow WebSocket connections to arbitrary Hive server URLs (CSP adjustments). File system access for workspace management is a Phase 3 goal but not part of this story -- it will be a separate story if needed.

--- a/docs/prd/hive/stories/frontend/fe-016-system-tray.md
+++ b/docs/prd/hive/stories/frontend/fe-016-system-tray.md
@@ -1,0 +1,26 @@
+# [FE-016] System Tray Icon with Agent Health Summary
+
+**As a** desktop user
+**I want to** see agent health status from the system tray without opening the main window
+**So that** I can monitor my agent fleet at a glance while working in other applications
+
+## Acceptance Criteria
+- [ ] The Tauri app places an icon in the system tray (macOS menu bar, Windows notification area, Linux system tray) that persists when the main window is closed
+- [ ] The tray icon color reflects aggregate agent health: green = all agents healthy, yellow = one or more agents in warning state, red = one or more agents in error/crashed state, gray = no agents running or disconnected from server
+- [ ] Clicking the tray icon opens a compact popup menu showing: each agent's name and health status (colored dot), a separator, and menu items for "Open Hive", "Spawn Agent...", and "Quit"
+- [ ] The popup menu updates in real-time as agent health changes via the WebSocket connection (the connection is maintained even when the main window is hidden)
+- [ ] Right-clicking the tray icon (or Ctrl+click on macOS) opens a context menu with: "Show/Hide Window", "Preferences", and "Quit"
+- [ ] When all agents are healthy, the tray tooltip shows "Hive - N agents running"; when issues exist, it shows the count of unhealthy agents
+- [ ] Closing the main window minimizes to tray instead of quitting the application (configurable in preferences; default: minimize to tray)
+
+## Phase
+Phase 3: Tauri Desktop
+
+## Priority
+P1
+
+## Components
+- AppShell (Tauri integration)
+
+## Notes
+Tauri v2 provides system tray APIs via the `tray-icon` plugin. The tray icon must work across all three platforms (macOS, Windows, Linux). The WebSocket connection must remain active when the window is hidden to keep the health data current. Icon assets are needed for each state (green, yellow, red, gray) in platform-appropriate formats.

--- a/docs/prd/hive/stories/frontend/fe-017-native-notifications.md
+++ b/docs/prd/hive/stories/frontend/fe-017-native-notifications.md
@@ -1,0 +1,27 @@
+# [FE-017] Native Notifications for @mentions and Task Assignments
+
+**As a** desktop user
+**I want to** receive native OS notifications when I am @mentioned or assigned a task
+**So that** I can respond promptly without keeping the Hive window in focus
+
+## Acceptance Criteria
+- [ ] When a message containing an @mention of the current user arrives via WebSocket and the Hive window is not focused, a native OS notification is displayed with: sender name, room name, and a truncated message preview (first 100 characters)
+- [ ] When a task is assigned to the current user (TaskClaimed event with matching username), a native notification is displayed with: "Task assigned: <task-id> - <description truncated>"
+- [ ] Clicking a notification brings the Hive window to the foreground and navigates to the relevant room (for @mentions) or the Tasks view (for task assignments)
+- [ ] Notification preferences are configurable: users can independently toggle @mention notifications, task assignment notifications, and DM notifications on or off
+- [ ] A "Do Not Disturb" mode suppresses all notifications; it can be toggled from the system tray menu or the app preferences
+- [ ] Notifications respect the OS-level notification settings (e.g., macOS Focus modes, Windows Quiet Hours) -- the app does not attempt to bypass system-level suppression
+- [ ] Notification sound follows the OS default; no custom sounds are bundled in Phase 3
+- [ ] Rate limiting: if more than 5 notifications arrive within 10 seconds, they are batched into a single summary notification ("5 new messages in #room-name")
+
+## Phase
+Phase 3: Tauri Desktop
+
+## Priority
+P1
+
+## Components
+- AppShell (Tauri integration)
+
+## Notes
+Tauri v2 provides native notification APIs via the `notification` plugin. On macOS, the app must request notification permissions on first launch. The web version can use the browser Notification API as a fallback, but this story focuses on the Tauri desktop experience. Rate limiting prevents notification storms during high-activity sprints.

--- a/docs/prd/hive/stories/frontend/fe-018-cost-dashboard.md
+++ b/docs/prd/hive/stories/frontend/fe-018-cost-dashboard.md
@@ -1,0 +1,27 @@
+# [FE-018] Cost Dashboard with Per-Agent Charts
+
+**As a** workspace admin
+**I want to** see cost breakdowns and trends across agents and models
+**So that** I can manage budget, identify expensive agents, and optimize model usage
+
+## Acceptance Criteria
+- [ ] The Costs tab renders a `<CostChart>` dashboard with three chart sections: cost over time (line chart), cost by model (bar chart), and cost by agent (horizontal bar chart)
+- [ ] The "cost over time" chart shows daily spending for the last 30 days by default, with selectable time ranges (7d, 30d, 90d, custom date range)
+- [ ] The "cost by model" chart breaks down spending per model (e.g., claude-sonnet, claude-opus) with percentage labels
+- [ ] The "cost by agent" chart ranks agents by total cost in the selected time period, with each bar segmented by model type
+- [ ] A summary card at the top displays: total spend in the selected period, average daily cost, projected monthly cost (based on trailing 7-day average), and comparison to the previous period (percentage change with up/down indicator)
+- [ ] Hovering over any chart data point shows a tooltip with the exact dollar amount, date, and breakdown
+- [ ] Budget alerts: if a configurable monthly budget threshold is set, a warning banner appears when spending exceeds 80% of the budget, and turns red at 100%
+- [ ] All cost data is fetched from the Hive server's cost API; charts update when new cost events arrive via WebSocket
+
+## Phase
+Phase 4: Advanced
+
+## Priority
+P2
+
+## Components
+- CostChart
+
+## Notes
+Cost data is tracked per-agent by room-ralph (token usage from Claude API responses). The Hive server aggregates this data. Chart rendering should use a lightweight library (e.g., Chart.js, Recharts for React, or LayerChart for Svelte). The PRD references cloud billing dashboards (AWS, GCP) as design inspiration. Currency display should be configurable (USD default).

--- a/docs/prd/hive/stories/frontend/fe-019-unified-timeline.md
+++ b/docs/prd/hive/stories/frontend/fe-019-unified-timeline.md
@@ -1,0 +1,28 @@
+# [FE-019] Cross-Room Unified Timeline
+
+**As a** user
+**I want to** see a single chronological feed of messages from all my subscribed rooms
+**So that** I can monitor activity across the workspace without switching between rooms
+
+## Acceptance Criteria
+- [ ] A "Unified" entry appears at the top of the `<RoomList>` sidebar (above workspace groups) that, when selected, renders a merged timeline in the main content area
+- [ ] The unified timeline interleaves messages from all subscribed rooms in chronological order, with each message prefixed by a colored room label chip (e.g., "[sprint-14]", "[general]")
+- [ ] Room label colors are deterministic per room (consistent hash to color) so users can visually distinguish rooms at a glance
+- [ ] Clicking a room label chip on any message navigates to that specific room's timeline, scrolled to the clicked message
+- [ ] The unified timeline supports the same real-time streaming as individual room timelines: new messages appear instantly via WebSocket
+- [ ] A room filter dropdown above the timeline allows selecting a subset of rooms to include in the unified view (default: all subscribed)
+- [ ] The unified timeline respects DM visibility: direct messages are only shown to the sender and recipient, same as in individual room views
+- [ ] Performance: the unified timeline virtualizes rendering to handle high message volumes across many rooms without degrading scroll performance
+
+## Phase
+Phase 4: Advanced
+
+## Priority
+P2
+
+## Components
+- ChatTimeline
+- RoomList
+
+## Notes
+This maps to the "multi-room workspace view with unified timeline" goal stated in the PRD. The existing `cmd_poll_multi` (oneshot/poll.rs) already merges messages from multiple rooms by timestamp -- the frontend implementation mirrors this logic client-side. The room filter state should be persisted in localStorage.

--- a/docs/prd/hive/stories/frontend/fe-020-agent-discovery-filtering.md
+++ b/docs/prd/hive/stories/frontend/fe-020-agent-discovery-filtering.md
@@ -1,0 +1,28 @@
+# [FE-020] Agent Discovery and Filtering by Domain/Capacity
+
+**As a** workspace admin
+**I want to** search and filter agents by their domain expertise and available capacity
+**So that** I can find the right agent for a task and identify underutilized agents
+
+## Acceptance Criteria
+- [ ] The Agents view includes a filter bar above the `<AgentGrid>` with the following filter controls: domain/personality (dropdown with multi-select), model type (dropdown), health status (checkbox group: healthy/warning/error/stopped), and room assignment (dropdown)
+- [ ] A text search field filters agents by name, personality label, or current status text (client-side, real-time as the user types)
+- [ ] Filters are combinable (AND logic): selecting "personality=debugger" and "status=healthy" shows only healthy debugger agents
+- [ ] Each agent card displays a capacity indicator: current context usage as a percentage bar (from room-ralph's context monitoring data), with color coding (green <50%, yellow 50-80%, red >80%)
+- [ ] Agents can be sorted by: name (A-Z), uptime (longest first), context usage (most available first), or cost (highest first) via a sort dropdown
+- [ ] Filter and sort state is reflected in the URL query string so that filtered views are shareable/bookmarkable
+- [ ] A "Available for assignment" quick filter shows only agents that are healthy, have <50% context usage, and are not currently assigned to a task
+- [ ] Empty state after filtering: display "No agents match filters" with a "Clear filters" button
+
+## Phase
+Phase 4: Advanced
+
+## Priority
+P2
+
+## Components
+- AgentGrid
+- AgentCard
+
+## Notes
+Agent discovery depends on the Hive server's agent registry and the prd-agent-discovery.md specification. Domain information comes from personality definitions. Capacity data (context usage) comes from room-ralph's monitoring output. This builds on the read-only agent list from FE-006 by adding interactive filtering and search.

--- a/docs/prd/hive/stories/frontend/fe-021-team-creation-wizard.md
+++ b/docs/prd/hive/stories/frontend/fe-021-team-creation-wizard.md
@@ -1,0 +1,29 @@
+# [FE-021] Team Creation Wizard from Manifest
+
+**As a** workspace admin
+**I want to** create an entire agent team from a manifest file through a guided wizard
+**So that** I can spin up pre-configured teams for sprints without manually spawning each agent
+
+## Acceptance Criteria
+- [ ] A "Create Team" button in the Agents view opens a `<TeamWizard>` modal dialog
+- [ ] Step 1 — Manifest input: the user can paste a YAML/JSON manifest or upload a manifest file; the wizard parses it and displays a preview of the team composition (agent names, personalities, models, room assignments)
+- [ ] Step 2 — Review and customize: each agent in the manifest is shown as an editable row where the user can override the personality, model, or target room before creation
+- [ ] Step 3 — Room setup: the wizard auto-creates rooms listed in the manifest that do not already exist, with a checkbox to skip room creation for existing rooms
+- [ ] Step 4 — Confirm and deploy: a summary shows the full team configuration; on confirmation, the wizard sends parallel spawn requests and displays a progress tracker showing each agent's startup status (pending/starting/healthy/failed)
+- [ ] Manifest validation: invalid manifests (missing required fields, unknown personalities, invalid room names) show specific inline error messages at the field level
+- [ ] If any agent fails to spawn, the wizard shows which agents succeeded and which failed, with error details and a "Retry failed" button
+- [ ] Previously used manifests are saved to localStorage and available in a "Recent manifests" dropdown for quick re-use
+- [ ] The manifest format is documented with an inline help link or expandable example within the wizard
+
+## Phase
+Phase 4: Advanced
+
+## Priority
+P2
+
+## Components
+- SpawnWizard (extended)
+- AgentGrid
+
+## Notes
+The manifest format should align with the team provisioning PRD (prd-team-provisioning.md). This wizard orchestrates multiple spawn operations from FE-008. The progress tracker should update in real-time as agents come online via WebSocket health events. Consider supporting a "dry run" mode that validates the manifest without actually spawning agents.

--- a/docs/prd/hive/stories/frontend/fe-022-dark-mode-theming.md
+++ b/docs/prd/hive/stories/frontend/fe-022-dark-mode-theming.md
@@ -1,0 +1,30 @@
+# [FE-022] Dark Mode / Theming Support
+
+**As a** user
+**I want to** switch between light and dark themes (or follow my OS preference)
+**So that** I can use Hive comfortably in any lighting condition and match my system appearance
+
+## Acceptance Criteria
+- [ ] A theme toggle is accessible from the app shell header (sun/moon icon) with three options: Light, Dark, and System (follows OS preference)
+- [ ] Dark mode applies a cohesive dark color palette across all components: backgrounds, text, borders, cards, charts, badges, and interactive elements
+- [ ] The theme preference is stored in localStorage and applied immediately on page load (no flash of wrong theme)
+- [ ] All color values are defined as CSS custom properties (or Tailwind theme tokens) so that a single theme swap changes the entire UI consistently
+- [ ] Color contrast ratios meet WCAG AA standards in both themes: minimum 4.5:1 for normal text and 3:1 for large text and UI components
+- [ ] Syntax highlighting in code blocks (chat messages) and the log viewer adapts to the active theme
+- [ ] Charts in the Costs view (`<CostChart>`) use theme-aware color palettes that are legible in both light and dark modes
+- [ ] The Tauri desktop version (FE-015) respects the same theme setting and applies it to the native title bar where possible (macOS vibrancy, Windows Mica)
+
+## Phase
+Phase 4: Advanced
+
+## Priority
+P2
+
+## Components
+- AppShell
+- ChatTimeline
+- CostChart
+- LogViewer
+
+## Notes
+Tailwind CSS supports dark mode via the `dark:` variant (class strategy recommended over media strategy for manual toggle support). The "System" option uses `prefers-color-scheme` media query and a MutationObserver or matchMedia listener to react to OS-level changes. Custom theming beyond light/dark (e.g., user-defined accent colors) is out of scope for this story.


### PR DESCRIPTION
## Summary
22 frontend user stories for the Hive dashboard, based on prd-hive-frontend.md:
- Phase 1 (Web MVP, P0): 7 stories — app shell, login, rooms, chat, members, agents, WebSocket
- Phase 2 (Interactive, P1): 7 stories — spawn wizard, agent mgmt, logs, kanban, messages
- Phase 3 (Tauri Desktop, P1): 3 stories — desktop shell, tray icon, notifications
- Phase 4 (Advanced, P2): 5 stories — costs, unified timeline, discovery, teams, theming

Each story has 7-8 testable acceptance criteria, phase/priority tags, component references.