### PR TITLE
ci: remove stale room-ralph references from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,13 +45,10 @@ jobs:
       - name: Stage artifacts
         run: |
           cp target/${{ matrix.target }}/release/room ${{ matrix.artifact }}
-          cp target/${{ matrix.target }}/release/room-ralph room-ralph-${{ matrix.suffix }}
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}
-          path: |
-            ${{ matrix.artifact }}
-            room-ralph-${{ matrix.suffix }}
+          path: ${{ matrix.artifact }}
 
   release:
     name: Publish release
@@ -76,9 +73,6 @@ jobs:
             artifacts/room-macos-arm64
             artifacts/room-macos-x86_64
             artifacts/room-linux-x86_64
-            artifacts/room-ralph-macos-arm64
-            artifacts/room-ralph-macos-x86_64
-            artifacts/room-ralph-linux-x86_64
             artifacts/SHA256SUMS
           generate_release_notes: true
 
@@ -97,11 +91,6 @@ jobs:
         run: cargo publish -p room-protocol --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --allow-dirty
       - name: Wait for crates.io index
         run: sleep 30
-      - name: Publish room-plugin-agent
-        continue-on-error: true
-        run: cargo publish -p room-plugin-agent --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --allow-dirty
-      - name: Wait for crates.io index
-        run: sleep 30
       - name: Publish room-plugin-taskboard
         continue-on-error: true
         run: cargo publish -p room-plugin-taskboard --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --allow-dirty
@@ -117,6 +106,3 @@ jobs:
         run: cargo publish -p room-cli --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --allow-dirty
       - name: Wait for crates.io index
         run: sleep 30
-      - name: Publish room-ralph
-        continue-on-error: true
-        run: cargo publish -p room-ralph --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --allow-dirty


### PR DESCRIPTION
Removes room-ralph and room-plugin-agent from room's release.yml:
- Remove room-ralph binary from build artifacts
- Remove room-ralph-* from GitHub release files
- Remove room-plugin-agent and room-ralph publish steps

These crates now live in knoxio/room-ralph with their own release workflow.