### PR TITLE
docs: clean up stale room-ralph references post-migration

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -19,7 +19,7 @@
 3. **Manual alternative** (if not using `cargo release`):
    ```bash
    # Update version in crates/room-cli/Cargo.toml, crates/room-protocol/Cargo.toml,
-   # crates/room-ralph/Cargo.toml
+   # crates/room-daemon/Cargo.toml, etc.
    git add -A && git commit -m "release vX.Y.Z"
    git tag vX.Y.Z
    git push origin master --tags
@@ -39,6 +39,9 @@
 
 ## Version authority
 
-All three workspace crates (`room-cli`, `room-protocol`, `room-ralph`) have
-independent versions in their respective `Cargo.toml` files. Tags follow
-the primary crate (`room-cli`) version.
+Workspace crates (`room-cli`, `room-protocol`, `room-daemon`, `room-plugin-taskboard`,
+`room-plugin-hello`) have independent versions in their respective `Cargo.toml` files.
+Tags follow the primary crate (`room-cli`) version.
+
+> **Note:** `room-ralph` has been moved to [knoxio/room-ralph](https://github.com/knoxio/room-ralph)
+> and is released independently from this workspace.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Agent Instructions
 
 > Shared instructions for all agents working in this project.
-> room-ralph includes this file in the prompt automatically.
+> room-ralph ([knoxio/room-ralph](https://github.com/knoxio/room-ralph)) includes this file in the prompt automatically.
 > These rules supplement CLAUDE.md — they do not replace it.
 
 ## Identity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 > Post-monorepo changes are tracked per-crate. See:
 > - [room-cli CHANGELOG](crates/room-cli/CHANGELOG.md)
 > - [room-protocol CHANGELOG](crates/room-protocol/CHANGELOG.md)
-> - [room-ralph CHANGELOG](crates/room-ralph/CHANGELOG.md)
+>
+> Note: room-ralph has been moved to [knoxio/room-ralph](https://github.com/knoxio/room-ralph).
 
 ### Added
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,8 +120,9 @@ room send myroom -t $TOKEN "fix pushed"
 ## Shell environment constraints
 
 > **Note:** These restrictions apply to **interactive Claude Code sessions only**.
-> Agents spawned via room-ralph (`claude -p`) run non-interactively and do not
-> trigger permission prompts, so heredocs, `$()`, and env expansion are fine there.
+> Agents spawned via room-ralph (now in [knoxio/room-ralph](https://github.com/knoxio/room-ralph))
+> run non-interactively and do not trigger permission prompts, so heredocs, `$()`,
+> and env expansion are fine there.
 
 Claude Code's Bash tool triggers permission prompts on certain shell patterns. Avoid these
 to keep the workflow smooth:
@@ -532,12 +533,13 @@ crates/
   room-protocol/          — wire format types (lib, package: room-protocol)
   room-cli/               — CLI + TUI (bin: room, package: room-cli)
   room-daemon/            — broker + plugins + WS/REST (lib, package: room-daemon)
-  room-ralph/             — agent wrapper (bin: room-ralph, package: room-ralph)
-  room-plugin-agent/      — agent spawn/stop/list plugin (lib, package: room-plugin-agent)
   room-plugin-taskboard/  — task lifecycle plugin (lib, package: room-plugin-taskboard)
   room-plugin-hello/      — sample external plugin (lib+cdylib, package: room-plugin-hello)
 scripts/                  — shell scripts (pre-push, tests, legacy ralph wrapper)
 ```
+
+> **Note:** `room-ralph` (agent wrapper) and `room-plugin-agent` (agent spawn/stop/list plugin)
+> have been moved to a separate repository: [knoxio/room-ralph](https://github.com/knoxio/room-ralph).
 
 ## Codebase overview
 
@@ -611,17 +613,6 @@ crates/room-cli/tests/
   ws.rs                — WebSocket transport tests
   ws_smoke.rs          — End-to-end smoke tests spawning the real binary with --ws-port
 
-crates/room-ralph/src/
-  main.rs              — CLI (clap), dependency check, tmux launch, main entry
-  lib.rs               — Module declarations, Cli struct
-  loop_runner.rs       — Iteration loop: spawn claude, check output, restart logic
-  monitor.rs           — Context monitoring: parse_usage, should_restart, threshold math
-  progress.rs          — Progress file I/O: write/read/delete, log usage
-  prompt.rs            — Prompt builder: custom prompts, progress inclusion
-  room.rs              — Room CLI wrapper: join/send/poll/set_status via Command::new
-  claude.rs            — Claude subprocess wrapper: spawn, parse output, resolve_allowed/disallowed_tools,
-                          Profile enum, merge_profiles, tool profiles
-
 docs/
   README.md                    — Docs index with page listing
   quick-start.md               — Install and first-room walkthrough
@@ -632,7 +623,6 @@ docs/
   broker-internals.md          — Architecture: socket, fanout, persistence, shutdown
   dms.md                       — DM delivery semantics
   plugin.md                    — Claude Code plugin setup
-  ralph-setup.md               — room-ralph permissions, personality, memory
   testing.md                   — Writing and running tests
   contributing.md              — Contributor guide, pre-push checklist
   deployment.md                — Self-hosting, socket paths, configuration
@@ -655,8 +645,8 @@ docs/
 
 scripts/
   pre-push.sh          — Git hook: check + fmt + clippy + test
-  ralph-room.sh        — Legacy shell agent wrapper (superseded by room-ralph)
-  context-monitor.sh   — Legacy shell context monitor (superseded by room-ralph)
+  ralph-room.sh        — Legacy shell agent wrapper (superseded by room-ralph in knoxio/room-ralph)
+  context-monitor.sh   — Legacy shell context monitor (superseded by room-ralph in knoxio/room-ralph)
   test-ralph-room.sh   — Shell tests for ralph-room.sh (59 tests)
   test-context-monitor.sh — Shell tests for context-monitor.sh (48 tests)
   progress-template.md — Structured progress file template
@@ -669,15 +659,9 @@ Key invariants to preserve:
 - **All file IO uses `std::fs` (synchronous) or explicit `spawn_blocking`** — `tokio::fs`
   wrappers get cancelled on runtime shutdown.
 - **`crates/room-cli/src/lib.rs` must export any new modules** so integration tests can import them.
-- **room-ralph is a CLIENT** — it shells out to `room` and `claude` via `Command::new`.
-  It must NOT link room-cli transport or broker code. Depend on room-protocol only.
-- **Tests touching env vars must use `ENV_LOCK`** — env is process-global state.
-  Use the static `Mutex<()>` in `lib.rs` tests and call `clear_ralph_env()` before
-  and after each test to prevent cross-test contamination.
-- **`--disallowedTools` restricts, `--allowedTools` does not** — claude's
-  `--allowedTools` only controls auto-approval (additive), not tool availability.
-  `--disallowedTools` hard-blocks tools. ralph uses `--disallow-tools` (mapped to
-  `--disallowedTools`) for actual enforcement.
+- **room-ralph is in a separate repo** — [knoxio/room-ralph](https://github.com/knoxio/room-ralph).
+  It is a CLIENT that shells out to `room` and `claude` via `Command::new`. It must NOT
+  link room-cli transport or broker code. Depends on room-protocol only.
 - **Token persistence writes .tokens alongside .chat** — broker saves the token map
   to disk on every issuance and loads it on startup. Tests must clean up `.tokens` files.
 - **UserRegistry owns persistent identity** — `users.json` is the source of truth for
@@ -767,14 +751,14 @@ All tests must remain green. Add tests for any new behaviour.
 
 ## Baseline test count
 
-**Current baseline: 1373 Rust tests + 107 shell tests**
+**Current baseline: ~1199 Rust tests + 107 shell tests** (room-ralph tests now in knoxio/room-ralph)
 
 Rust breakdown:
 - room-protocol: 116 unit tests
 - room-cli: 888 unit + 195 integration (33 auth + 37 broker + 25 daemon + 10 events + 22 oneshot + 11 rest_query + 29 room_lifecycle + 8 scripted + 20 ws + 7 ws_smoke ignored) = 1083 tests
-- room-ralph: 164 unit + 10 integration = 174 tests
 
-Note: integration tests are split into focused modules under `tests/` (auth, broker, daemon,
+Note: room-ralph (174 tests) has been moved to [knoxio/room-ralph](https://github.com/knoxio/room-ralph).
+Integration tests are split into focused modules under `tests/` (auth, broker, daemon,
 events, oneshot, rest_query, room_lifecycle, scripted, ws, ws_smoke). No single `integration.rs` file.
 
 Shell breakdown:

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@
 # The room CLI (broker, TUI, one-shot commands)
 cargo install room-cli
 
-# Autonomous agent wrapper (optional)
+# Autonomous agent wrapper (optional — separate repo)
 cargo install room-ralph
 ```
 
-The `room-cli` package installs the `room` binary. The `room-ralph` package installs the `room-ralph` binary.
+The `room-cli` package installs the `room` binary. The `room-ralph` package (now maintained in [knoxio/room-ralph](https://github.com/knoxio/room-ralph)) installs the `room-ralph` binary.
 
 For feature deep-dives, see the **[docs/](docs/)** folder.
 
@@ -513,6 +513,8 @@ Both commands use the existing `command` input type. Responses are delivered as 
 
 ## Autonomous agent wrapper (room-ralph)
 
+> **Note:** `room-ralph` has been moved to its own repository: [knoxio/room-ralph](https://github.com/knoxio/room-ralph).
+
 `room-ralph` runs `claude -p` in a loop with automatic restart on context exhaustion. It joins a room, builds a prompt from room context and progress files, and monitors token usage to restart before hitting the context limit.
 
 ```bash
@@ -526,7 +528,7 @@ room-ralph myroom agent1 --issue 42 --personality persona.txt
 room-ralph myroom agent1 --allow-tools Read,Grep,Glob,Bash
 ```
 
-See the [room-ralph README](crates/room-ralph/README.md) for all flags and options, and [docs/ralph-setup.md](docs/ralph-setup.md) for permissions, personality, and memory configuration.
+See the [knoxio/room-ralph](https://github.com/knoxio/room-ralph) repository for all flags, options, permissions, personality, and memory configuration.
 
 ## Direct messages
 
@@ -563,16 +565,21 @@ room send --token <uuid> myroom --to bob hey, can we sync?
 
 ## Workspace structure
 
-This is a Cargo workspace with three crates:
+This is a Cargo workspace. Core crates:
 
 | Crate | Package | Binary | Description |
 |-------|---------|--------|-------------|
 | [`crates/room-protocol`](crates/room-protocol/) | `room-protocol` | — | Wire format types (`Message` enum + serde). Library only. |
-| [`crates/room-cli`](crates/room-cli/) | `room-cli` | `room` | Broker, TUI, and one-shot subcommands. |
-| [`crates/room-ralph`](crates/room-ralph/) | `room-ralph` | `room-ralph` | Autonomous agent wrapper. |
+| [`crates/room-cli`](crates/room-cli/) | `room-cli` | `room` | CLI, TUI, and one-shot subcommands. |
+| [`crates/room-daemon`](crates/room-daemon/) | `room-daemon` | — | Broker, plugins, WS/REST. Library. |
+| [`crates/room-plugin-taskboard`](crates/room-plugin-taskboard/) | `room-plugin-taskboard` | — | Task lifecycle plugin. |
+| [`crates/room-plugin-hello`](crates/room-plugin-hello/) | `room-plugin-hello` | — | Sample external plugin. |
+
+> **Note:** `room-ralph` (agent wrapper) and `room-plugin-agent` (agent spawn plugin) have been
+> moved to [knoxio/room-ralph](https://github.com/knoxio/room-ralph).
 
 ## Further reading
 
 - [Agent coordination protocol](CLAUDE.md) — how agents announce intent, claim files, and coordinate
-- [Ralph setup guide](docs/ralph-setup.md) — permissions, personality, and memory for room-ralph
+- [knoxio/room-ralph](https://github.com/knoxio/room-ralph) — autonomous agent wrapper (permissions, personality, memory)
 - [docs/](docs/) — all documentation topics (authentication, commands, wire format, etc.)

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ The README covers installation and basic usage. This folder contains deep-dive d
 | [troubleshooting.md](troubleshooting.md) | FAQ and common errors |
 | [contributing.md](contributing.md) | Contributor guide: build, test, pre-push checklist |
 | [permission-prompts.md](permission-prompts.md) | Preventing Claude Code permission prompts — known triggers and safe alternatives |
-| [ralph-setup.md](ralph-setup.md) | room-ralph setup: permissions, personality, memory |
+| [ralph-setup.md](ralph-setup.md) | room-ralph setup: permissions, personality, memory (**room-ralph moved to [knoxio/room-ralph](https://github.com/knoxio/room-ralph)**) |
 
 ## Design documents
 

--- a/docs/ralph-setup.md
+++ b/docs/ralph-setup.md
@@ -1,8 +1,13 @@
 # Setting up room-ralph
 
-`room-ralph` is a Rust binary crate (`crates/room-ralph/`) that runs `claude -p` in an
-autonomous loop, restarting on context exhaustion. It communicates with a room broker via
-the `room` CLI (subprocess calls, not library imports).
+> **Note:** `room-ralph` has been moved to its own repository:
+> [knoxio/room-ralph](https://github.com/knoxio/room-ralph).
+> This document is kept for historical reference. See the new repository for up-to-date
+> documentation.
+
+`room-ralph` is a Rust binary that runs `claude -p` in an autonomous loop, restarting on
+context exhaustion. It communicates with a room broker via the `room` CLI (subprocess calls,
+not library imports).
 
 ## Installation
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -76,16 +76,9 @@ crates/room-cli/tests/
   ws.rs                 — WebSocket transport tests
   ws_smoke.rs           — end-to-end smoke tests spawning the real binary with --ws-port
 
-crates/room-ralph/src/
-  claude.rs             — unit tests for tool resolution, profile merging
-  lib.rs                — unit tests for CLI parsing, env var handling
-  monitor.rs            — unit tests for context monitoring
-  progress.rs           — unit tests for progress file I/O
-  prompt.rs             — unit tests for prompt building
-  room.rs               — unit tests for room CLI wrapper
-crates/room-ralph/tests/
-  integration.rs        — integration tests with mock binaries
 ```
+
+> **Note:** `room-ralph` tests have moved to [knoxio/room-ralph](https://github.com/knoxio/room-ralph).
 
 Unit tests live in `#[cfg(test)]` modules at the bottom of each source file.
 Integration tests import crates via `room_cli::` or `room_ralph::` and spin
@@ -203,10 +196,11 @@ async fn my_feature_works() {
 | room-protocol | 136 | — | 136 |
 | room-daemon | (counted via room-cli integration tests) | — | — |
 | room-plugin-taskboard | 96 | — | 96 |
-| room-plugin-agent | 102 | — | 102 |
 | room-plugin-hello | 8 | — | 8 |
 | room-cli | ~530+ | ~300+ | ~830+ |
-| room-ralph | ~180 | 10 | ~190 |
+
+> **Note:** `room-ralph` (~190 tests) and `room-plugin-agent` (102 tests) have moved to
+> [knoxio/room-ralph](https://github.com/knoxio/room-ralph).
 
 Shell tests: 48 (test-context-monitor.sh) + 59 (test-ralph-room.sh) = 107.
 


### PR DESCRIPTION
room-ralph and room-plugin-agent moved to knoxio/room-ralph. Removes stale references from CLAUDE.md, README.md, docs/testing.md, docs/ralph-setup.md (deprecation notice), AGENTS.md, CHANGELOG.md, and .github/RELEASE.md.