### PR TITLE
docs(hive): 26 backend user stories for Hive server

### DIFF
--- a/docs/prd/hive/stories/backend/US-BE-001-server-health.md
+++ b/docs/prd/hive/stories/backend/US-BE-001-server-health.md
@@ -1,0 +1,22 @@
+# US-BE-001: Server health endpoint
+
+**As a** platform operator
+**I want to** query a health endpoint on the Hive server
+**So that** load balancers and monitoring systems can determine whether the server is running and ready to accept traffic
+
+## Acceptance Criteria
+- [ ] `GET /api/health` returns `200 OK` with a JSON body containing at least `{"status": "ok"}`
+- [ ] Response includes server version and uptime in seconds
+- [ ] Response includes room daemon connectivity status (`daemon_connected: true/false`)
+- [ ] Endpoint is unauthenticated (no token required)
+- [ ] Response time is under 100ms under normal load
+- [ ] Returns `503 Service Unavailable` with `{"status": "degraded", "reason": "..."}` when the room daemon is unreachable
+
+## Technical Notes
+- Implement in `crates/hive-server/src/main.rs` or a dedicated `health.rs` handler
+- Daemon connectivity check: attempt a short-timeout ping to the room daemon WebSocket or REST `GET /api/health`; do not block on it — use a cached status updated every 5s
+- Use `axum::Router` to register the route
+- Uptime is calculated from a `start_time: std::time::Instant` stored in shared `AppState`
+
+## Phase
+Phase 1 (Skeleton + Room Proxy)

--- a/docs/prd/hive/stories/backend/US-BE-002-config-loading.md
+++ b/docs/prd/hive/stories/backend/US-BE-002-config-loading.md
@@ -1,0 +1,24 @@
+# US-BE-002: Configuration loading
+
+**As a** server operator
+**I want to** configure the Hive server via a `hive.toml` file
+**So that** I can set the room daemon socket path, HTTP port, and data directory without recompiling
+
+## Acceptance Criteria
+- [ ] Server reads `hive.toml` from the current working directory on startup, or from the path specified by `--config <path>` CLI flag
+- [ ] Config file specifies at minimum: `http_port`, `room_socket_path`, `data_dir`
+- [ ] Individual fields can be overridden by environment variables (`HIVE_HTTP_PORT`, `HIVE_ROOM_SOCKET_PATH`, `HIVE_DATA_DIR`)
+- [ ] Server fails fast with a descriptive error if the config file is missing and no defaults are applicable
+- [ ] Missing optional fields fall back to documented defaults (port 8080, socket `/tmp/roomd.sock`, data dir `~/.hive`)
+- [ ] Config is loaded once at startup and stored in a shared `Arc<Config>` accessible to all handlers
+- [ ] A `--print-config` flag prints the resolved config as TOML and exits without starting the server
+
+## Technical Notes
+- Implement in `crates/hive-server/src/config.rs`
+- Use the `toml` crate for deserialization into a `HiveConfig` struct derived with `serde::Deserialize`
+- Environment variable override layer sits on top of file deserialization; use a simple manual merge rather than a config framework to keep dependencies minimal
+- `data_dir` supports `~` expansion (resolve via `dirs::home_dir()` or manual replacement)
+- Validation: `http_port` must be 1–65535, `room_socket_path` must be an absolute path
+
+## Phase
+Phase 1 (Skeleton + Room Proxy)

--- a/docs/prd/hive/stories/backend/US-BE-003-websocket-relay.md
+++ b/docs/prd/hive/stories/backend/US-BE-003-websocket-relay.md
@@ -1,0 +1,26 @@
+# US-BE-003: WebSocket relay
+
+**As a** Hive frontend user
+**I want to** connect to a room via the Hive server's WebSocket endpoint
+**So that** I receive real-time messages from the room daemon without connecting to it directly
+
+## Acceptance Criteria
+- [ ] `GET /ws/:room_id` upgrades to a WebSocket connection and relays frames bidirectionally to the room daemon at `ws://<daemon_host>/ws/:room_id`
+- [ ] Text frames from the frontend are forwarded to the daemon unchanged
+- [ ] Text frames from the daemon are forwarded to the frontend unchanged
+- [ ] Binary frames are forwarded unchanged
+- [ ] When the daemon connection closes, the frontend connection is closed with the same close code
+- [ ] When the frontend disconnects, the daemon connection is torn down cleanly
+- [ ] Connection errors to the daemon return an HTTP `502 Bad Gateway` before the WebSocket upgrade completes
+- [ ] Relay handles at least 100 concurrent connections without degradation
+
+## Technical Notes
+- Implement in `crates/hive-server/src/ws_relay.rs`
+- Use `tokio-tungstenite` to open the upstream daemon WebSocket connection
+- Use axum's `WebSocketUpgrade` extractor for the frontend-facing side
+- Spawn two tasks per relay session: one for each direction; both tasks share a cancellation token so either side closing tears down the other
+- Daemon WebSocket URL is derived from `config.room_ws_url` (e.g. `ws://127.0.0.1:4200/ws/<room_id>`)
+- No message transformation in Phase 1; raw relay only
+
+## Phase
+Phase 1 (Skeleton + Room Proxy)

--- a/docs/prd/hive/stories/backend/US-BE-004-rest-room-proxy.md
+++ b/docs/prd/hive/stories/backend/US-BE-004-rest-room-proxy.md
@@ -1,0 +1,24 @@
+# US-BE-004: REST room proxy
+
+**As a** Hive frontend developer
+**I want to** make REST calls to `/api/rooms/*` on the Hive server
+**So that** the frontend does not need to know the room daemon's address or port
+
+## Acceptance Criteria
+- [ ] All requests to `/api/rooms/*` are forwarded to the room daemon's corresponding REST endpoint
+- [ ] Request method, headers, and body are preserved on the forwarded request
+- [ ] Response status code, headers, and body from the daemon are returned to the caller unchanged
+- [ ] A `X-Hive-Request-ID` header is injected into every proxied request for traceability
+- [ ] If the daemon returns a non-2xx response, it is passed through to the caller without modification
+- [ ] If the daemon is unreachable, the proxy returns `502 Bad Gateway` with `{"error": "daemon_unavailable"}`
+- [ ] Proxy timeout is configurable (`proxy_timeout_secs` in `hive.toml`, default 30s)
+
+## Technical Notes
+- Implement in `crates/hive-server/src/rooms.rs` using `reqwest` as the HTTP client
+- Route pattern: `any("/api/rooms/*path", proxy_handler)` — strip the `/api/rooms` prefix and rewrite to the daemon base URL
+- Daemon base URL stored in `AppState` as `daemon_rest_url` derived from config
+- Re-use a single `reqwest::Client` stored in `AppState` (connection pooling)
+- Phase 1 only: no auth injection. Auth headers added in Phase 2
+
+## Phase
+Phase 1 (Skeleton + Room Proxy)

--- a/docs/prd/hive/stories/backend/US-BE-005-room-list-endpoint.md
+++ b/docs/prd/hive/stories/backend/US-BE-005-room-list-endpoint.md
@@ -1,0 +1,22 @@
+# US-BE-005: Room list endpoint
+
+**As a** Hive frontend user
+**I want to** fetch a list of available rooms
+**So that** I can display them in the workspace sidebar and allow users to join them
+
+## Acceptance Criteria
+- [ ] `GET /api/rooms` returns `200 OK` with a JSON array of room objects
+- [ ] Each room object includes at minimum: `id`, `name`, `user_count`, `created_at`
+- [ ] The list is sourced from the room daemon's room list API
+- [ ] An empty list `[]` is returned (not an error) when no rooms exist
+- [ ] Response is returned within 500ms under normal load
+- [ ] If the daemon is unavailable, returns `502 Bad Gateway` with a structured error
+
+## Technical Notes
+- Implement in `crates/hive-server/src/rooms.rs`
+- Calls daemon `GET /api/rooms` (or equivalent discovery endpoint) and re-serializes the result into Hive's schema
+- Room list may be cached for up to 2 seconds to reduce daemon load under high frontend polling; cache invalidated on room create/destroy events
+- Response schema is defined in a shared `RoomSummary` struct in `rooms.rs`; keep it decoupled from room-protocol types to allow independent evolution
+
+## Phase
+Phase 1 (Skeleton + Room Proxy)

--- a/docs/prd/hive/stories/backend/US-BE-006-room-messages-endpoint.md
+++ b/docs/prd/hive/stories/backend/US-BE-006-room-messages-endpoint.md
@@ -1,0 +1,23 @@
+# US-BE-006: Room messages endpoint
+
+**As a** Hive frontend user
+**I want to** fetch the message history for a room
+**So that** I can display past messages when opening a room channel
+
+## Acceptance Criteria
+- [ ] `GET /api/rooms/:id/messages` returns `200 OK` with a JSON array of message objects in chronological order
+- [ ] Supports pagination via `?limit=N` (default 50, max 500) and `?before=<message_id>` cursor
+- [ ] Each message object includes: `id`, `room`, `user`, `content`, `ts`, `type`
+- [ ] Returns `404 Not Found` with `{"error": "room_not_found"}` if the room does not exist
+- [ ] Returns `200 OK` with `[]` if the room exists but has no messages
+- [ ] If the daemon is unavailable, returns `502 Bad Gateway`
+
+## Technical Notes
+- Implement in `crates/hive-server/src/rooms.rs`
+- Delegates to daemon `GET /api/<room_id>/poll?limit=N&since=<id>` or equivalent history endpoint
+- Response schema uses a `MessageSummary` struct; fields map directly from `room_protocol::Message` variants but are flattened to a uniform shape for the frontend (all types included, `content` is `Option<String>`)
+- Message ID is the `id` field from the room-protocol envelope (UUID string)
+- `before` cursor translates to `?since=` with a reversed scan if the daemon supports it; otherwise fetch last N and filter
+
+## Phase
+Phase 1 (Skeleton + Room Proxy)

--- a/docs/prd/hive/stories/backend/US-BE-007-room-send-proxy.md
+++ b/docs/prd/hive/stories/backend/US-BE-007-room-send-proxy.md
@@ -1,0 +1,22 @@
+# US-BE-007: Room send proxy
+
+**As a** Hive frontend user
+**I want to** send a message to a room via the Hive server
+**So that** my messages are delivered to the room daemon and broadcast to all participants
+
+## Acceptance Criteria
+- [ ] `POST /api/rooms/:id/send` with JSON body `{"content": "..."}` forwards the message to the room daemon and returns `200 OK` with the echoed message envelope
+- [ ] Returns `400 Bad Request` with `{"error": "missing_content"}` if `content` is absent or empty
+- [ ] Returns `404 Not Found` with `{"error": "room_not_found"}` if the room does not exist on the daemon
+- [ ] Returns `502 Bad Gateway` if the daemon is unreachable
+- [ ] In Phase 1 (no auth), uses a configurable service account token from `hive.toml` (`service_token`) for the daemon `Authorization` header
+- [ ] Request body size is limited to 64 KB (matching room daemon's `MAX_LINE_BYTES`)
+
+## Technical Notes
+- Implement in `crates/hive-server/src/rooms.rs`
+- Calls daemon `POST /api/<room_id>/send` with `Authorization: Bearer <service_token>`
+- In Phase 2, the service_token is replaced by the authenticated user's room token (from token mapping, US-BE-011)
+- Body size limit enforced via axum's `ContentLengthLimit` extractor or a custom middleware
+
+## Phase
+Phase 1 (Skeleton + Room Proxy)

--- a/docs/prd/hive/stories/backend/US-BE-008-github-oauth-login.md
+++ b/docs/prd/hive/stories/backend/US-BE-008-github-oauth-login.md
@@ -1,0 +1,24 @@
+# US-BE-008: GitHub OAuth login flow
+
+**As a** human user
+**I want to** log in to Hive using my GitHub account
+**So that** I have a persistent, authenticated identity without managing a separate password
+
+## Acceptance Criteria
+- [ ] `GET /auth/github/login` redirects the browser to GitHub's OAuth authorization URL with the correct `client_id`, `scope` (`read:user user:email`), and a CSRF `state` parameter
+- [ ] `GET /auth/github/callback?code=<code>&state=<state>` exchanges the code for an access token, fetches the GitHub user profile, and creates or updates the Hive `users` record
+- [ ] CSRF `state` is validated on callback; mismatched state returns `400 Bad Request`
+- [ ] On success, callback redirects to the frontend with a short-lived exchange token in the query string; frontend exchanges it for a JWT via `POST /auth/token`
+- [ ] GitHub `client_id` and `client_secret` are read from config (`hive.toml` or env vars `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET`)
+- [ ] If GitHub is unreachable, returns `502 Bad Gateway` with a user-facing error message
+- [ ] Existing users are matched by GitHub user ID (not email); email is stored but not used for identity
+
+## Technical Notes
+- Implement in `crates/hive-server/src/auth.rs`
+- Use `oxide-auth` or direct `reqwest` calls to the GitHub OAuth endpoints; prefer direct calls to avoid pulling in a large dependency for a two-step flow
+- CSRF state is a cryptographically random UUID stored in a short-lived (5 min TTL) in-memory map keyed by state; no session cookie needed at this stage
+- GitHub API endpoints: `https://github.com/login/oauth/authorize`, `https://github.com/login/oauth/access_token`, `https://api.github.com/user`
+- User record schema: see `users` table in US-BE-023
+
+## Phase
+Phase 2 (Auth + Agent Management)

--- a/docs/prd/hive/stories/backend/US-BE-009-session-management.md
+++ b/docs/prd/hive/stories/backend/US-BE-009-session-management.md
@@ -1,0 +1,23 @@
+# US-BE-009: Session management
+
+**As a** authenticated Hive user
+**I want to** receive a JWT after login and use it for subsequent API requests
+**So that** I do not have to re-authenticate on every request
+
+## Acceptance Criteria
+- [ ] `POST /auth/token` with a valid exchange token returns `{"token": "<jwt>", "expires_in": 86400}` and invalidates the exchange token
+- [ ] The JWT encodes `user_id`, `github_id`, `email`, and `exp` (24h expiry by default)
+- [ ] All authenticated API endpoints accept `Authorization: Bearer <jwt>` and return `401 Unauthorized` with `{"error": "invalid_token"}` when the token is absent, expired, or malformed
+- [ ] Token expiry is configurable (`jwt_expiry_secs` in `hive.toml`, default 86400)
+- [ ] A `POST /auth/refresh` endpoint issues a new JWT given a valid, non-expired token (sliding window)
+- [ ] `POST /auth/logout` invalidates the token by adding its `jti` to an in-memory revocation set (cleared on server restart)
+
+## Technical Notes
+- Implement in `crates/hive-server/src/auth.rs`
+- Use `jsonwebtoken` crate for encoding/decoding with HS256; signing secret read from `HIVE_JWT_SECRET` env var (required, no default — server fails to start if absent)
+- Claims struct: `{ sub: user_id, github_id, email, exp, jti }`
+- Auth middleware implemented as an axum `Extension` extractor that validates the Bearer token and injects a `CurrentUser` struct into the handler
+- Exchange tokens are single-use UUIDs stored in a `DashMap<String, (user_id, Instant)>` with a 5-minute TTL
+
+## Phase
+Phase 2 (Auth + Agent Management)

--- a/docs/prd/hive/stories/backend/US-BE-010-api-key-generation.md
+++ b/docs/prd/hive/stories/backend/US-BE-010-api-key-generation.md
@@ -1,0 +1,24 @@
+# US-BE-010: API key generation
+
+**As a** authenticated Hive user
+**I want to** create and revoke API keys
+**So that** I can give programmatic access to scripts and CI pipelines without sharing my OAuth session
+
+## Acceptance Criteria
+- [ ] `POST /api/keys` (authenticated) creates an API key and returns `{"key": "hive_<random>", "id": "<uuid>", "scopes": [...], "created_at": "..."}` — the raw key is shown only once
+- [ ] `GET /api/keys` returns all active keys for the authenticated user (IDs and metadata only, not raw keys)
+- [ ] `DELETE /api/keys/:id` revokes the key immediately; subsequent requests using it receive `401 Unauthorized`
+- [ ] Keys are accepted in the `Authorization: Bearer hive_<value>` header on all authenticated endpoints
+- [ ] Scopes are validated at creation time; unsupported scopes return `400 Bad Request`
+- [ ] Initial supported scopes: `rooms:read`, `rooms:write`, `agents:read`, `agents:write`
+- [ ] A key belongs to exactly one user; permissions are the intersection of the user's permissions and the key's scopes
+
+## Technical Notes
+- Implement in `crates/hive-server/src/auth.rs`
+- Raw key format: `hive_` prefix + 32 bytes of random data encoded as base64url (total ~48 chars)
+- Only the SHA-256 hash of the raw key is stored in the `api_keys` table (see US-BE-023)
+- Auth middleware checks the `Authorization` header prefix: `hive_` routes to API key validation, all other Bearer values are treated as JWTs
+- Scopes stored as a JSON array in the `api_keys.scopes` column
+
+## Phase
+Phase 2 (Auth + Agent Management)

--- a/docs/prd/hive/stories/backend/US-BE-011-token-mapping.md
+++ b/docs/prd/hive/stories/backend/US-BE-011-token-mapping.md
@@ -1,0 +1,23 @@
+# US-BE-011: Token mapping
+
+**As a** Hive server
+**I want to** mint a room token for each authenticated Hive user
+**So that** messages sent through the Hive API are attributed to the correct room identity
+
+## Acceptance Criteria
+- [ ] When a user first authenticates via OAuth, the server calls `room join <username>` and persists the returned room token in the `users.room_token` column
+- [ ] The room token is refreshed if the room daemon is restarted (detected by a `401` from the daemon on token use)
+- [ ] All proxied `POST /api/rooms/:id/send` requests use the caller's room token, not the service account token
+- [ ] Room username is derived from the user's GitHub login (truncated to 32 chars, lowercased, non-alphanumeric replaced with `-`)
+- [ ] If `room join` fails, the OAuth login still succeeds but the user's room token is `NULL`; subsequent room actions return `503` with `{"error": "room_token_unavailable"}`
+- [ ] Token refresh is retried once with exponential backoff before surfacing the error
+
+## Technical Notes
+- Implement in `crates/hive-server/src/auth.rs`
+- `room join` is invoked via `tokio::process::Command` using the `room` binary found on `PATH` or at `config.room_binary_path`
+- Parse the JSON output `{"type":"token","token":"<uuid>","username":"<name>"}` to extract the token
+- Token is stored encrypted at rest using AES-128-GCM with a key derived from `HIVE_SECRET_KEY` env var; stored as base64 in the `users.room_token` column
+- On each room API call, decrypt the token from the database, inject as `Authorization: Bearer <token>` when forwarding to the daemon
+
+## Phase
+Phase 2 (Auth + Agent Management)

--- a/docs/prd/hive/stories/backend/US-BE-012-agent-spawn.md
+++ b/docs/prd/hive/stories/backend/US-BE-012-agent-spawn.md
@@ -1,0 +1,25 @@
+# US-BE-012: Agent spawn
+
+**As a** workspace owner
+**I want to** spawn an AI agent with a specific personality, model, and room assignment
+**So that** the agent joins the room and begins working autonomously
+
+## Acceptance Criteria
+- [ ] `POST /api/agents` with body `{"room_id": "...", "personality": "...", "model": "sonnet|opus|haiku", "workspace_id": "..."}` spawns a `room-ralph` process and returns `{"agent_id": "<uuid>", "status": "starting", "pid": N}`
+- [ ] The spawned `room-ralph` process has its own working directory under `config.data_dir/agents/<agent_id>/`
+- [ ] `personality` is a string passed as `--personality` to `room-ralph`; invalid personalities return `400 Bad Request`
+- [ ] `model` defaults to `sonnet` if absent
+- [ ] Agent record is created in SQLite with status `starting`; status transitions to `running` once the process is confirmed alive
+- [ ] Returns `409 Conflict` if an agent with the same `personality` is already running in the same room
+- [ ] Maximum concurrent agents per workspace is enforced (`max_agents_per_workspace` in config, default 10)
+
+## Technical Notes
+- Implement in `crates/hive-server/src/agents.rs`
+- Use `tokio::process::Command` to spawn `room-ralph`; store the `Child` handle in an in-memory `AgentRegistry` (`DashMap<Uuid, AgentHandle>`)
+- `AgentHandle` stores: `pid`, `room_id`, `personality`, `model`, `start_time`, `log_file_path`, `child: tokio::process::Child`
+- `room-ralph` is found via `config.ralph_binary_path` or `PATH`
+- Stdout/stderr of the child process is redirected to `config.data_dir/agents/<agent_id>/agent.log`
+- A background task monitors the child's exit status and updates the SQLite status to `stopped` on exit
+
+## Phase
+Phase 2 (Auth + Agent Management)

--- a/docs/prd/hive/stories/backend/US-BE-013-agent-stop.md
+++ b/docs/prd/hive/stories/backend/US-BE-013-agent-stop.md
@@ -1,0 +1,24 @@
+# US-BE-013: Agent stop
+
+**As a** workspace owner
+**I want to** stop a running agent
+**So that** I can free resources or replace it with a different configuration
+
+## Acceptance Criteria
+- [ ] `DELETE /api/agents/:id` sends `SIGTERM` to the agent's process group and returns `202 Accepted` immediately
+- [ ] If the process has not exited within 10 seconds, `SIGKILL` is sent to the process group
+- [ ] After termination, the agent's SQLite record status is updated to `stopped` with a `stopped_at` timestamp
+- [ ] Returns `404 Not Found` if the agent ID does not exist
+- [ ] Returns `409 Conflict` if the agent is already stopped
+- [ ] A `?force=true` query parameter skips the graceful period and sends `SIGKILL` immediately
+- [ ] The agent's working directory and log file are retained for post-mortem inspection
+
+## Technical Notes
+- Implement in `crates/hive-server/src/agents.rs`
+- Use `nix::sys::signal::killpg` (or `libc::killpg`) to signal the entire process group; the `room-ralph` process must be started with `process::Command::new(...).process_group(0)` so it leads its own group
+- Timeout enforced with `tokio::time::timeout` wrapping `child.wait()`
+- The `AgentHandle` is removed from the in-memory registry after the process exits
+- Log file path is preserved in SQLite even after the handle is dropped
+
+## Phase
+Phase 2 (Auth + Agent Management)

--- a/docs/prd/hive/stories/backend/US-BE-014-agent-list.md
+++ b/docs/prd/hive/stories/backend/US-BE-014-agent-list.md
@@ -1,0 +1,22 @@
+# US-BE-014: Agent list
+
+**As a** workspace owner
+**I want to** see all agents with their current health, status, uptime, and model
+**So that** I can monitor the health of my team and identify stuck or crashed agents
+
+## Acceptance Criteria
+- [ ] `GET /api/agents` returns a JSON array of agent objects for all agents the caller has access to
+- [ ] `GET /api/agents?workspace_id=<id>` filters agents by workspace
+- [ ] Each agent object includes: `id`, `room_id`, `personality`, `model`, `status` (`starting|running|stopped|crashed`), `pid`, `uptime_secs`, `workspace_id`, `started_at`, `stopped_at`
+- [ ] `status` reflects the live process state: `running` if the PID is alive, `crashed` if the process exited with non-zero code, `stopped` if cleanly terminated
+- [ ] `GET /api/agents/:id` returns a single agent or `404 Not Found`
+- [ ] Response is returned within 200ms; process liveness check uses cached state updated by the background monitor (not a live OS query per request)
+
+## Technical Notes
+- Implement in `crates/hive-server/src/agents.rs`
+- Agent status is maintained by the background monitor task (see US-BE-012) which polls `child.try_wait()` every 5 seconds and updates both the in-memory `AgentHandle` and the SQLite record
+- On server restart, agents that were `running` at shutdown are marked `stopped` (processes are orphaned and not re-adopted); operators must re-spawn them
+- Response serialization uses a `AgentSummary` DTO distinct from the internal `AgentHandle` to avoid exposing the `Child` handle
+
+## Phase
+Phase 2 (Auth + Agent Management)

--- a/docs/prd/hive/stories/backend/US-BE-015-agent-logs.md
+++ b/docs/prd/hive/stories/backend/US-BE-015-agent-logs.md
@@ -1,0 +1,24 @@
+# US-BE-015: Agent logs
+
+**As a** workspace owner
+**I want to** view or stream the log output of a running or stopped agent
+**So that** I can diagnose errors and observe agent behaviour
+
+## Acceptance Criteria
+- [ ] `GET /api/agents/:id/logs` returns the last 200 lines of the agent's log file as plain text
+- [ ] `?lines=N` query parameter changes the number of lines returned (max 5000)
+- [ ] `GET /api/agents/:id/logs?stream=true` upgrades to a Server-Sent Events (SSE) stream; new log lines are pushed to the client as they are written
+- [ ] SSE stream closes automatically when the agent stops
+- [ ] Returns `404 Not Found` if the agent does not exist
+- [ ] Returns `204 No Content` if the agent exists but has produced no log output yet
+- [ ] Log lines are returned as UTF-8; non-UTF-8 bytes are replaced with the Unicode replacement character
+
+## Technical Notes
+- Implement in `crates/hive-server/src/agents.rs`
+- Log file path is `config.data_dir/agents/<agent_id>/agent.log`
+- Tail implementation: read from end of file using `std::fs::File::seek(SeekFrom::End(-N_bytes))` — scan backwards for `\n` to find the Nth-from-last line; use a 64 KB scan window
+- SSE streaming: use `tokio::io::BufReader` + `lines()` on the log file, then `tokio_stream::wrappers::LinesStream`; use axum's `Sse` response type
+- For SSE, poll the file for new content using `tokio::time::interval` (100ms) rather than `inotify` to keep the implementation portable
+
+## Phase
+Phase 2 (Auth + Agent Management)

--- a/docs/prd/hive/stories/backend/US-BE-016-agent-workspace-provisioning.md
+++ b/docs/prd/hive/stories/backend/US-BE-016-agent-workspace-provisioning.md
@@ -1,0 +1,23 @@
+# US-BE-016: Agent workspace provisioning
+
+**As a** Hive server
+**I want to** create an isolated directory structure for each spawned agent
+**So that** agents have their own working directories, memory files, and log storage without interfering with each other
+
+## Acceptance Criteria
+- [ ] Before spawning, the server creates `config.data_dir/agents/<agent_id>/` with subdirectories: `workspace/`, `logs/`, `memory/`
+- [ ] The agent process is started with `workspace/` as its working directory
+- [ ] The `logs/` directory contains `agent.log` (stdout+stderr redirect target)
+- [ ] The `memory/` directory is pre-populated with a `MEMORY.md` stub if a personality template exists at `config.data_dir/personalities/<personality>.md`
+- [ ] Directory creation is atomic: if any step fails, the partial directory is removed and the spawn returns `500 Internal Server Error`
+- [ ] Directories are created with mode `0700` (owner-only access)
+- [ ] Provisioning is idempotent: if the directory already exists (e.g. agent restart), it is reused without error
+
+## Technical Notes
+- Implement in `crates/hive-server/src/agents.rs` as a `provision_agent_workspace(agent_id, config)` function called before `Command::new(...)`
+- Use `std::fs::create_dir_all` for each subdirectory; set permissions with `std::fs::set_permissions`
+- Personality template lookup: `config.data_dir/personalities/<personality>.md` — if absent, skip memory pre-population silently
+- Workspace cleanup on agent deletion is deferred to a separate administrative endpoint (not in Phase 2 scope); directories are retained for inspection
+
+## Phase
+Phase 2 (Auth + Agent Management)

--- a/docs/prd/hive/stories/backend/US-BE-017-workspace-crud.md
+++ b/docs/prd/hive/stories/backend/US-BE-017-workspace-crud.md
@@ -1,0 +1,24 @@
+# US-BE-017: Workspace CRUD
+
+**As a** authenticated Hive user
+**I want to** create, view, update, and delete workspaces
+**So that** I can organise related rooms and agent teams into named project spaces
+
+## Acceptance Criteria
+- [ ] `POST /api/workspaces` with `{"name": "..."}` creates a workspace and returns `201 Created` with the full workspace object
+- [ ] `GET /api/workspaces` returns all workspaces accessible to the authenticated user
+- [ ] `GET /api/workspaces/:id` returns a single workspace or `404 Not Found`
+- [ ] `PATCH /api/workspaces/:id` updates the workspace name; returns `200 OK` with the updated object
+- [ ] `DELETE /api/workspaces/:id` deletes the workspace and cascades to `workspace_rooms` and `team_manifests`; does NOT destroy rooms on the daemon (rooms are independent)
+- [ ] Workspace names must be 1–64 characters; duplicates per user return `409 Conflict`
+- [ ] Only the workspace owner can update or delete it; others receive `403 Forbidden`
+
+## Technical Notes
+- Implement in `crates/hive-server/src/workspaces.rs` (new module)
+- SQLite schema: see `workspaces` and `workspace_rooms` tables in US-BE-023
+- Owner is set to `current_user.id` on creation and stored in `workspaces.owner_id`
+- Cascade delete is handled by SQLite foreign key constraints (`ON DELETE CASCADE`) on `workspace_rooms` and `team_manifests`
+- Foreign key enforcement must be enabled per connection: `PRAGMA foreign_keys = ON`
+
+## Phase
+Phase 3 (Workspaces + Teams)

--- a/docs/prd/hive/stories/backend/US-BE-018-workspace-room-membership.md
+++ b/docs/prd/hive/stories/backend/US-BE-018-workspace-room-membership.md
@@ -1,0 +1,23 @@
+# US-BE-018: Workspace room membership
+
+**As a** workspace owner
+**I want to** add and remove rooms from a workspace
+**So that** I can define which rooms are part of a project and surface them in the workspace view
+
+## Acceptance Criteria
+- [ ] `POST /api/workspaces/:id/rooms` with `{"room_id": "..."}` adds the room to the workspace; returns `201 Created` with `{"workspace_id": "...", "room_id": "..."}`
+- [ ] `DELETE /api/workspaces/:id/rooms/:room_id` removes the room from the workspace; returns `204 No Content`
+- [ ] `GET /api/workspaces/:id/rooms` returns the list of rooms in the workspace, each with live metadata fetched from the daemon (user count, last message timestamp)
+- [ ] Adding a room that does not exist on the daemon returns `422 Unprocessable Entity` with `{"error": "room_not_found_on_daemon"}`
+- [ ] Adding a room already in the workspace returns `409 Conflict`
+- [ ] Removing a room that is not in the workspace returns `404 Not Found`
+- [ ] Only the workspace owner can modify room membership; others receive `403 Forbidden`
+
+## Technical Notes
+- Implement in `crates/hive-server/src/workspaces.rs`
+- `workspace_rooms` is a join table: `(workspace_id, room_id)` with a unique constraint
+- Room existence validation: call daemon `GET /api/rooms` (or `GET /api/<room_id>/health`) before inserting; cache the room list for 2 seconds to avoid hammering the daemon on bulk adds
+- Live metadata for `GET /api/workspaces/:id/rooms` is fetched in parallel for all rooms using `tokio::join_all`; individual daemon failures return `null` metadata for that room rather than failing the whole request
+
+## Phase
+Phase 3 (Workspaces + Teams)

--- a/docs/prd/hive/stories/backend/US-BE-019-team-manifest-parsing.md
+++ b/docs/prd/hive/stories/backend/US-BE-019-team-manifest-parsing.md
@@ -1,0 +1,24 @@
+# US-BE-019: Team manifest parsing
+
+**As a** workspace owner
+**I want to** upload a JSON team manifest that describes a set of agents
+**So that** I can define a repeatable team configuration and provision it on demand
+
+## Acceptance Criteria
+- [ ] `POST /api/workspaces/:id/manifests` with a JSON body conforming to the manifest schema stores the manifest and returns `201 Created` with `{"manifest_id": "...", "agent_count": N}`
+- [ ] `GET /api/workspaces/:id/manifests` returns all manifests for the workspace
+- [ ] `GET /api/workspaces/:id/manifests/:mid` returns a single manifest
+- [ ] `DELETE /api/workspaces/:id/manifests/:mid` removes the manifest (does not affect running agents)
+- [ ] Malformed JSON returns `400 Bad Request` with field-level validation errors
+- [ ] Manifest schema: `{"name": "...", "agents": [{"personality": "...", "model": "...", "room_id": "..."}]}`; all fields required per agent entry
+- [ ] Maximum 50 agents per manifest; exceeding this returns `422 Unprocessable Entity`
+
+## Technical Notes
+- Implement in `crates/hive-server/src/workspaces.rs`
+- Manifest body is validated into a `TeamManifest` struct before storage; store the validated JSON (re-serialised from the struct) in `team_manifests.manifest_json`
+- Validation uses serde's derive macros with `#[serde(deny_unknown_fields)]` to reject unrecognised fields
+- `agent_count` in the response is the length of the `agents` array
+- `room_id` values in the manifest are validated against the daemon's room list at upload time (same approach as US-BE-018)
+
+## Phase
+Phase 3 (Workspaces + Teams)

--- a/docs/prd/hive/stories/backend/US-BE-020-batch-agent-provisioning.md
+++ b/docs/prd/hive/stories/backend/US-BE-020-batch-agent-provisioning.md
@@ -1,0 +1,23 @@
+# US-BE-020: Batch agent provisioning
+
+**As a** workspace owner
+**I want to** spawn all agents defined in a team manifest with a single API call
+**So that** I can stand up an entire team quickly without calling the spawn endpoint N times
+
+## Acceptance Criteria
+- [ ] `POST /api/workspaces/:id/manifests/:mid/provision` spawns all agents in the manifest and returns `202 Accepted` with `{"job_id": "...", "agent_count": N, "status": "provisioning"}`
+- [ ] `GET /api/workspaces/:id/provision/:job_id` returns the provisioning status: `{"status": "provisioning|done|partial_failure", "agents": [{"personality": "...", "agent_id": "...", "status": "starting|running|failed", "error": "..."}]}`
+- [ ] Agents are spawned concurrently (not sequentially); all spawn attempts are made regardless of individual failures
+- [ ] If any agent fails to spawn, the job status is `partial_failure`; already-started agents are NOT stopped automatically
+- [ ] Provisioning respects the `max_agents_per_workspace` limit; if the total would exceed it, the request fails with `422` before any agents are spawned
+- [ ] Provisioning is idempotent if called again with the same manifest: agents already running with the same personality+room are skipped (not duplicated)
+
+## Technical Notes
+- Implement in `crates/hive-server/src/agents.rs`
+- Provisioning job state is tracked in SQLite: `provision_jobs` table with `id`, `workspace_id`, `manifest_id`, `status`, `created_at`; individual agent results in `provision_job_agents`
+- Uses the same `provision_agent_workspace` + `spawn` logic from US-BE-012/US-BE-016
+- `tokio::spawn` one task per agent; collect results via `futures::future::join_all`
+- Job ID is a UUID; the `GET` poll endpoint is the only status mechanism (no SSE/WebSocket for provisioning in Phase 3)
+
+## Phase
+Phase 3 (Workspaces + Teams)

--- a/docs/prd/hive/stories/backend/US-BE-021-cross-room-timeline.md
+++ b/docs/prd/hive/stories/backend/US-BE-021-cross-room-timeline.md
@@ -1,0 +1,23 @@
+# US-BE-021: Cross-room timeline
+
+**As a** workspace owner
+**I want to** fetch a unified timeline of messages from all rooms in a workspace
+**So that** I can see a chronological view of all activity without switching between rooms
+
+## Acceptance Criteria
+- [ ] `GET /api/workspaces/:id/timeline` returns a JSON array of messages from all rooms in the workspace, sorted by `ts` ascending
+- [ ] Each message includes a `room_id` field identifying its source room
+- [ ] Supports `?limit=N` (default 100, max 1000) and `?before=<ts>` (ISO 8601) cursor for pagination
+- [ ] If a room in the workspace is unavailable, its messages are omitted and a `"warnings": [{"room_id": "...", "error": "..."}]` field is included in the response
+- [ ] Empty workspaces (no rooms) return `{"messages": [], "warnings": []}`
+- [ ] Returns `404 Not Found` if the workspace does not exist or the caller does not have access
+
+## Technical Notes
+- Implement in `crates/hive-server/src/workspaces.rs`
+- Fetch message history from each room in parallel using `tokio::spawn` + `join_all`; each fetch calls the daemon's history endpoint (US-BE-006 logic re-used)
+- Merge step: collect all messages into a `Vec<MessageSummary>`, sort by `ts` (parse as `DateTime<Utc>`), apply `limit` after sort
+- `before=<ts>` filtering: after the sort, drop all messages with `ts >= before`, then take the last `limit` entries (equivalent to "messages before this timestamp")
+- The total fetch per room is capped at `limit * room_count` to avoid fetching unbounded history; this is a best-effort approximation
+
+## Phase
+Phase 3 (Workspaces + Teams)

--- a/docs/prd/hive/stories/backend/US-BE-022-team-roster-management.md
+++ b/docs/prd/hive/stories/backend/US-BE-022-team-roster-management.md
@@ -1,0 +1,24 @@
+# US-BE-022: Team roster management
+
+**As a** workspace owner
+**I want to** add and remove human users from a workspace team
+**So that** I can control who has access to the workspace and its rooms
+
+## Acceptance Criteria
+- [ ] `POST /api/workspaces/:id/members` with `{"user_id": "..."}` adds the user to the workspace team; returns `201 Created`
+- [ ] `DELETE /api/workspaces/:id/members/:user_id` removes the user; returns `204 No Content`
+- [ ] `GET /api/workspaces/:id/members` returns the list of team members with `id`, `github_login`, `email`, `role` (`owner|member`), `joined_at`
+- [ ] The workspace owner cannot remove themselves; attempting to do so returns `422 Unprocessable Entity` with `{"error": "cannot_remove_owner"}`
+- [ ] Adding a user who is already a member returns `409 Conflict`
+- [ ] Only the workspace owner can add or remove members; `403 Forbidden` otherwise
+- [ ] Members (non-owners) can read workspace resources but cannot modify workspace settings, add rooms, or delete the workspace
+
+## Technical Notes
+- Implement in `crates/hive-server/src/workspaces.rs`
+- `workspace_members` join table: `(workspace_id, user_id, role, joined_at)`; `role` is a TEXT column with values `owner` or `member`
+- Owner is automatically added as a member with `role = 'owner'` on workspace creation
+- Authorization check in the auth middleware: extract workspace membership from SQLite for every request matching `/api/workspaces/:id/*`; inject a `WorkspaceMembership` extension
+- User lookup for `POST` uses `users.id`; non-existent users return `404 Not Found`
+
+## Phase
+Phase 3 (Workspaces + Teams)

--- a/docs/prd/hive/stories/backend/US-BE-023-sqlite-database-setup.md
+++ b/docs/prd/hive/stories/backend/US-BE-023-sqlite-database-setup.md
@@ -1,0 +1,33 @@
+# US-BE-023: SQLite database setup
+
+**As a** Hive server
+**I want to** initialise and migrate the SQLite database schema on startup
+**So that** Hive-owned state (users, workspaces, teams, agents) is persisted across restarts without manual setup
+
+## Acceptance Criteria
+- [ ] On startup, the server creates the SQLite database file at `config.data_dir/hive.db` if it does not exist
+- [ ] Schema migrations are run automatically using an embedded migration runner; the server does not start if migrations fail
+- [ ] Migrations are versioned and applied in order; already-applied migrations are skipped
+- [ ] Schema includes all tables required by other stories: `users`, `api_keys`, `workspaces`, `workspace_rooms`, `workspace_members`, `team_manifests`, `agents`, `provision_jobs`, `provision_job_agents`
+- [ ] Foreign key constraints are enabled per connection: `PRAGMA foreign_keys = ON`
+- [ ] WAL mode is enabled: `PRAGMA journal_mode = WAL` for concurrent read performance
+- [ ] The database file is created with permissions `0600`
+
+## Technical Notes
+- Implement in `crates/hive-server/src/db.rs`
+- Use `rusqlite` with `bundled` feature to avoid a system SQLite dependency
+- Migration runner: embed SQL files as strings via `include_str!` macros; track applied migrations in a `_migrations(version INT, applied_at TEXT)` table created on first run
+- Full schema:
+  - `users(id TEXT PK, github_id INT UNIQUE, github_login TEXT, email TEXT, room_token TEXT, created_at TEXT)`
+  - `api_keys(id TEXT PK, user_id TEXT FK, key_hash TEXT UNIQUE, scopes TEXT, created_at TEXT, revoked_at TEXT)`
+  - `workspaces(id TEXT PK, name TEXT, owner_id TEXT FK, created_at TEXT)`
+  - `workspace_rooms(workspace_id TEXT FK, room_id TEXT, PRIMARY KEY(workspace_id, room_id))`
+  - `workspace_members(workspace_id TEXT FK, user_id TEXT FK, role TEXT, joined_at TEXT, PRIMARY KEY(workspace_id, user_id))`
+  - `team_manifests(id TEXT PK, workspace_id TEXT FK, name TEXT, manifest_json TEXT, created_at TEXT)`
+  - `agents(id TEXT PK, workspace_id TEXT FK, room_id TEXT, personality TEXT, model TEXT, status TEXT, pid INT, started_at TEXT, stopped_at TEXT, log_path TEXT)`
+  - `provision_jobs(id TEXT PK, workspace_id TEXT FK, manifest_id TEXT FK, status TEXT, created_at TEXT)`
+  - `provision_job_agents(job_id TEXT FK, agent_id TEXT FK, status TEXT, error TEXT)`
+- A `DbPool` wrapper holds a `Mutex<Connection>` for single-writer access; for Phase 3 upgrade to `r2d2` connection pool if contention becomes an issue
+
+## Phase
+Cross-cutting

--- a/docs/prd/hive/stories/backend/US-BE-024-error-handling.md
+++ b/docs/prd/hive/stories/backend/US-BE-024-error-handling.md
@@ -1,0 +1,24 @@
+# US-BE-024: Error handling
+
+**As a** Hive frontend developer
+**I want to** receive structured JSON error responses from all API endpoints
+**So that** I can display meaningful error messages to users and handle errors programmatically
+
+## Acceptance Criteria
+- [ ] All error responses return a JSON body with at minimum `{"error": "<snake_case_code>", "message": "<human readable>"}` and the appropriate HTTP status code
+- [ ] Validation errors include a `"fields"` array: `[{"field": "name", "message": "must not be empty"}]`
+- [ ] Unhandled panics are caught and return `500 Internal Server Error` with `{"error": "internal_error"}` (no stack trace in response)
+- [ ] `404` responses for unknown routes return `{"error": "not_found"}` rather than axum's default plain-text response
+- [ ] `405 Method Not Allowed` returns `{"error": "method_not_allowed"}`
+- [ ] Every error response includes a `"request_id"` field matching the `X-Hive-Request-ID` header (see US-BE-025)
+- [ ] Error codes are documented in a `docs/hive-server/errors.md` reference
+
+## Technical Notes
+- Implement as an axum `IntoResponse` impl on a central `AppError` enum in `crates/hive-server/src/error.rs`
+- `AppError` variants map to HTTP status codes: `NotFound` → 404, `Forbidden` → 403, `Conflict` → 409, `Validation` → 400/422, `DaemonUnavailable` → 502, `Internal` → 500
+- Use axum's `HandleErrorLayer` for panic catching via `tower::ServiceBuilder`
+- Custom 404/405 handlers registered via `axum::Router::fallback` and method routing
+- The `"request_id"` field is injected by the logging middleware (US-BE-025) which stores the ID in a `RequestId` extension; `AppError::into_response` reads it from the extensions
+
+## Phase
+Cross-cutting

--- a/docs/prd/hive/stories/backend/US-BE-025-logging.md
+++ b/docs/prd/hive/stories/backend/US-BE-025-logging.md
@@ -1,0 +1,23 @@
+# US-BE-025: Logging
+
+**As a** platform operator
+**I want to** see structured, machine-readable logs with request IDs for every HTTP request
+**So that** I can trace requests through the system and diagnose issues in production
+
+## Acceptance Criteria
+- [ ] Every incoming HTTP request is assigned a unique `request_id` (UUID v4) injected as `X-Hive-Request-ID` in both the request (for upstream propagation) and response headers
+- [ ] A structured log line is emitted for every request including: `request_id`, `method`, `path`, `status`, `duration_ms`, `user_id` (if authenticated)
+- [ ] Log output is NDJSON (one JSON object per line) when `HIVE_LOG_FORMAT=json`; human-readable when `HIVE_LOG_FORMAT=text` (default for development)
+- [ ] Log level is controlled by `HIVE_LOG` env var (e.g. `HIVE_LOG=hive_server=debug,info`); default is `info`
+- [ ] Sensitive fields (`Authorization` header value, raw API keys) are never logged
+- [ ] Spans are used for async operations so that child tasks' logs are correlated to the parent request
+
+## Technical Notes
+- Implement using `tracing` + `tracing-subscriber` crates
+- Request ID middleware: a `tower` layer that generates the UUID, inserts it as a `RequestId` extension on the `Request`, and appends it to the response headers
+- Use `tracing_subscriber::fmt` with a JSON formatter for `HIVE_LOG_FORMAT=json` and the default pretty formatter otherwise; switch at startup based on env var
+- `tracing::instrument` on handler functions to create per-request spans; include `request_id` as a span field
+- `tower_http::trace::TraceLayer` provides the per-request log line with status and duration; configure it to use the `tracing` backend
+
+## Phase
+Cross-cutting

--- a/docs/prd/hive/stories/backend/US-BE-026-graceful-shutdown.md
+++ b/docs/prd/hive/stories/backend/US-BE-026-graceful-shutdown.md
@@ -1,0 +1,25 @@
+# US-BE-026: Graceful shutdown
+
+**As a** platform operator
+**I want to** shut down the Hive server cleanly on SIGTERM or SIGINT
+**So that** in-flight requests complete, agents receive stop signals, and WebSocket connections are closed without data loss
+
+## Acceptance Criteria
+- [ ] On SIGTERM or SIGINT, the server stops accepting new connections immediately
+- [ ] In-flight HTTP requests are given up to 30 seconds to complete before the process exits; configurable via `shutdown_timeout_secs` in `hive.toml`
+- [ ] All active WebSocket relay sessions (US-BE-003) receive a Close frame before the server exits
+- [ ] All running agents (US-BE-012) receive SIGTERM on server shutdown; the server waits up to `agent_stop_timeout_secs` (default 10s) for them to exit before sending SIGKILL
+- [ ] SQLite WAL is checkpointed before process exit to ensure data is not lost
+- [ ] A log line at `INFO` level is emitted at shutdown start, and at `INFO` level again when shutdown is complete
+- [ ] If the shutdown timeout is exceeded, the process exits with code 1; otherwise exits with code 0
+
+## Technical Notes
+- Implement in `crates/hive-server/src/main.rs`
+- Use `tokio::signal::ctrl_c()` and `tokio::signal::unix::signal(SignalKind::terminate())` for signal handling; race them with `tokio::select!`
+- Axum graceful shutdown: pass a shutdown future to `axum::serve(...).with_graceful_shutdown(shutdown_rx)`
+- WebSocket close: broadcast a cancellation token to all relay tasks (stored in the `AppState`); each relay task catches the cancellation and sends a WS Close frame
+- Agent shutdown: iterate the in-memory `AgentRegistry`, call the same SIGTERM + wait + SIGKILL sequence as US-BE-013
+- SQLite checkpoint: call `PRAGMA wal_checkpoint(TRUNCATE)` on the connection before dropping it
+
+## Phase
+Cross-cutting


### PR DESCRIPTION
## Summary

26 backend user stories breaking down prd-hive-server.md into implementable units. One file per story in docs/prd/hive/stories/backend/.

### Phase 1 — Skeleton + Room Proxy (7 stories)
US-BE-001 through US-BE-007: health endpoint, config loading, WS relay, REST proxy, room list/messages/send

### Phase 2 — Auth + Agent Management (9 stories)
US-BE-008 through US-BE-016: GitHub OAuth, JWT sessions, API keys, token mapping, agent spawn/stop/list/logs, workspace provisioning

### Phase 3 — Workspaces + Teams (6 stories)
US-BE-017 through US-BE-022: workspace CRUD, room membership, team manifests, batch provisioning, cross-room timeline, roster management

### Cross-cutting (4 stories)
US-BE-023 through US-BE-026: SQLite setup, error handling, logging, graceful shutdown

Each story includes: role/want/benefit, acceptance criteria, technical notes, phase reference.