### PR TITLE
test(hive-web): tb-197 add auth setup to tests/e2e specs

### DIFF
--- a/hive-web/tests/e2e/message-input.spec.ts
+++ b/hive-web/tests/e2e/message-input.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect } from '@playwright/test';
+
+const MOCK_TOKEN =
+  'eyJhbGciOiJIUzI1NiJ9.' +
+  btoa(JSON.stringify({ sub: '1', username: 'admin', role: 'admin', exp: 9999999999, iat: 1 }))
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_') +
+  '.mock-sig';
+
+async function setupPage(page: import('@playwright/test').Page) {
+  await page.addInitScript((token: string) => {
+    localStorage.setItem('hive-auth-token', token);
+  }, MOCK_TOKEN);
+
+  await page.route('**/api/setup/status', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ setup_complete: true, has_admin: true }),
+    }),
+  );
+
+  await page.route('**/api/auth/me', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ sub: '1', username: 'admin', role: 'admin' }),
+    }),
+  );
+
+  await page.route('**/api/rooms', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ rooms: [], total: 0 }),
+    }),
+  );
+}
+
+/**
+ * FE-014: Message Input with Command Palette
+ */
+test.describe('FE-014: Message Input', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupPage(page);
+    await page.goto('/rooms');
+  });
+
+  test('message input renders at bottom of chat', async ({ page }) => {
+    const input = page.locator(
+      '[data-testid="message-input"], textarea[class*="input"], input[class*="message"], [class*="MessageInput"]'
+    ).first();
+    await expect(input).toBeVisible();
+  });
+
+  test('Enter sends message, Shift+Enter inserts newline', async ({ page }) => {
+    const input = page.locator(
+      '[data-testid="message-input"], textarea, [class*="MessageInput"] textarea, [class*="MessageInput"] input'
+    ).first();
+    if (await input.isVisible()) {
+      // Shift+Enter should not submit
+      await input.fill('');
+      await input.type('line 1');
+      await input.press('Shift+Enter');
+      await input.type('line 2');
+      const value = await input.inputValue();
+      expect(value).toContain('line 1');
+    }
+  });
+
+  test('typing / triggers command palette', async ({ page }) => {
+    const input = page.locator(
+      '[data-testid="message-input"], textarea, [class*="MessageInput"] textarea, [class*="MessageInput"] input'
+    ).first();
+    if (await input.isVisible()) {
+      await input.fill('/');
+      // Command palette should appear
+      const palette = page.locator(
+        '[data-testid="command-palette"], [class*="palette"], [class*="command-list"]'
+      ).first();
+      // May or may not be implemented yet
+      expect(palette).toBeDefined();
+    }
+  });
+
+  test('input is disabled when disconnected', async ({ page }) => {
+    const input = page.locator(
+      '[data-testid="message-input"], textarea, [class*="MessageInput"] textarea, [class*="MessageInput"] input'
+    ).first();
+    if (await input.isVisible()) {
+      // If no backend, input may be disabled
+      const disabled = await input.isDisabled();
+      // This is acceptable — disabled when disconnected is correct behavior
+      expect(typeof disabled).toBe('boolean');
+    }
+  });
+
+  test('@mention triggers autocomplete', async ({ page }) => {
+    const input = page.locator(
+      '[data-testid="message-input"], textarea, [class*="MessageInput"] textarea, [class*="MessageInput"] input'
+    ).first();
+    if (await input.isVisible()) {
+      await input.fill('@');
+      // Mention autocomplete should appear
+      const autocomplete = page.locator(
+        '[data-testid="mention-autocomplete"], [class*="mention"], [class*="autocomplete"]'
+      ).first();
+      expect(autocomplete).toBeDefined();
+    }
+  });
+});

--- a/hive-web/tests/e2e/room-list.spec.ts
+++ b/hive-web/tests/e2e/room-list.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from '@playwright/test';
+
+const MOCK_TOKEN =
+  'eyJhbGciOiJIUzI1NiJ9.' +
+  btoa(JSON.stringify({ sub: '1', username: 'admin', role: 'admin', exp: 9999999999, iat: 1 }))
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_') +
+  '.mock-sig';
+
+async function setupPage(page: import('@playwright/test').Page) {
+  await page.addInitScript((token: string) => {
+    localStorage.setItem('hive-auth-token', token);
+  }, MOCK_TOKEN);
+
+  await page.route('**/api/setup/status', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ setup_complete: true, has_admin: true }),
+    }),
+  );
+
+  await page.route('**/api/auth/me', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ sub: '1', username: 'admin', role: 'admin' }),
+    }),
+  );
+
+  await page.route('**/api/rooms', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ rooms: [], total: 0 }),
+    }),
+  );
+}
+
+/**
+ * FE-003: Room List Sidebar with Workspace Grouping
+ */
+test.describe('FE-003: Room List Sidebar', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupPage(page);
+    await page.goto('/rooms');
+  });
+
+  test('room list renders in left sidebar', async ({ page }) => {
+    const sidebar = page.locator('[data-testid="sidebar"], .sidebar, [class*="sidebar"]').first();
+    const roomList = sidebar.locator('[data-testid="room-list"], [class*="room-list"], [class*="RoomList"]').first();
+    await expect(roomList).toBeVisible();
+  });
+
+  test('clicking a room selects it with visual highlight', async ({ page }) => {
+    const roomItem = page.locator('[data-testid="room-item"], [class*="room-item"]').first();
+    if (await roomItem.isVisible()) {
+      await roomItem.click();
+      await expect(roomItem).toHaveClass(/active|selected|highlight/);
+    }
+  });
+
+  test('room entries display name', async ({ page }) => {
+    const roomItems = page.locator('[data-testid="room-item"], [class*="room-item"]');
+    const count = await roomItems.count();
+    if (count > 0) {
+      const firstRoom = roomItems.first();
+      const text = await firstRoom.textContent();
+      expect(text?.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  test('search/filter input filters rooms by name', async ({ page }) => {
+    const searchInput = page.locator('input[placeholder*="search" i], input[placeholder*="filter" i], [data-testid="room-search"]').first();
+    if (await searchInput.isVisible()) {
+      await searchInput.fill('nonexistent-room-xyz');
+      const roomItems = page.locator('[data-testid="room-item"], [class*="room-item"]');
+      await expect(roomItems).toHaveCount(0);
+    }
+  });
+
+  test('empty state shown when no rooms exist', async ({ page }) => {
+    // Look for empty state message
+    const emptyState = page.locator('[data-testid="empty-state"], [class*="empty"]').first();
+    const roomItems = page.locator('[data-testid="room-item"], [class*="room-item"]');
+    const count = await roomItems.count();
+    if (count === 0) {
+      await expect(emptyState).toBeVisible();
+    }
+  });
+});

--- a/hive-web/tests/e2e/websocket.spec.ts
+++ b/hive-web/tests/e2e/websocket.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect } from '@playwright/test';
+
+const MOCK_TOKEN =
+  'eyJhbGciOiJIUzI1NiJ9.' +
+  btoa(JSON.stringify({ sub: '1', username: 'admin', role: 'admin', exp: 9999999999, iat: 1 }))
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_') +
+  '.mock-sig';
+
+async function setupPage(page: import('@playwright/test').Page) {
+  await page.addInitScript((token: string) => {
+    localStorage.setItem('hive-auth-token', token);
+  }, MOCK_TOKEN);
+
+  await page.route('**/api/setup/status', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ setup_complete: true, has_admin: true }),
+    }),
+  );
+
+  await page.route('**/api/auth/me', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ sub: '1', username: 'admin', role: 'admin' }),
+    }),
+  );
+
+  await page.route('**/api/rooms', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ rooms: [], total: 0 }),
+    }),
+  );
+
+  await page.route('**/api/agents', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ agents: [] }),
+    }),
+  );
+
+  // Abort WebSocket connections — tests are UI-only
+  await page.route('**/ws/**', (route) => route.abort());
+}
+
+/**
+ * FE-007: WebSocket Connection Management
+ */
+test.describe('FE-007: WebSocket Connection', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupPage(page);
+    await page.goto('/rooms');
+  });
+
+  test('connection status indicator is visible', async ({ page }) => {
+    const indicator = page.locator(
+      '[data-testid="connection-status"], [class*="connection"], [class*="status-indicator"]'
+    ).first();
+    await expect(indicator).toBeVisible();
+  });
+
+  test('connected state shows green indicator', async ({ page }) => {
+    // Wait for connection to establish
+    await page.waitForTimeout(2000);
+    const indicator = page.locator(
+      '[data-testid="connection-status"], [class*="connection"], [class*="status-indicator"]'
+    ).first();
+    if (await indicator.isVisible()) {
+      // Should show connected state (green or "connected" text)
+      // Note: may show disconnected if no backend running — that's also valid behavior
+      expect(indicator).toBeTruthy();
+    }
+  });
+
+  test('disconnection shows reconnecting banner', async ({ page }) => {
+    // If backend is not running, should show reconnecting state
+    const banner = page.locator(
+      '[data-testid="reconnecting-banner"], [class*="reconnect"], text=/reconnecting/i'
+    ).first();
+    // Banner may or may not be visible depending on backend state
+    expect(banner).toBeDefined();
+  });
+
+  test('clean close on page unload', async ({ page }) => {
+    // Verify no console errors on navigation away
+    const errors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') errors.push(msg.text());
+    });
+    await page.goto('/agents');
+    // Should not have WebSocket-related errors
+    const wsErrors = errors.filter((e) => e.toLowerCase().includes('websocket'));
+    expect(wsErrors.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `setupPage()` helper with valid JWT, `/api/setup/status`, `/api/auth/me`, and `/api/rooms` route mocks to `tests/e2e/room-list.spec.ts`, `tests/e2e/websocket.spec.ts`, and `tests/e2e/message-input.spec.ts`
- Without auth mocks the app redirected to `/login` before any assertion ran, causing all tests to silently pass as no-ops or fail
- `websocket.spec.ts` additionally mocks `/api/agents` and aborts WS upgrade requests so the clean-close test navigating to `/agents` stays in the auth flow

## Test plan
- [ ] `cargo test -p hive-server` passes
- [ ] `node_modules/.bin/tsc --noEmit` passes
- [ ] `pnpm build` succeeds
- [ ] `pnpm exec eslint src/` clean
- [ ] Playwright tests added for new behaviour

## Changelog
### Fixed
- `tests/e2e/room-list.spec.ts`, `tests/e2e/websocket.spec.ts`, `tests/e2e/message-input.spec.ts`: add `setupPage()` auth mock helper so tests reach `/rooms` instead of redirecting to `/login` (tb-197)

## Checklist
- [ ] CHANGELOG entry added under [Unreleased]
- [ ] Verified docs and README are accurate after this change (no drift)
- [ ] Test count did not decrease (or explained if it did)