### PR TITLE
feat(taskboard): add /taskboard mine to filter tasks by assignee (#827)

### DIFF
--- a/crates/room-plugin-taskboard/CHANGELOG.md
+++ b/crates/room-plugin-taskboard/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `/taskboard mine` subcommand — filter tasks to show only those assigned to the calling user (#827)
+
 ## [3.5.1] - 2026-03-16
 
 ## [3.5.0] - 2026-03-15

--- a/crates/room-plugin-taskboard/src/handlers.rs
+++ b/crates/room-plugin-taskboard/src/handlers.rs
@@ -146,6 +146,47 @@ impl TaskboardPlugin {
         lines.join("\n")
     }
 
+    pub(super) fn handle_mine(&self, sender: &str) -> String {
+        self.sweep_expired();
+        let board = self.board.lock().unwrap();
+        let mine: Vec<&LiveTask> = board
+            .iter()
+            .filter(|lt| lt.task.assigned_to.as_deref() == Some(sender))
+            .collect();
+        if mine.is_empty() {
+            return format!("no tasks assigned to {sender}");
+        }
+        let mut lines = Vec::new();
+        lines.push(format!(
+            "{:<8} {:<10} {:<12} {}",
+            "ID", "STATUS", "ELAPSED", "DESCRIPTION"
+        ));
+        for lt in &mine {
+            let elapsed = match lt.lease_start {
+                Some(start) => {
+                    let secs = start.elapsed().as_secs();
+                    if secs < 60 {
+                        format!("{secs}s")
+                    } else {
+                        format!("{}m", secs / 60)
+                    }
+                }
+                None => "-".to_owned(),
+            };
+            let desc = if lt.task.description.chars().count() > 40 {
+                let truncated: String = lt.task.description.chars().take(37).collect();
+                format!("{truncated}...")
+            } else {
+                lt.task.description.clone()
+            };
+            lines.push(format!(
+                "{:<8} {:<10} {:<12} {}",
+                lt.task.id, lt.task.status, elapsed, desc
+            ));
+        }
+        lines.join("\n")
+    }
+
     pub(super) fn handle_claim(&self, ctx: &CommandContext) -> (String, bool) {
         let task_id = match ctx.params.get(1) {
             Some(id) => id,

--- a/crates/room-plugin-taskboard/src/lib.rs
+++ b/crates/room-plugin-taskboard/src/lib.rs
@@ -84,7 +84,7 @@ impl TaskboardPlugin {
         vec![CommandInfo {
             name: "taskboard".to_owned(),
             description:
-                "Manage task lifecycle — post, list, show, claim, assign, plan, approve, update, review, release, finish, cancel"
+                "Manage task lifecycle — post, list, mine, show, claim, assign, plan, approve, update, review, release, finish, cancel"
                     .to_owned(),
             usage: "/taskboard <action> [args...]".to_owned(),
             params: vec![
@@ -93,6 +93,7 @@ impl TaskboardPlugin {
                     param_type: ParamType::Choice(vec![
                         "post".to_owned(),
                         "list".to_owned(),
+                        "mine".to_owned(),
                         "show".to_owned(),
                         "claim".to_owned(),
                         "assign".to_owned(),
@@ -164,6 +165,7 @@ impl Plugin for TaskboardPlugin {
                     let show_all = ctx.params.get(1).map(|s| s.as_str()) == Some("all");
                     (self.handle_list(show_all), false)
                 }
+                "mine" => (self.handle_mine(&ctx.sender), false),
                 "claim" => self.handle_claim(&ctx),
                 "assign" => self.handle_assign(&ctx),
                 "plan" => self.handle_plan(&ctx),
@@ -174,8 +176,8 @@ impl Plugin for TaskboardPlugin {
                 "review" => self.handle_review(&ctx),
                 "finish" => self.handle_finish(&ctx),
                 "cancel" => self.handle_cancel(&ctx),
-                "" => ("usage: /taskboard <post|list|show|claim|assign|plan|approve|update|review|release|finish|cancel> [args...]".to_owned(), false),
-                other => (format!("unknown action: {other}. use: post, list, show, claim, assign, plan, approve, update, review, release, finish, cancel"), false),
+                "" => ("usage: /taskboard <post|list|mine|show|claim|assign|plan|approve|update|review|release|finish|cancel> [args...]".to_owned(), false),
+                other => (format!("unknown action: {other}. use: post, list, mine, show, claim, assign, plan, approve, update, review, release, finish, cancel"), false),
             };
             if broadcast {
                 // Emit a typed event alongside the system broadcast.
@@ -252,7 +254,7 @@ mod tests {
             assert!(choices.contains(&"post".to_owned()));
             assert!(choices.contains(&"approve".to_owned()));
             assert!(choices.contains(&"assign".to_owned()));
-            assert_eq!(choices.len(), 12);
+            assert_eq!(choices.len(), 13);
         } else {
             panic!("expected Choice param type");
         }
@@ -479,5 +481,79 @@ mod tests {
                 assert!(lt.lease_start.is_none());
             }
         }
+    }
+
+    // ── handle_mine tests ────────────────────────────────────────────────
+
+    #[test]
+    fn handle_mine_returns_only_assigned_tasks() {
+        let (plugin, _tmp) = make_plugin();
+        seed_task(&plugin, "tb-001", TaskStatus::Open);
+        seed_task(&plugin, "tb-002", TaskStatus::Claimed); // assigned to "bob"
+        seed_task(&plugin, "tb-003", TaskStatus::Approved); // assigned to "bob"
+
+        // Seed one task assigned to "alice".
+        {
+            let mut board = plugin.board.lock().unwrap();
+            let t = task::Task {
+                id: "tb-004".to_owned(),
+                description: "alice task".to_owned(),
+                status: TaskStatus::Claimed,
+                posted_by: "manager".to_owned(),
+                assigned_to: Some("alice".to_owned()),
+                posted_at: chrono::Utc::now(),
+                claimed_at: None,
+                plan: None,
+                approved_by: None,
+                approved_at: None,
+                updated_at: None,
+                notes: None,
+                team: None,
+            };
+            board.push(LiveTask::new(t));
+        }
+
+        let output = plugin.handle_mine("bob");
+        assert!(
+            output.contains("tb-002"),
+            "bob's claimed task should appear"
+        );
+        assert!(
+            output.contains("tb-003"),
+            "bob's approved task should appear"
+        );
+        assert!(
+            !output.contains("tb-001"),
+            "unassigned task should not appear"
+        );
+        assert!(
+            !output.contains("tb-004"),
+            "alice's task should not appear for bob"
+        );
+    }
+
+    #[test]
+    fn handle_mine_empty_when_no_tasks_assigned() {
+        let (plugin, _tmp) = make_plugin();
+        seed_task(&plugin, "tb-001", TaskStatus::Open);
+        seed_task(&plugin, "tb-002", TaskStatus::Claimed); // assigned to "bob"
+
+        let output = plugin.handle_mine("alice");
+        assert!(
+            output.contains("no tasks assigned to alice"),
+            "should show empty message, got: {output}"
+        );
+    }
+
+    #[test]
+    fn handle_mine_includes_finished_tasks() {
+        let (plugin, _tmp) = make_plugin();
+        seed_task(&plugin, "tb-001", TaskStatus::Finished); // assigned to "bob"
+
+        let output = plugin.handle_mine("bob");
+        assert!(
+            output.contains("tb-001"),
+            "finished tasks should appear in mine"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Adds `/taskboard mine` subcommand that filters tasks to show only those assigned to the calling user
- Reuses the same elapsed/description formatting as `/taskboard list`
- Shows all assigned tasks (including finished/cancelled) for full task history

## Files modified
- `crates/room-plugin-taskboard/src/handlers.rs` — added `handle_mine()` method
- `crates/room-plugin-taskboard/src/lib.rs` — added "mine" to Choice params, dispatch, usage string, 3 unit tests

## Test plan
- [x] 3 new unit tests (mine_empty, mine_filters, mine_excludes_unassigned)
- [x] All 99 taskboard tests pass
- [x] cargo check / fmt / clippy / test all pass
- [ ] Verified docs/README are accurate after this change (no drift)

Closes #827

🤖 Generated with [Claude Code](https://claude.com/claude-code)