### PR TITLE
feat(hive-server): add hive-server crate with CORS middleware (MH-001)

### DIFF
--- a/crates/hive-server/Cargo.toml
+++ b/crates/hive-server/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "hive-server"
+version = "0.1.0"
+edition = "2021"
+description = "Hive orchestration server — manages rooms, agents, and workspaces"
+license = "MIT"
+repository = "https://github.com/knoxio/hive"
+
+[[bin]]
+name = "hive"
+path = "src/main.rs"
+
+[dependencies]
+axum = { version = "0.8", features = ["ws"] }
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+toml = "0.8"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tokio-tungstenite = "0.28"
+futures-util = "0.3"
+rusqlite = { version = "0.34", features = ["bundled"] }
+reqwest = { version = "0.12", features = ["json"] }
+base64 = "0.22"
+tower = "0.5"
+tower-http = { version = "0.6", features = ["cors"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/hive-server/Dockerfile
+++ b/crates/hive-server/Dockerfile
@@ -1,0 +1,29 @@
+# Multi-stage Rust build for hive-server
+# Uses cargo-chef for dependency caching
+
+FROM rust:1-slim AS chef
+RUN cargo install cargo-chef --locked
+WORKDIR /app
+
+FROM chef AS planner
+COPY Cargo.toml Cargo.lock ./
+COPY crates/ crates/
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+RUN apt-get update && apt-get install -y pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
+COPY --from=planner /app/recipe.json recipe.json
+# Build dependencies (cached unless Cargo.toml/lock changes)
+RUN cargo chef cook --release --recipe-path recipe.json
+# Build application
+COPY Cargo.toml Cargo.lock ./
+COPY crates/ crates/
+RUN cargo build --release --bin hive
+
+FROM debian:bookworm-slim AS runtime
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=builder /app/target/release/hive /usr/local/bin/hive
+EXPOSE 3000
+ENV RUST_LOG=hive=info
+CMD ["hive"]

--- a/crates/hive-server/src/auth.rs
+++ b/crates/hive-server/src/auth.rs
@@ -1,0 +1,192 @@
+use axum::extract::State;
+use axum::http::{header, Request};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use crate::error::HiveError;
+use crate::AppState;
+
+// JWT_SECRET will be used when we switch to HMAC-SHA256 signed tokens.
+// For MVP, tokens are base64-encoded claims (not cryptographically signed).
+
+/// Token response returned by POST /api/auth/token.
+#[derive(Serialize)]
+pub struct TokenResponse {
+    pub token: String,
+    pub token_type: &'static str,
+    pub expires_in: u64,
+}
+
+/// Login request body.
+#[derive(Deserialize)]
+pub struct LoginRequest {
+    pub username: String,
+    pub password: Option<String>,
+    pub api_key: Option<String>,
+}
+
+/// Claims encoded in the JWT.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Claims {
+    pub sub: String,
+    pub exp: u64,
+    pub iat: u64,
+}
+
+/// Issue a JWT token for a user.
+///
+/// POST /api/auth/token
+///
+/// For MVP: accepts any username (no password validation).
+/// Production: validate against user database or OAuth provider.
+pub(crate) async fn issue_token(
+    State(_state): State<Arc<AppState>>,
+    Json(req): Json<LoginRequest>,
+) -> Result<Json<TokenResponse>, HiveError> {
+    if req.username.is_empty() {
+        return Err(HiveError::BadRequest("username is required".into()));
+    }
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let expires_in = 86400; // 24 hours
+
+    let claims = Claims {
+        sub: req.username,
+        exp: now + expires_in,
+        iat: now,
+    };
+
+    // Simple base64-encoded JSON token (not cryptographically secure — MVP only).
+    // Production: use jsonwebtoken crate with HMAC-SHA256.
+    let claims_json = serde_json::to_string(&claims)
+        .map_err(|e| HiveError::Internal(format!("failed to serialize claims: {e}")))?;
+    let token = base64_encode(&claims_json);
+
+    Ok(Json(TokenResponse {
+        token,
+        token_type: "Bearer",
+        expires_in,
+    }))
+}
+
+/// Auth middleware — validates Bearer token on protected routes.
+#[allow(dead_code)]
+pub(crate) async fn auth_middleware(
+    State(_state): State<Arc<AppState>>,
+    request: Request<axum::body::Body>,
+    next: Next,
+) -> Response {
+    let auth_header = request
+        .headers()
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok());
+
+    match auth_header {
+        Some(header) if header.starts_with("Bearer ") => {
+            let token = &header[7..];
+            match validate_token(token) {
+                Ok(_claims) => next.run(request).await,
+                Err(e) => HiveError::Unauthorized(e).into_response(),
+            }
+        }
+        Some(_) => {
+            HiveError::Unauthorized("invalid authorization header format".into()).into_response()
+        }
+        None => {
+            // For MVP: allow unauthenticated access (auth is optional)
+            next.run(request).await
+        }
+    }
+}
+
+/// Validate a token and extract claims.
+#[allow(dead_code)]
+fn validate_token(token: &str) -> Result<Claims, String> {
+    let decoded = base64_decode(token).map_err(|_| "invalid token encoding".to_string())?;
+    let claims: Claims =
+        serde_json::from_str(&decoded).map_err(|_| "invalid token format".to_string())?;
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+
+    if claims.exp < now {
+        return Err("token expired".to_string());
+    }
+
+    Ok(claims)
+}
+
+/// Simple base64 encode (URL-safe, no padding).
+fn base64_encode(input: &str) -> String {
+    use base64::Engine;
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(input.as_bytes())
+}
+
+/// Simple base64 decode (URL-safe, no padding).
+#[allow(dead_code)]
+fn base64_decode(input: &str) -> Result<String, String> {
+    use base64::Engine;
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(input)
+        .map_err(|e| e.to_string())?;
+    String::from_utf8(bytes).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        let input = r#"{"sub":"alice","exp":9999999999,"iat":1000000000}"#;
+        let encoded = base64_encode(input);
+        let decoded = base64_decode(&encoded).unwrap();
+        assert_eq!(input, decoded);
+    }
+
+    #[test]
+    fn validate_valid_token() {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let claims = Claims {
+            sub: "test-user".into(),
+            exp: now + 3600,
+            iat: now,
+        };
+        let json = serde_json::to_string(&claims).unwrap();
+        let token = base64_encode(&json);
+        let result = validate_token(&token);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().sub, "test-user");
+    }
+
+    #[test]
+    fn validate_expired_token() {
+        let claims = Claims {
+            sub: "test-user".into(),
+            exp: 1000000000, // way in the past
+            iat: 999999999,
+        };
+        let json = serde_json::to_string(&claims).unwrap();
+        let token = base64_encode(&json);
+        let result = validate_token(&token);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("expired"));
+    }
+
+    #[test]
+    fn validate_invalid_token() {
+        let result = validate_token("not-a-valid-token!!!");
+        assert!(result.is_err());
+    }
+}

--- a/crates/hive-server/src/config.rs
+++ b/crates/hive-server/src/config.rs
@@ -1,0 +1,99 @@
+//! Hive server configuration.
+//!
+//! Loaded from `hive.toml` (or path specified via `--config`). Falls back to
+//! sensible defaults when the file is missing.
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+/// Top-level Hive server configuration.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct HiveConfig {
+    /// HTTP server settings.
+    pub server: ServerConfig,
+    /// Room daemon connection settings.
+    pub daemon: DaemonConfig,
+}
+
+/// HTTP server bind configuration.
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct ServerConfig {
+    /// Address to bind the HTTP server to.
+    pub host: String,
+    /// Port for the HTTP server.
+    pub port: u16,
+    /// Directory for persistent data (SQLite database, etc.).
+    pub data_dir: String,
+    /// Allowed CORS origins. Overridden by `HIVE_CORS_ORIGINS` (comma-separated).
+    /// Defaults to `["http://localhost:5173"]`.
+    pub cors_origins: Vec<String>,
+}
+
+/// Room daemon connection configuration.
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct DaemonConfig {
+    /// Path to the room daemon Unix socket.
+    pub socket_path: PathBuf,
+    /// WebSocket URL of the room daemon (e.g. ws://127.0.0.1:4200).
+    pub ws_url: String,
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        let host = std::env::var("HIVE_HOST").unwrap_or_else(|_| "127.0.0.1".to_owned());
+        let port = std::env::var("HIVE_PORT")
+            .ok()
+            .and_then(|p| p.parse().ok())
+            .unwrap_or(3000);
+        let data_dir = std::env::var("HIVE_DATA_DIR").unwrap_or_else(|_| {
+            let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_owned());
+            format!("{home}/.hive/data")
+        });
+        let cors_origins = std::env::var("HIVE_CORS_ORIGINS")
+            .map(|s| s.split(',').map(|o| o.trim().to_owned()).collect())
+            .unwrap_or_else(|_| vec!["http://localhost:5173".to_owned()]);
+        Self {
+            host,
+            port,
+            data_dir,
+            cors_origins,
+        }
+    }
+}
+
+/// Returns `true` when `HIVE_ENV=production` is set.
+pub fn is_production() -> bool {
+    std::env::var("HIVE_ENV")
+        .map(|v| v == "production")
+        .unwrap_or(false)
+}
+
+impl Default for DaemonConfig {
+    fn default() -> Self {
+        Self {
+            socket_path: PathBuf::from("/tmp/roomd.sock"),
+            ws_url: "ws://127.0.0.1:4200".to_owned(),
+        }
+    }
+}
+
+/// Load configuration from a TOML file, falling back to defaults.
+pub fn load_config(path: &Path) -> HiveConfig {
+    match std::fs::read_to_string(path) {
+        Ok(content) => toml::from_str(&content).unwrap_or_else(|e| {
+            eprintln!(
+                "[hive] warning: invalid config {}: {e} — using defaults",
+                path.display()
+            );
+            HiveConfig::default()
+        }),
+        Err(_) => {
+            eprintln!("[hive] no config at {} — using defaults", path.display());
+            HiveConfig::default()
+        }
+    }
+}

--- a/crates/hive-server/src/daemon.rs
+++ b/crates/hive-server/src/daemon.rs
@@ -1,0 +1,102 @@
+//! WebSocket connection to the room daemon.
+//!
+//! Manages the upstream connection from hive-server to the co-located room
+//! daemon. Handles connection, keepalive config, and exponential backoff
+//! reconnection.
+
+use std::time::Duration;
+
+use futures_util::StreamExt;
+use tokio_tungstenite::{connect_async, tungstenite::Message as WsMessage};
+
+/// Configuration for connecting to the room daemon.
+#[derive(Debug, Clone)]
+pub struct DaemonWsConfig {
+    /// Base WebSocket URL (e.g. `ws://127.0.0.1:4200`).
+    pub ws_url: String,
+    /// Keepalive ping interval.
+    pub ping_interval: Duration,
+    /// Maximum reconnection backoff.
+    pub max_backoff: Duration,
+}
+
+impl Default for DaemonWsConfig {
+    fn default() -> Self {
+        Self {
+            ws_url: "ws://127.0.0.1:4200".to_owned(),
+            ping_interval: Duration::from_secs(30),
+            max_backoff: Duration::from_secs(30),
+        }
+    }
+}
+
+/// Connect to the room daemon's WebSocket endpoint for a specific room.
+///
+/// Returns the split (sink, stream) on success, or an error string.
+pub async fn connect_to_room(
+    config: &DaemonWsConfig,
+    room_id: &str,
+) -> Result<
+    (
+        futures_util::stream::SplitSink<
+            tokio_tungstenite::WebSocketStream<
+                tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+            >,
+            WsMessage,
+        >,
+        futures_util::stream::SplitStream<
+            tokio_tungstenite::WebSocketStream<
+                tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+            >,
+        >,
+    ),
+    String,
+> {
+    let url = format!("{}/ws/{}", config.ws_url, room_id);
+    tracing::info!("connecting to room daemon at {url}");
+
+    let connect_timeout = Duration::from_secs(5);
+    let (ws_stream, _) = tokio::time::timeout(connect_timeout, connect_async(&url))
+        .await
+        .map_err(|_| format!("connection to daemon timed out after {connect_timeout:?}"))?
+        .map_err(|e| format!("failed to connect to daemon: {e}"))?;
+
+    tracing::info!("connected to room daemon for room {room_id}");
+    Ok(ws_stream.split())
+}
+
+/// Calculate exponential backoff delay for reconnection attempts.
+pub fn backoff_delay(attempt: u32, max: Duration) -> Duration {
+    let secs = 1u64 << attempt.min(63);
+    Duration::from_secs(secs).min(max)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backoff_increases_exponentially() {
+        let max = Duration::from_secs(30);
+        assert_eq!(backoff_delay(0, max), Duration::from_secs(1));
+        assert_eq!(backoff_delay(1, max), Duration::from_secs(2));
+        assert_eq!(backoff_delay(2, max), Duration::from_secs(4));
+        assert_eq!(backoff_delay(3, max), Duration::from_secs(8));
+        assert_eq!(backoff_delay(4, max), Duration::from_secs(16));
+    }
+
+    #[test]
+    fn backoff_caps_at_max() {
+        let max = Duration::from_secs(30);
+        assert_eq!(backoff_delay(5, max), Duration::from_secs(30));
+        assert_eq!(backoff_delay(10, max), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn default_config_values() {
+        let config = DaemonWsConfig::default();
+        assert_eq!(config.ws_url, "ws://127.0.0.1:4200");
+        assert_eq!(config.ping_interval, Duration::from_secs(30));
+        assert_eq!(config.max_backoff, Duration::from_secs(30));
+    }
+}

--- a/crates/hive-server/src/db.rs
+++ b/crates/hive-server/src/db.rs
@@ -1,0 +1,332 @@
+//! SQLite database setup and migration for Hive.
+//!
+//! Manages the Hive-specific state: users, workspaces, workspace-room
+//! mappings, API keys, and team manifests. Room-side data (messages,
+//! tokens, subscriptions) remains in room's own storage.
+
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use rusqlite::Connection;
+
+/// Schema version — bump when adding new migrations.
+const SCHEMA_VERSION: i64 = 1;
+
+/// SQL statements for schema v1.
+const SCHEMA_V1: &str = r#"
+CREATE TABLE IF NOT EXISTS users (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    provider    TEXT NOT NULL,
+    provider_id TEXT NOT NULL,
+    email       TEXT,
+    display_name TEXT,
+    room_token  TEXT,
+    created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(provider, provider_id)
+);
+
+CREATE TABLE IF NOT EXISTS workspaces (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    name        TEXT NOT NULL,
+    owner_id    INTEGER NOT NULL REFERENCES users(id),
+    created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS workspace_rooms (
+    workspace_id INTEGER NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    room_id      TEXT NOT NULL,
+    added_at     TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (workspace_id, room_id)
+);
+
+CREATE TABLE IF NOT EXISTS api_keys (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    key_hash    TEXT NOT NULL UNIQUE,
+    label       TEXT,
+    scopes      TEXT NOT NULL DEFAULT '*',
+    created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    expires_at  TEXT
+);
+
+CREATE TABLE IF NOT EXISTS team_manifests (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    workspace_id  INTEGER NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    name          TEXT NOT NULL,
+    manifest_json TEXT NOT NULL,
+    created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+"#;
+
+/// Thread-safe database handle.
+///
+/// Uses a `Mutex<Connection>` for synchronous SQLite access from async
+/// handlers via `spawn_blocking`. SQLite in WAL mode supports concurrent
+/// readers but single writer — the mutex serializes writes.
+#[derive(Clone)]
+pub struct Database {
+    conn: Arc<Mutex<Connection>>,
+}
+
+impl Database {
+    /// Open (or create) the database at `path` and run migrations.
+    pub fn open(path: &Path) -> Result<Self, rusqlite::Error> {
+        let conn = Connection::open(path)?;
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
+
+        let db = Self {
+            conn: Arc::new(Mutex::new(conn)),
+        };
+        db.migrate()?;
+        Ok(db)
+    }
+
+    /// Open an in-memory database (for tests).
+    pub fn open_memory() -> Result<Self, rusqlite::Error> {
+        let conn = Connection::open_in_memory()?;
+        conn.execute_batch("PRAGMA foreign_keys=ON;")?;
+
+        let db = Self {
+            conn: Arc::new(Mutex::new(conn)),
+        };
+        db.migrate()?;
+        Ok(db)
+    }
+
+    /// Run schema migrations up to `SCHEMA_VERSION`.
+    fn migrate(&self) -> Result<(), rusqlite::Error> {
+        let conn = self.conn.lock().expect("db lock poisoned");
+
+        // Create migration tracking table
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS _migrations (
+                version INTEGER PRIMARY KEY,
+                applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+            )",
+        )?;
+
+        let current: i64 = conn
+            .query_row(
+                "SELECT COALESCE(MAX(version), 0) FROM _migrations",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap_or(0);
+
+        if current < 1 {
+            conn.execute_batch(SCHEMA_V1)?;
+            conn.execute("INSERT INTO _migrations (version) VALUES (1)", [])?;
+            tracing::info!("database migrated to schema v1");
+        }
+
+        let final_version: i64 = conn.query_row(
+            "SELECT COALESCE(MAX(version), 0) FROM _migrations",
+            [],
+            |row| row.get(0),
+        )?;
+        tracing::info!("database schema at v{final_version} (target: v{SCHEMA_VERSION})");
+
+        Ok(())
+    }
+
+    /// Execute a closure with the database connection.
+    ///
+    /// Callers should keep the closure short to avoid holding the mutex.
+    pub fn with_conn<F, T>(&self, f: F) -> Result<T, rusqlite::Error>
+    where
+        F: FnOnce(&Connection) -> Result<T, rusqlite::Error>,
+    {
+        let conn = self.conn.lock().expect("db lock poisoned");
+        f(&conn)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_memory_creates_tables() {
+        let db = Database::open_memory().unwrap();
+        db.with_conn(|conn| {
+            let mut stmt =
+                conn.prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")?;
+            let names: Vec<String> = stmt
+                .query_map([], |row| row.get(0))?
+                .collect::<Result<Vec<_>, _>>()?;
+            assert!(names.contains(&"users".to_owned()));
+            assert!(names.contains(&"workspaces".to_owned()));
+            assert!(names.contains(&"workspace_rooms".to_owned()));
+            assert!(names.contains(&"api_keys".to_owned()));
+            assert!(names.contains(&"team_manifests".to_owned()));
+            assert!(names.contains(&"_migrations".to_owned()));
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn migration_is_idempotent() {
+        let db = Database::open_memory().unwrap();
+        // Running migrate again should not fail
+        db.migrate().unwrap();
+        db.migrate().unwrap();
+
+        db.with_conn(|conn| {
+            let version: i64 =
+                conn.query_row("SELECT MAX(version) FROM _migrations", [], |row| row.get(0))?;
+            assert_eq!(version, 1);
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn foreign_keys_enforced() {
+        let db = Database::open_memory().unwrap();
+        let result = db.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO workspaces (name, owner_id) VALUES ('test', 999)",
+                [],
+            )
+        });
+        // Should fail — owner_id 999 doesn't exist in users
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn insert_user_and_workspace() {
+        let db = Database::open_memory().unwrap();
+        db.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO users (provider, provider_id, email, display_name) VALUES ('github', '12345', 'test@example.com', 'Test User')",
+                [],
+            )?;
+            let user_id: i64 = conn.query_row(
+                "SELECT id FROM users WHERE provider_id = '12345'",
+                [],
+                |row| row.get(0),
+            )?;
+
+            conn.execute(
+                "INSERT INTO workspaces (name, owner_id) VALUES ('my-workspace', ?1)",
+                [user_id],
+            )?;
+            let ws_name: String = conn.query_row(
+                "SELECT name FROM workspaces WHERE owner_id = ?1",
+                [user_id],
+                |row| row.get(0),
+            )?;
+            assert_eq!(ws_name, "my-workspace");
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn workspace_room_membership() {
+        let db = Database::open_memory().unwrap();
+        db.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO users (provider, provider_id) VALUES ('github', '1')",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO workspaces (name, owner_id) VALUES ('ws', 1)",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO workspace_rooms (workspace_id, room_id) VALUES (1, 'room-dev')",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO workspace_rooms (workspace_id, room_id) VALUES (1, 'room-staging')",
+                [],
+            )?;
+
+            let count: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM workspace_rooms WHERE workspace_id = 1",
+                [],
+                |row| row.get(0),
+            )?;
+            assert_eq!(count, 2);
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn cascade_delete_workspace_removes_rooms() {
+        let db = Database::open_memory().unwrap();
+        db.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO users (provider, provider_id) VALUES ('github', '1')",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO workspaces (name, owner_id) VALUES ('ws', 1)",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO workspace_rooms (workspace_id, room_id) VALUES (1, 'room-a')",
+                [],
+            )?;
+
+            // Delete workspace — should cascade to workspace_rooms
+            conn.execute("DELETE FROM workspaces WHERE id = 1", [])?;
+
+            let count: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM workspace_rooms WHERE workspace_id = 1",
+                [],
+                |row| row.get(0),
+            )?;
+            assert_eq!(count, 0);
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn unique_user_constraint() {
+        let db = Database::open_memory().unwrap();
+        db.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO users (provider, provider_id) VALUES ('github', '1')",
+                [],
+            )?;
+            let result = conn.execute(
+                "INSERT INTO users (provider, provider_id) VALUES ('github', '1')",
+                [],
+            );
+            assert!(result.is_err());
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn open_file_database() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("hive.db");
+        let db = Database::open(&db_path).unwrap();
+
+        db.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO users (provider, provider_id) VALUES ('test', '1')",
+                [],
+            )?;
+            Ok(())
+        })
+        .unwrap();
+
+        // Reopen — data should persist
+        let db2 = Database::open(&db_path).unwrap();
+        db2.with_conn(|conn| {
+            let count: i64 = conn.query_row("SELECT COUNT(*) FROM users", [], |row| row.get(0))?;
+            assert_eq!(count, 1);
+            Ok(())
+        })
+        .unwrap();
+    }
+}

--- a/crates/hive-server/src/error.rs
+++ b/crates/hive-server/src/error.rs
@@ -1,0 +1,193 @@
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde::Serialize;
+
+/// Unified error type for the Hive server.
+///
+/// All handler errors should return `HiveError` — axum's `IntoResponse`
+/// impl converts it to a consistent JSON error response with the
+/// appropriate HTTP status code.
+#[derive(Debug)]
+pub enum HiveError {
+    /// 404 — requested resource does not exist.
+    NotFound(String),
+    /// 400 — client sent an invalid request.
+    BadRequest(String),
+    /// 401 — missing or invalid authentication.
+    Unauthorized(String),
+    /// 403 — authenticated but not permitted.
+    Forbidden(String),
+    /// 409 — conflict (e.g. duplicate agent name).
+    Conflict(String),
+    /// 502 — room daemon is unreachable or returned an error.
+    DaemonUnavailable(String),
+    /// 500 — unexpected internal error.
+    Internal(String),
+}
+
+/// JSON body returned for all error responses.
+#[derive(Serialize)]
+struct ErrorBody {
+    error: ErrorDetail,
+}
+
+#[derive(Serialize)]
+struct ErrorDetail {
+    code: &'static str,
+    message: String,
+}
+
+impl HiveError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            Self::NotFound(_) => StatusCode::NOT_FOUND,
+            Self::BadRequest(_) => StatusCode::BAD_REQUEST,
+            Self::Unauthorized(_) => StatusCode::UNAUTHORIZED,
+            Self::Forbidden(_) => StatusCode::FORBIDDEN,
+            Self::Conflict(_) => StatusCode::CONFLICT,
+            Self::DaemonUnavailable(_) => StatusCode::BAD_GATEWAY,
+            Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+
+    fn error_code(&self) -> &'static str {
+        match self {
+            Self::NotFound(_) => "not_found",
+            Self::BadRequest(_) => "bad_request",
+            Self::Unauthorized(_) => "unauthorized",
+            Self::Forbidden(_) => "forbidden",
+            Self::Conflict(_) => "conflict",
+            Self::DaemonUnavailable(_) => "daemon_unavailable",
+            Self::Internal(_) => "internal_error",
+        }
+    }
+
+    fn message(&self) -> &str {
+        match self {
+            Self::NotFound(m)
+            | Self::BadRequest(m)
+            | Self::Unauthorized(m)
+            | Self::Forbidden(m)
+            | Self::Conflict(m)
+            | Self::DaemonUnavailable(m)
+            | Self::Internal(m) => m,
+        }
+    }
+}
+
+impl IntoResponse for HiveError {
+    fn into_response(self) -> Response {
+        let status = self.status_code();
+        let body = ErrorBody {
+            error: ErrorDetail {
+                code: self.error_code(),
+                message: self.message().to_owned(),
+            },
+        };
+        (status, axum::Json(body)).into_response()
+    }
+}
+
+impl std::fmt::Display for HiveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.error_code(), self.message())
+    }
+}
+
+impl std::error::Error for HiveError {}
+
+/// Convenience type for handler return values.
+pub type HiveResult<T> = Result<T, HiveError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::to_bytes;
+    use axum::response::IntoResponse;
+
+    #[tokio::test]
+    async fn not_found_returns_404() {
+        let err = HiveError::NotFound("workspace not found".into());
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"]["code"], "not_found");
+        assert_eq!(json["error"]["message"], "workspace not found");
+    }
+
+    #[tokio::test]
+    async fn bad_request_returns_400() {
+        let err = HiveError::BadRequest("missing field".into());
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn unauthorized_returns_401() {
+        let err = HiveError::Unauthorized("invalid token".into());
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn forbidden_returns_403() {
+        let err = HiveError::Forbidden("not permitted".into());
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn conflict_returns_409() {
+        let err = HiveError::Conflict("agent already exists".into());
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn daemon_unavailable_returns_502() {
+        let err = HiveError::DaemonUnavailable("connection refused".into());
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+    }
+
+    #[tokio::test]
+    async fn internal_returns_500() {
+        let err = HiveError::Internal("unexpected panic".into());
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[tokio::test]
+    async fn error_body_is_json() {
+        let err = HiveError::NotFound("test".into());
+        let resp = err.into_response();
+        let content_type = resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(
+            content_type.contains("application/json"),
+            "expected JSON content-type, got: {content_type}"
+        );
+    }
+
+    #[test]
+    fn display_includes_code_and_message() {
+        let err = HiveError::BadRequest("oops".into());
+        assert_eq!(err.to_string(), "bad_request: oops");
+    }
+
+    #[test]
+    fn hive_result_ok() {
+        let result: HiveResult<i32> = Ok(42);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn hive_result_err() {
+        let result: HiveResult<i32> = Err(HiveError::Internal("fail".into()));
+        assert!(result.is_err());
+    }
+}

--- a/crates/hive-server/src/main.rs
+++ b/crates/hive-server/src/main.rs
@@ -1,0 +1,373 @@
+pub mod auth;
+mod config;
+pub mod daemon;
+pub mod db;
+pub mod error;
+mod rest_proxy;
+mod ws_relay;
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use axum::{
+    http::{HeaderName, HeaderValue, Method},
+    routing::{get, post},
+    Json, Router,
+};
+use config::HiveConfig;
+use tower_http::cors::{AllowHeaders, AllowMethods, AllowOrigin, CorsLayer};
+
+/// Shared application state.
+struct AppState {
+    config: HiveConfig,
+    #[allow(dead_code)]
+    db: db::Database,
+    start_time: std::time::Instant,
+}
+
+/// Health check response (BE-001).
+#[derive(serde::Serialize)]
+struct HealthResponse {
+    status: &'static str,
+    version: &'static str,
+    uptime_secs: u64,
+    daemon_connected: bool,
+    daemon_url: String,
+}
+
+/// GET /api/health — returns server status, version, uptime, and daemon connection.
+async fn health(state: axum::extract::State<Arc<AppState>>) -> Json<HealthResponse> {
+    let daemon_url = state.config.daemon.ws_url.clone();
+    let base = daemon_url
+        .replace("ws://", "http://")
+        .replace("wss://", "https://");
+    let daemon_connected = reqwest::Client::new()
+        .get(format!("{base}/api/health"))
+        .timeout(std::time::Duration::from_secs(2))
+        .send()
+        .await
+        .is_ok();
+
+    let status = if daemon_connected { "ok" } else { "degraded" };
+
+    Json(HealthResponse {
+        status,
+        version: env!("CARGO_PKG_VERSION"),
+        uptime_secs: state.start_time.elapsed().as_secs(),
+        daemon_connected,
+        daemon_url,
+    })
+}
+
+/// Build a [`CorsLayer`] from a list of allowed origin strings.
+///
+/// Allows `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, and `OPTIONS` methods, with
+/// `Authorization`, `Content-Type`, and `X-Request-ID` headers exposed.
+fn build_cors_layer(origins: &[String]) -> CorsLayer {
+    let allowed: Vec<HeaderValue> = origins
+        .iter()
+        .filter_map(|o| o.parse::<HeaderValue>().ok())
+        .collect();
+
+    CorsLayer::new()
+        .allow_origin(AllowOrigin::list(allowed))
+        .allow_methods(AllowMethods::list([
+            Method::GET,
+            Method::POST,
+            Method::PUT,
+            Method::PATCH,
+            Method::DELETE,
+            Method::OPTIONS,
+        ]))
+        .allow_headers(AllowHeaders::list([
+            HeaderName::from_static("authorization"),
+            HeaderName::from_static("content-type"),
+            HeaderName::from_static("x-request-id"),
+        ]))
+}
+
+#[tokio::main]
+async fn main() {
+    // Logging
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "hive=info".parse().unwrap()),
+        )
+        .init();
+
+    // Config
+    let config_path = std::env::args()
+        .nth(1)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("hive.toml"));
+    let config = config::load_config(&config_path);
+
+    // Database
+    let db_path = PathBuf::from(&config.server.data_dir).join("hive.db");
+    if let Some(parent) = db_path.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            eprintln!(
+                "[hive] error: cannot create data directory {}: {e}\n\
+                 hint: set data_dir in hive.toml or HIVE_DATA_DIR env to a writable path",
+                parent.display()
+            );
+            std::process::exit(1);
+        }
+    }
+    let db = db::Database::open(&db_path).expect("failed to open database");
+    tracing::info!("database opened at {}", db_path.display());
+
+    let bind_addr = format!("{}:{}", config.server.host, config.server.port);
+    tracing::info!("hive-server starting on {bind_addr}");
+
+    // CORS validation: wildcard is forbidden in production.
+    for origin in &config.server.cors_origins {
+        if origin == "*" && config::is_production() {
+            eprintln!(
+                "[hive] error: HIVE_CORS_ORIGINS='*' is forbidden in production (HIVE_ENV=production). \
+                 Set explicit allowed origins."
+            );
+            std::process::exit(1);
+        }
+    }
+    if std::env::var("HIVE_CORS_ORIGINS").is_err() && config::is_production() {
+        tracing::warn!(
+            "HIVE_CORS_ORIGINS is not set; defaulting to http://localhost:5173. \
+             Set HIVE_CORS_ORIGINS explicitly in production."
+        );
+    }
+
+    let cors_layer = build_cors_layer(&config.server.cors_origins);
+
+    let state = Arc::new(AppState {
+        config,
+        db,
+        start_time: std::time::Instant::now(),
+    });
+
+    let app = Router::new()
+        .route("/api/health", get(health))
+        .route("/api/auth/token", post(auth::issue_token))
+        .route("/api/rooms", get(rest_proxy::list_rooms))
+        .route("/api/rooms/{room_id}", get(rest_proxy::get_room))
+        .route(
+            "/api/rooms/{room_id}/messages",
+            get(rest_proxy::get_messages),
+        )
+        .route("/api/rooms/{room_id}/send", post(rest_proxy::send_message))
+        .route("/ws/{room_id}", get(ws_relay::ws_handler))
+        .layer(cors_layer)
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind(&bind_addr)
+        .await
+        .expect("failed to bind");
+
+    tracing::info!("hive-server listening on {bind_addr}");
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await
+        .expect("server error");
+
+    tracing::info!("hive-server shutting down gracefully");
+}
+
+#[cfg(test)]
+mod cors_tests {
+    use super::*;
+    use axum::{body::Body, http::Request, routing::get};
+    use tower::ServiceExt; // for `oneshot`
+
+    /// Minimal router with a single route, wrapped in a CorsLayer built from `origins`.
+    fn test_app(origins: &[&str]) -> Router {
+        let origin_strings: Vec<String> = origins.iter().map(|s| s.to_string()).collect();
+        Router::new()
+            .route("/api/test", get(|| async { "ok" }))
+            .layer(build_cors_layer(&origin_strings))
+    }
+
+    /// Returns the value of an HTTP response header as a String, panicking if absent.
+    fn header_str(resp: &axum::response::Response, name: &str) -> String {
+        resp.headers()
+            .get(name)
+            .unwrap_or_else(|| panic!("expected header {name} to be present"))
+            .to_str()
+            .expect("header value is not valid UTF-8")
+            .to_owned()
+    }
+
+    #[tokio::test]
+    async fn preflight_returns_2xx_with_cors_headers() {
+        let app = test_app(&["http://localhost:5173"]);
+
+        let req = Request::builder()
+            .method("OPTIONS")
+            .uri("/api/test")
+            .header("Origin", "http://localhost:5173")
+            .header("Access-Control-Request-Method", "GET")
+            .header("Access-Control-Request-Headers", "authorization")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+
+        // tower-http CorsLayer returns 200 for preflights (which is spec-compliant —
+        // the CORS spec requires a "successful HTTP response", 200 and 204 are both valid).
+        assert!(
+            resp.status().is_success(),
+            "expected 2xx for preflight, got {}",
+            resp.status()
+        );
+
+        let allow_origin = header_str(&resp, "access-control-allow-origin");
+        assert_eq!(allow_origin, "http://localhost:5173");
+
+        let allow_methods = header_str(&resp, "access-control-allow-methods");
+        for method in &["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"] {
+            assert!(
+                allow_methods.contains(method),
+                "expected {method} in Access-Control-Allow-Methods: {allow_methods}"
+            );
+        }
+
+        let allow_headers = header_str(&resp, "access-control-allow-headers");
+        for header in &["authorization", "content-type", "x-request-id"] {
+            assert!(
+                allow_headers.to_lowercase().contains(header),
+                "expected {header} in Access-Control-Allow-Headers: {allow_headers}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn disallowed_origin_is_rejected() {
+        let app = test_app(&["http://localhost:5173"]);
+
+        let req = Request::builder()
+            .method("OPTIONS")
+            .uri("/api/test")
+            .header("Origin", "http://evil.example.com")
+            .header("Access-Control-Request-Method", "GET")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+
+        // The origin header should not be echoed back.
+        let origin_echo = resp.headers().get("access-control-allow-origin");
+        assert!(
+            origin_echo
+                .map(|v| v != "http://evil.example.com")
+                .unwrap_or(true),
+            "evil.example.com should not be reflected as an allowed origin"
+        );
+    }
+
+    #[tokio::test]
+    async fn non_preflight_request_receives_allow_origin_header() {
+        let app = test_app(&["http://localhost:5173"]);
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/api/test")
+            .header("Origin", "http://localhost:5173")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+
+        assert!(resp.status().is_success());
+        let allow_origin = header_str(&resp, "access-control-allow-origin");
+        assert_eq!(allow_origin, "http://localhost:5173");
+    }
+
+    #[tokio::test]
+    async fn allowed_origin_is_reflected() {
+        let app = test_app(&["http://localhost:5173", "https://app.example.com"]);
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/api/test")
+            .header("Origin", "http://localhost:5173")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        let allow_origin = header_str(&resp, "access-control-allow-origin");
+        assert_eq!(allow_origin, "http://localhost:5173");
+    }
+
+    #[tokio::test]
+    async fn second_allowed_origin_is_reflected() {
+        let app = test_app(&["http://localhost:5173", "https://app.example.com"]);
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/api/test")
+            .header("Origin", "https://app.example.com")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        let allow_origin = header_str(&resp, "access-control-allow-origin");
+        assert_eq!(allow_origin, "https://app.example.com");
+    }
+
+    #[test]
+    fn is_production_false_without_env() {
+        // Don't set HIVE_ENV — should return false.
+        // (This test assumes HIVE_ENV is not set in the test environment.
+        //  If it is, this test will correctly fail, indicating misconfiguration.)
+        if std::env::var("HIVE_ENV").is_ok() {
+            return; // skip: env is externally controlled
+        }
+        assert!(!config::is_production());
+    }
+
+    #[test]
+    fn is_production_true_when_env_set() {
+        // Guard: only assert if we can control the env.
+        // Note: env mutation in parallel tests is unsafe; this is a best-effort check.
+        if std::env::var("HIVE_ENV")
+            .map(|v| v == "production")
+            .unwrap_or(false)
+        {
+            assert!(config::is_production());
+        }
+    }
+
+    #[test]
+    fn default_cors_origins_fallback_to_dev() {
+        if std::env::var("HIVE_CORS_ORIGINS").is_ok() {
+            return; // skip: externally controlled
+        }
+        let config = config::HiveConfig::default();
+        assert_eq!(config.server.cors_origins, vec!["http://localhost:5173"]);
+    }
+}
+
+/// Wait for SIGTERM or SIGINT (Ctrl+C) to initiate graceful shutdown.
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => tracing::info!("received SIGINT, initiating shutdown"),
+        _ = terminate => tracing::info!("received SIGTERM, initiating shutdown"),
+    }
+}

--- a/crates/hive-server/src/rest_proxy.rs
+++ b/crates/hive-server/src/rest_proxy.rs
@@ -1,0 +1,166 @@
+//! REST proxy — forwards API requests to the co-located room daemon.
+//!
+//! Implements BE-004 through BE-007: room list, room info, messages, send.
+//! Forwards Authorization headers from the client to the daemon.
+
+use std::sync::Arc;
+
+use axum::{
+    extract::{Path, State},
+    http::{HeaderMap, StatusCode},
+    Json,
+};
+use serde_json::Value;
+
+use crate::AppState;
+
+/// Extract the daemon REST base URL from config.
+fn daemon_base(state: &AppState) -> String {
+    state
+        .config
+        .daemon
+        .ws_url
+        .replace("ws://", "http://")
+        .replace("wss://", "https://")
+}
+
+/// Build a reqwest client with optional auth header forwarding.
+fn build_request(
+    client: &reqwest::Client,
+    method: reqwest::Method,
+    url: &str,
+    headers: &HeaderMap,
+) -> reqwest::RequestBuilder {
+    let mut req = client.request(method, url);
+    // Forward Authorization header to room daemon
+    if let Some(auth) = headers.get("authorization") {
+        if let Ok(val) = auth.to_str() {
+            req = req.header("Authorization", val);
+        }
+    }
+    req
+}
+
+/// GET /api/rooms — list available rooms from the daemon.
+pub async fn list_rooms(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<Json<Value>, StatusCode> {
+    let base = daemon_base(&state);
+    let client = reqwest::Client::new();
+
+    // Try daemon health endpoint to discover rooms
+    let health_url = format!("{base}/api/health");
+    match build_request(&client, reqwest::Method::GET, &health_url, &headers)
+        .send()
+        .await
+    {
+        Ok(resp) => {
+            let body: Value = resp.json().await.unwrap_or_default();
+            let room = body
+                .get("room")
+                .and_then(|r| r.as_str())
+                .unwrap_or("default");
+            let users = body.get("users").and_then(|u| u.as_u64()).unwrap_or(0);
+            Ok(Json(serde_json::json!({
+                "rooms": [{ "id": room, "name": room, "users": users }],
+                "daemon_connected": true
+            })))
+        }
+        Err(_) => Ok(Json(serde_json::json!({
+            "rooms": [],
+            "daemon_connected": false,
+            "error": "daemon unavailable"
+        }))),
+    }
+}
+
+/// GET /api/rooms/:room_id — get room info.
+pub async fn get_room(
+    State(state): State<Arc<AppState>>,
+    Path(room_id): Path<String>,
+    headers: HeaderMap,
+) -> Result<Json<Value>, StatusCode> {
+    let base = daemon_base(&state);
+    let url = format!("{base}/api/{room_id}/poll");
+
+    let client = reqwest::Client::new();
+    match build_request(&client, reqwest::Method::GET, &url, &headers)
+        .send()
+        .await
+    {
+        Ok(resp) if resp.status().is_success() => Ok(Json(serde_json::json!({
+            "id": room_id,
+            "name": room_id,
+            "status": "active"
+        }))),
+        Ok(resp) => Ok(Json(serde_json::json!({
+            "id": room_id,
+            "name": room_id,
+            "status": "error",
+            "daemon_status": resp.status().as_u16()
+        }))),
+        Err(_) => Ok(Json(serde_json::json!({
+            "id": room_id,
+            "name": room_id,
+            "status": "daemon_unavailable"
+        }))),
+    }
+}
+
+/// GET /api/rooms/:room_id/messages — poll messages from a room.
+pub async fn get_messages(
+    State(state): State<Arc<AppState>>,
+    Path(room_id): Path<String>,
+    headers: HeaderMap,
+) -> Result<Json<Value>, StatusCode> {
+    let base = daemon_base(&state);
+    let url = format!("{base}/api/{room_id}/poll");
+
+    let client = reqwest::Client::new();
+    match build_request(&client, reqwest::Method::GET, &url, &headers)
+        .send()
+        .await
+    {
+        Ok(resp) => {
+            let body: Value = resp
+                .json()
+                .await
+                .unwrap_or(serde_json::json!({"messages": []}));
+            Ok(Json(body))
+        }
+        Err(e) => Ok(Json(serde_json::json!({
+            "messages": [],
+            "error": format!("daemon unavailable: {e}")
+        }))),
+    }
+}
+
+/// POST /api/rooms/:room_id/send — send a message to a room.
+pub async fn send_message(
+    State(state): State<Arc<AppState>>,
+    Path(room_id): Path<String>,
+    headers: HeaderMap,
+    Json(body): Json<Value>,
+) -> Result<Json<Value>, StatusCode> {
+    let base = daemon_base(&state);
+    let url = format!("{base}/api/{room_id}/send");
+
+    let client = reqwest::Client::new();
+    match build_request(&client, reqwest::Method::POST, &url, &headers)
+        .json(&body)
+        .send()
+        .await
+    {
+        Ok(resp) if resp.status().is_success() => {
+            let result: Value = resp.json().await.unwrap_or_default();
+            Ok(Json(result))
+        }
+        Ok(resp) => {
+            let status = resp.status().as_u16();
+            let _error: Value = resp.json().await.unwrap_or_default();
+            Err(StatusCode::from_u16(status).unwrap_or(StatusCode::BAD_GATEWAY))
+        }
+        Err(_) => Err(StatusCode::BAD_GATEWAY),
+    }
+}

--- a/crates/hive-server/src/ws_relay.rs
+++ b/crates/hive-server/src/ws_relay.rs
@@ -1,0 +1,424 @@
+//! WebSocket relay between frontend clients and the room daemon.
+//!
+//! Each frontend WS connection gets paired with an upstream WS connection to
+//! the room daemon. Messages flow bidirectionally:
+//!
+//! ```text
+//! Frontend ←→ Hive WS Relay ←→ Room Daemon
+//! ```
+//!
+//! Features:
+//! - All message types forwarded (Text, Binary, Ping, Pong)
+//! - Keepalive pings sent to daemon on configurable interval
+//! - Automatic reconnection with exponential backoff on upstream failure
+//! - 2-second connection timeout on upstream connects (local network)
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::{
+    extract::{
+        ws::{Message, WebSocket},
+        Path, State, WebSocketUpgrade,
+    },
+    response::IntoResponse,
+};
+use futures_util::{SinkExt, StreamExt};
+use tokio_tungstenite::{connect_async, tungstenite::Message as TungsteniteMsg};
+
+use crate::daemon::{backoff_delay, DaemonWsConfig};
+use crate::AppState;
+
+/// Maximum reconnection attempts before giving up and closing the relay.
+const MAX_RECONNECT_ATTEMPTS: u32 = 5;
+
+/// Connection timeout for upstream daemon WebSocket connections.
+///
+/// Kept short (2s) since the relay connects to a co-located daemon on the
+/// same host or local network. A longer timeout causes Playwright e2e tests
+/// to hang when the daemon is unavailable (see #87).
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Type alias for the daemon WebSocket stream.
+type DaemonStream =
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+
+/// GET /ws/:room_id — upgrade to WebSocket and relay to room daemon.
+pub async fn ws_handler(
+    ws: WebSocketUpgrade,
+    Path(room_id): Path<String>,
+    State(state): State<Arc<AppState>>,
+) -> impl IntoResponse {
+    let daemon_ws_url = format!("{}/ws/{}", state.config.daemon.ws_url, room_id);
+    let ws_config = DaemonWsConfig {
+        ws_url: state.config.daemon.ws_url.clone(),
+        ..DaemonWsConfig::default()
+    };
+    ws.on_upgrade(move |socket| relay(socket, daemon_ws_url, ws_config))
+}
+
+/// Connect to the daemon WebSocket with a timeout.
+async fn connect_with_timeout(url: &str) -> Result<DaemonStream, String> {
+    tokio::time::timeout(CONNECT_TIMEOUT, connect_async(url))
+        .await
+        .map_err(|_| format!("connection timed out after {CONNECT_TIMEOUT:?}"))?
+        .map(|(ws, _)| ws)
+        .map_err(|e| format!("connection failed: {e}"))
+}
+
+/// Convert a tungstenite message to an axum WebSocket message.
+///
+/// Returns `None` for Close and Frame messages, which are handled separately.
+fn tungstenite_to_axum(msg: TungsteniteMsg) -> Option<Message> {
+    match msg {
+        TungsteniteMsg::Text(text) => Some(Message::Text(text.to_string().into())),
+        TungsteniteMsg::Binary(data) => Some(Message::Binary(data.to_vec().into())),
+        TungsteniteMsg::Ping(data) => Some(Message::Ping(data.to_vec().into())),
+        TungsteniteMsg::Pong(data) => Some(Message::Pong(data.to_vec().into())),
+        TungsteniteMsg::Close(_) => None,
+        // Frame is an internal tungstenite type — not forwarded.
+        _ => None,
+    }
+}
+
+/// Convert an axum WebSocket message to a tungstenite message.
+///
+/// Returns `None` for Close messages, which are handled separately.
+fn axum_to_tungstenite(msg: Message) -> Option<TungsteniteMsg> {
+    match msg {
+        Message::Text(text) => Some(TungsteniteMsg::Text(text.to_string().into())),
+        Message::Binary(data) => Some(TungsteniteMsg::Binary(data.to_vec().into())),
+        Message::Ping(data) => Some(TungsteniteMsg::Ping(data.to_vec().into())),
+        Message::Pong(data) => Some(TungsteniteMsg::Pong(data.to_vec().into())),
+        Message::Close(_) => None,
+    }
+}
+
+/// Attempt to reconnect to the daemon with exponential backoff.
+///
+/// If `handshake` is provided, it is replayed after each successful connection
+/// to re-authenticate with the daemon (the first frontend message is typically
+/// a handshake frame).
+///
+/// Returns the reconnected stream on success, or `None` after exhausting attempts.
+async fn try_reconnect(
+    daemon_url: &str,
+    config: &DaemonWsConfig,
+    handshake: Option<&TungsteniteMsg>,
+) -> Option<DaemonStream> {
+    for attempt in 0..MAX_RECONNECT_ATTEMPTS {
+        let delay = backoff_delay(attempt, config.max_backoff);
+        tracing::info!(
+            "reconnecting to daemon (attempt {}/{MAX_RECONNECT_ATTEMPTS}) after {delay:?}: {daemon_url}",
+            attempt + 1,
+        );
+        tokio::time::sleep(delay).await;
+
+        match connect_with_timeout(daemon_url).await {
+            Ok(mut ws) => {
+                if let Some(hs) = handshake {
+                    if ws.send(hs.clone()).await.is_err() {
+                        tracing::warn!("handshake replay failed on attempt {}", attempt + 1);
+                        continue;
+                    }
+                }
+                return Some(ws);
+            }
+            Err(e) => {
+                tracing::warn!("reconnection attempt {} failed: {e}", attempt + 1);
+            }
+        }
+    }
+    tracing::error!("all {MAX_RECONNECT_ATTEMPTS} reconnection attempts failed: {daemon_url}");
+    None
+}
+
+/// Bidirectional relay between a frontend WebSocket and a room daemon WebSocket.
+///
+/// Uses a single `select!` loop to handle:
+/// - Frontend → daemon message forwarding (all types)
+/// - Daemon → frontend message forwarding (all types)
+/// - Periodic keepalive pings to the daemon
+/// - Automatic reconnection when the daemon connection drops
+async fn relay(frontend_ws: WebSocket, daemon_url: String, config: DaemonWsConfig) {
+    // Connect upstream to room daemon with timeout.
+    let upstream = match connect_with_timeout(&daemon_url).await {
+        Ok(ws) => ws,
+        Err(e) => {
+            tracing::error!("failed to connect to room daemon at {daemon_url}: {e}");
+            return;
+        }
+    };
+
+    tracing::info!("relay established: frontend ↔ {daemon_url}");
+
+    let (mut fe_tx, mut fe_rx) = frontend_ws.split();
+    let (mut daemon_tx, mut daemon_rx) = upstream.split();
+
+    let mut ping_interval = tokio::time::interval(config.ping_interval);
+    // Skip the first immediate tick — first ping fires after one full interval.
+    ping_interval.tick().await;
+
+    // Cache the first frontend→daemon message for handshake replay on reconnect.
+    let mut handshake: Option<TungsteniteMsg> = None;
+    let mut is_first_message = true;
+
+    loop {
+        tokio::select! {
+            // Frontend → daemon
+            msg = fe_rx.next() => {
+                match msg {
+                    Some(Ok(Message::Close(_))) | None => {
+                        let _ = daemon_tx.send(TungsteniteMsg::Close(None)).await;
+                        break;
+                    }
+                    Some(Ok(fe_msg)) => {
+                        if let Some(tung_msg) = axum_to_tungstenite(fe_msg) {
+                            if is_first_message {
+                                handshake = Some(tung_msg.clone());
+                                is_first_message = false;
+                            }
+                            if daemon_tx.send(tung_msg).await.is_err() {
+                                match try_reconnect(&daemon_url, &config, handshake.as_ref()).await {
+                                    Some(ws) => {
+                                        let (tx, rx) = ws.split();
+                                        daemon_tx = tx;
+                                        daemon_rx = rx;
+                                        tracing::info!("relay reconnected: {daemon_url}");
+                                    }
+                                    None => break,
+                                }
+                            }
+                        }
+                    }
+                    Some(Err(e)) => {
+                        tracing::warn!("frontend receive error: {e}");
+                        break;
+                    }
+                }
+            }
+
+            // Daemon → frontend
+            msg = daemon_rx.next() => {
+                match msg {
+                    Some(Ok(TungsteniteMsg::Close(_))) | None => {
+                        tracing::warn!("daemon disconnected: {daemon_url}");
+                        match try_reconnect(&daemon_url, &config, handshake.as_ref()).await {
+                            Some(ws) => {
+                                let (tx, rx) = ws.split();
+                                daemon_tx = tx;
+                                daemon_rx = rx;
+                                tracing::info!("relay reconnected: {daemon_url}");
+                            }
+                            None => {
+                                let _ = fe_tx.send(Message::Close(None)).await;
+                                break;
+                            }
+                        }
+                    }
+                    Some(Ok(daemon_msg)) => {
+                        if let Some(axum_msg) = tungstenite_to_axum(daemon_msg) {
+                            if fe_tx.send(axum_msg).await.is_err() {
+                                tracing::info!("frontend gone, closing relay: {daemon_url}");
+                                break;
+                            }
+                        }
+                    }
+                    Some(Err(e)) => {
+                        tracing::warn!("daemon receive error: {e}");
+                        match try_reconnect(&daemon_url, &config, handshake.as_ref()).await {
+                            Some(ws) => {
+                                let (tx, rx) = ws.split();
+                                daemon_tx = tx;
+                                daemon_rx = rx;
+                                tracing::info!("relay reconnected after error: {daemon_url}");
+                            }
+                            None => {
+                                let _ = fe_tx.send(Message::Close(None)).await;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Keepalive ping to daemon
+            _ = ping_interval.tick() => {
+                if daemon_tx.send(TungsteniteMsg::Ping(Vec::new().into())).await.is_err() {
+                    tracing::warn!("keepalive ping failed: {daemon_url}");
+                    match try_reconnect(&daemon_url, &config, handshake.as_ref()).await {
+                        Some(ws) => {
+                            let (tx, rx) = ws.split();
+                            daemon_tx = tx;
+                            daemon_rx = rx;
+                            tracing::info!("relay reconnected after ping failure: {daemon_url}");
+                        }
+                        None => break,
+                    }
+                }
+            }
+        }
+    }
+
+    tracing::info!("relay closed: {daemon_url}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tungstenite_text_converts_to_axum() {
+        let msg = TungsteniteMsg::Text("hello".into());
+        let result = tungstenite_to_axum(msg);
+        assert!(result.is_some());
+        if let Some(Message::Text(t)) = result {
+            assert_eq!(t.to_string(), "hello");
+        } else {
+            panic!("expected Text variant");
+        }
+    }
+
+    #[test]
+    fn tungstenite_binary_converts_to_axum() {
+        let data: Vec<u8> = vec![1, 2, 3];
+        let msg = TungsteniteMsg::Binary(data.clone().into());
+        let result = tungstenite_to_axum(msg);
+        if let Some(Message::Binary(b)) = result {
+            assert_eq!(b.to_vec(), data);
+        } else {
+            panic!("expected Binary variant");
+        }
+    }
+
+    #[test]
+    fn tungstenite_ping_converts_to_axum() {
+        let data: Vec<u8> = vec![42];
+        let msg = TungsteniteMsg::Ping(data.clone().into());
+        let result = tungstenite_to_axum(msg);
+        if let Some(Message::Ping(p)) = result {
+            assert_eq!(p.to_vec(), data);
+        } else {
+            panic!("expected Ping variant");
+        }
+    }
+
+    #[test]
+    fn tungstenite_pong_converts_to_axum() {
+        let data: Vec<u8> = vec![99];
+        let msg = TungsteniteMsg::Pong(data.clone().into());
+        let result = tungstenite_to_axum(msg);
+        if let Some(Message::Pong(p)) = result {
+            assert_eq!(p.to_vec(), data);
+        } else {
+            panic!("expected Pong variant");
+        }
+    }
+
+    #[test]
+    fn tungstenite_close_returns_none() {
+        let msg = TungsteniteMsg::Close(None);
+        assert!(tungstenite_to_axum(msg).is_none());
+    }
+
+    #[test]
+    fn axum_text_converts_to_tungstenite() {
+        let msg = Message::Text("world".into());
+        let result = axum_to_tungstenite(msg);
+        if let Some(TungsteniteMsg::Text(t)) = result {
+            assert_eq!(t.to_string(), "world");
+        } else {
+            panic!("expected Text variant");
+        }
+    }
+
+    #[test]
+    fn axum_binary_converts_to_tungstenite() {
+        let data: Vec<u8> = vec![4, 5, 6];
+        let msg = Message::Binary(data.clone().into());
+        let result = axum_to_tungstenite(msg);
+        if let Some(TungsteniteMsg::Binary(b)) = result {
+            assert_eq!(b.to_vec(), data);
+        } else {
+            panic!("expected Binary variant");
+        }
+    }
+
+    #[test]
+    fn axum_ping_converts_to_tungstenite() {
+        let data: Vec<u8> = vec![7];
+        let msg = Message::Ping(data.clone().into());
+        let result = axum_to_tungstenite(msg);
+        if let Some(TungsteniteMsg::Ping(p)) = result {
+            assert_eq!(p.to_vec(), data);
+        } else {
+            panic!("expected Ping variant");
+        }
+    }
+
+    #[test]
+    fn axum_pong_converts_to_tungstenite() {
+        let data: Vec<u8> = vec![8];
+        let msg = Message::Pong(data.clone().into());
+        let result = axum_to_tungstenite(msg);
+        if let Some(TungsteniteMsg::Pong(p)) = result {
+            assert_eq!(p.to_vec(), data);
+        } else {
+            panic!("expected Pong variant");
+        }
+    }
+
+    #[test]
+    fn axum_close_returns_none() {
+        let msg = Message::Close(None);
+        assert!(axum_to_tungstenite(msg).is_none());
+    }
+
+    #[test]
+    fn text_roundtrip_preserves_content() {
+        let original = "test message with unicode: 日本語";
+        let tung = TungsteniteMsg::Text(original.into());
+        let axum_msg = tungstenite_to_axum(tung).unwrap();
+        let back = axum_to_tungstenite(axum_msg).unwrap();
+        if let TungsteniteMsg::Text(t) = back {
+            assert_eq!(t.to_string(), original);
+        } else {
+            panic!("expected Text variant");
+        }
+    }
+
+    #[test]
+    fn binary_roundtrip_preserves_content() {
+        let data: Vec<u8> = vec![0, 1, 127, 128, 255];
+        let tung = TungsteniteMsg::Binary(data.clone().into());
+        let axum_msg = tungstenite_to_axum(tung).unwrap();
+        let back = axum_to_tungstenite(axum_msg).unwrap();
+        if let TungsteniteMsg::Binary(b) = back {
+            assert_eq!(b.to_vec(), data);
+        } else {
+            panic!("expected Binary variant");
+        }
+    }
+
+    #[test]
+    fn empty_binary_roundtrip() {
+        let tung = TungsteniteMsg::Binary(Vec::new().into());
+        let axum_msg = tungstenite_to_axum(tung).unwrap();
+        let back = axum_to_tungstenite(axum_msg).unwrap();
+        if let TungsteniteMsg::Binary(b) = back {
+            assert!(b.to_vec().is_empty());
+        } else {
+            panic!("expected Binary variant");
+        }
+    }
+
+    #[test]
+    fn connect_timeout_is_two_seconds() {
+        assert_eq!(CONNECT_TIMEOUT, Duration::from_secs(2));
+    }
+
+    #[test]
+    fn max_reconnect_attempts_is_five() {
+        assert_eq!(MAX_RECONNECT_ATTEMPTS, 5);
+    }
+}


### PR DESCRIPTION
## Summary
- Introduces the `hive-server` Rust crate — axum-based orchestration server that proxies room daemon APIs and manages Hive state
- CORS middleware via `tower-http` `CorsLayer` on all `/api/*` and `/ws/*` routes (MH-001)
- Allowed origins read from `HIVE_CORS_ORIGINS` (comma-separated); defaults to `http://localhost:5173`
- Wildcard origin (`*`) rejected at startup when `HIVE_ENV=production`
- Exposes `Authorization`, `Content-Type`, and `X-Request-ID` request headers
- 49 unit tests across auth, db, CORS, daemon, ws-relay, and error handling

## Test plan
- [x] `cargo test -p hive-server` — 49 tests pass
- [x] `cargo clippy -p hive-server -- -D warnings` — clean
- [x] `cargo fmt --check -p hive-server` — clean
- [x] Preflight OPTIONS returns 2xx with correct CORS headers
- [x] Disallowed origins are not reflected
- [x] Default config is `http://localhost:5173` when `HIVE_CORS_ORIGINS` is unset

Closes MH-001