### PR TITLE
fix: TUI palette sends command name only for optional-param commands (#839)

### DIFF
--- a/crates/room-cli/CHANGELOG.md
+++ b/crates/room-cli/CHANGELOG.md
@@ -10,6 +10,12 @@ For changes prior to the workspace restructure (v0.1.2 through v1.0.2), see the
 
 ## [Unreleased]
 
+### Fixed
+
+- **tui:** Command palette no longer sends usage placeholders for optional-param commands.
+  Selecting `/help`, `/info`, `/subscribe`, or `/stats` from the palette now sets input
+  to just the command name instead of including bracket placeholders like `[command]`. (#839)
+
 ## [3.5.1] - 2026-03-16
 
 ### Added

--- a/crates/room-cli/src/tui/input.rs
+++ b/crates/room-cli/src/tui/input.rs
@@ -474,10 +474,11 @@ fn complete_palette_selection(
     let selected_idx = state.palette.filtered.get(state.palette.selected).copied();
     if let Some(idx) = selected_idx {
         let cmd_name = state.palette.commands[idx].cmd.clone();
+        let is_required = state.palette.is_param_required(&cmd_name, 0);
         let is_username = state.palette.is_username_param(&cmd_name, 0);
         let has_choices = !state.palette.completions_at(&cmd_name, 0).is_empty();
 
-        if is_username {
+        if is_username && is_required {
             // Set input to "/<cmd> " and activate mention picker at the space.
             let prefix = format!("/{cmd_name} ");
             let at_byte = prefix.len();
@@ -491,7 +492,7 @@ fn complete_palette_selection(
             if state.mention.filtered.is_empty() {
                 state.mention.deactivate();
             }
-        } else if has_choices {
+        } else if has_choices && is_required {
             // Set input to "/<cmd> " and activate choice picker.
             let choices = state.palette.completions_at(&cmd_name, 0);
             let prefix = format!("/{cmd_name} ");
@@ -504,12 +505,12 @@ fn complete_palette_selection(
             if state.choice.filtered.is_empty() {
                 state.choice.deactivate();
             }
-        } else if let Some(usage) = state.palette.selected_usage() {
-            state.input = usage.to_owned();
+        } else {
+            // Command has no params, or only optional params.
+            // Set input to just "/<cmd>" (no placeholder suffixes) and send.
+            state.input = format!("/{cmd_name}");
             state.cursor_pos = state.input.len();
             state.input_row_scroll = 0;
-            state.palette.deactivate();
-        } else {
             state.palette.deactivate();
         }
     } else {
@@ -1324,7 +1325,8 @@ mod tests {
     }
 
     #[test]
-    fn tab_on_stats_sets_short_prefix_for_choices() {
+    fn tab_on_stats_does_not_activate_choice_picker() {
+        // /stats has an optional Choice param — should NOT auto-activate choice picker
         let mut state = InputState::new();
         let users: Vec<String> = vec![];
         for c in "/stats".chars() {
@@ -1332,18 +1334,13 @@ mod tests {
         }
         assert!(state.palette.active);
         handle_key(make_key(KeyCode::Tab), &mut state, &users, &[], 10, 80);
-        // stats has Choice param — should set "/stats " and activate choice picker
-        assert_eq!(state.input, "/stats ");
-        assert!(!state.palette.active);
-        assert!(!state.mention.active);
+        assert!(!state.palette.active, "palette should deactivate");
         assert!(
-            state.choice.active,
-            "choice picker should activate for Choice params"
+            !state.choice.active,
+            "choice picker should NOT activate for optional Choice param"
         );
-        assert!(
-            !state.choice.filtered.is_empty(),
-            "choice picker should have filtered values"
-        );
+        // Should set input to just the command name, no placeholder
+        assert_eq!(state.input, "/stats");
     }
 
     #[test]
@@ -1370,6 +1367,46 @@ mod tests {
         handle_key(make_key(KeyCode::Enter), &mut state, &users, &[], 10, 80);
         assert_eq!(state.input, "/dm ");
         assert!(state.mention.active);
+    }
+
+    // ── optional-param palette selection tests (#839) ─────────────────────────
+
+    #[test]
+    fn tab_on_info_does_not_activate_mention_picker() {
+        // /info has an optional Username param — should NOT auto-activate mention picker
+        let mut state = InputState::new();
+        let users = vec!["alice".to_owned()];
+        for c in "/info".chars() {
+            handle_key(make_key(KeyCode::Char(c)), &mut state, &users, &[], 10, 80);
+        }
+        assert!(state.palette.active);
+        handle_key(make_key(KeyCode::Tab), &mut state, &users, &[], 10, 80);
+        assert!(!state.palette.active, "palette should deactivate");
+        assert!(
+            !state.mention.active,
+            "mention picker should NOT activate for optional Username param"
+        );
+        // Should set input to just the command name, no placeholder
+        assert_eq!(state.input, "/info");
+    }
+
+    #[test]
+    fn tab_on_subscribe_does_not_activate_choice_picker() {
+        // /subscribe has an optional Choice param — should NOT auto-activate choice picker
+        let mut state = InputState::new();
+        let users: Vec<String> = vec![];
+        for c in "/subscribe".chars() {
+            handle_key(make_key(KeyCode::Char(c)), &mut state, &users, &[], 10, 80);
+        }
+        assert!(state.palette.active);
+        handle_key(make_key(KeyCode::Tab), &mut state, &users, &[], 10, 80);
+        assert!(!state.palette.active, "palette should deactivate");
+        assert!(
+            !state.choice.active,
+            "choice picker should NOT activate for optional Choice param"
+        );
+        // Should set input to just the command name, no placeholder
+        assert_eq!(state.input, "/subscribe");
     }
 
     // ── Tab switching keybinding tests ──────────────────────────────────────
@@ -1422,20 +1459,23 @@ mod tests {
 
     // ── ChoicePicker integration tests ──────────────────────────────────────
 
-    /// Helper: type a command and Tab to activate the choice picker.
+    /// Helper: set up input with "/<cmd> " and directly activate the choice picker.
+    /// This bypasses palette selection (which only auto-activates for required params)
+    /// so we can test choice picker mechanics in isolation.
     fn activate_choice_picker(cmd: &str) -> InputState {
         let mut state = InputState::new();
-        let users: Vec<String> = vec![];
-        for c in cmd.chars() {
-            handle_key(make_key(KeyCode::Char(c)), &mut state, &users, &[], 10, 80);
-        }
-        handle_key(make_key(KeyCode::Tab), &mut state, &users, &[], 10, 80);
+        let prefix = format!("/{cmd} ");
+        let value_start = prefix.len();
+        state.input = prefix;
+        state.cursor_pos = value_start;
+        let choices = state.palette.completions_at(cmd, 0);
+        state.choice.activate(cmd, choices, value_start, "");
         state
     }
 
     #[test]
-    fn choice_picker_activates_on_subscribe_tab() {
-        let state = activate_choice_picker("/subscribe");
+    fn choice_picker_activates_on_subscribe() {
+        let state = activate_choice_picker("subscribe");
         assert!(state.choice.active);
         assert_eq!(state.input, "/subscribe ");
         assert!(state.choice.filtered.contains(&"full".to_owned()));
@@ -1444,7 +1484,7 @@ mod tests {
 
     #[test]
     fn choice_picker_tab_completes_selection() {
-        let mut state = activate_choice_picker("/subscribe");
+        let mut state = activate_choice_picker("subscribe");
         assert!(state.choice.active);
         // Default selection is first item
         handle_key(make_key(KeyCode::Tab), &mut state, &[], &[], 10, 80);
@@ -1462,7 +1502,7 @@ mod tests {
 
     #[test]
     fn choice_picker_enter_completes_selection() {
-        let mut state = activate_choice_picker("/subscribe");
+        let mut state = activate_choice_picker("subscribe");
         assert!(state.choice.active);
         handle_key(make_key(KeyCode::Enter), &mut state, &[], &[], 10, 80);
         assert!(!state.choice.active);
@@ -1471,7 +1511,7 @@ mod tests {
 
     #[test]
     fn choice_picker_up_down_navigates() {
-        let mut state = activate_choice_picker("/subscribe");
+        let mut state = activate_choice_picker("subscribe");
         assert!(state.choice.active);
         assert_eq!(state.choice.selected, 0);
         handle_key(make_key(KeyCode::Down), &mut state, &[], &[], 10, 80);
@@ -1482,7 +1522,7 @@ mod tests {
 
     #[test]
     fn choice_picker_esc_dismisses() {
-        let mut state = activate_choice_picker("/subscribe");
+        let mut state = activate_choice_picker("subscribe");
         assert!(state.choice.active);
         handle_key(make_key(KeyCode::Esc), &mut state, &[], &[], 10, 80);
         assert!(!state.choice.active);
@@ -1490,7 +1530,7 @@ mod tests {
 
     #[test]
     fn choice_picker_typing_filters() {
-        let mut state = activate_choice_picker("/subscribe");
+        let mut state = activate_choice_picker("subscribe");
         assert!(state.choice.active);
         let initial_count = state.choice.filtered.len();
         // Type 'f' to filter to "full"
@@ -1502,7 +1542,7 @@ mod tests {
 
     #[test]
     fn choice_picker_typing_no_match_deactivates() {
-        let mut state = activate_choice_picker("/subscribe");
+        let mut state = activate_choice_picker("subscribe");
         assert!(state.choice.active);
         for c in "zzz".chars() {
             handle_key(make_key(KeyCode::Char(c)), &mut state, &[], &[], 10, 80);
@@ -1515,7 +1555,7 @@ mod tests {
 
     #[test]
     fn choice_picker_backspace_updates_filter() {
-        let mut state = activate_choice_picker("/subscribe");
+        let mut state = activate_choice_picker("subscribe");
         assert!(state.choice.active);
         // Type 'f' to filter
         handle_key(make_key(KeyCode::Char('f')), &mut state, &[], &[], 10, 80);
@@ -1528,7 +1568,7 @@ mod tests {
 
     #[test]
     fn choice_picker_backspace_past_value_start_deactivates() {
-        let mut state = activate_choice_picker("/subscribe");
+        let mut state = activate_choice_picker("subscribe");
         assert!(state.choice.active);
         // Backspace into the command prefix should deactivate
         handle_key(make_key(KeyCode::Backspace), &mut state, &[], &[], 10, 80);
@@ -1539,8 +1579,14 @@ mod tests {
     }
 
     #[test]
-    fn choice_picker_not_active_for_who() {
-        let state = activate_choice_picker("/who");
+    fn tab_on_who_does_not_activate_choice_picker() {
+        // /who has no Choice params — palette Tab should not activate choice picker
+        let mut state = InputState::new();
+        let users: Vec<String> = vec![];
+        for c in "/who".chars() {
+            handle_key(make_key(KeyCode::Char(c)), &mut state, &users, &[], 10, 80);
+        }
+        handle_key(make_key(KeyCode::Tab), &mut state, &users, &[], 10, 80);
         assert!(
             !state.choice.active,
             "who has no Choice params — picker should not activate"

--- a/crates/room-cli/src/tui/widgets.rs
+++ b/crates/room-cli/src/tui/widgets.rs
@@ -87,13 +87,6 @@ impl CommandPalette {
         }
     }
 
-    /// The full usage string (e.g. `/dm <user>`) of the selected entry.
-    pub(super) fn selected_usage(&self) -> Option<&str> {
-        self.filtered
-            .get(self.selected)
-            .map(|&i| self.commands[i].usage.as_str())
-    }
-
     /// Look up a command by name and return completions for the given argument
     /// position. Returns `Choice` values or an empty vec.
     pub(super) fn completions_at(&self, cmd_name: &str, arg_pos: usize) -> Vec<String> {
@@ -447,21 +440,6 @@ mod tests {
     }
 
     #[test]
-    fn palette_selected_usage_returns_usage_string() {
-        let mut p = make_palette();
-        p.activate();
-        let usage = p.selected_usage().unwrap();
-        assert!(usage.starts_with('/'));
-    }
-
-    #[test]
-    fn palette_selected_usage_empty_when_no_filtered() {
-        let mut p = make_palette();
-        p.filtered.clear();
-        assert!(p.selected_usage().is_none());
-    }
-
-    #[test]
     fn palette_selected_clamps_after_filter_narrows() {
         let mut p = make_palette();
         p.activate();
@@ -529,14 +507,6 @@ mod tests {
         p.update_filter("ki");
         assert_eq!(p.filtered.len(), 1);
         assert_eq!(p.commands[p.filtered[0]].cmd, "kick");
-    }
-
-    #[test]
-    fn admin_selected_usage_slash() {
-        let mut p = make_palette();
-        p.activate();
-        let usage = p.selected_usage().unwrap();
-        assert!(usage.starts_with('/'));
     }
 
     // ── Filter ranking tests (#172) ────────────────────────────────────────────

--- a/crates/room-cli/src/tui/widgets.rs
+++ b/crates/room-cli/src/tui/widgets.rs
@@ -118,6 +118,18 @@ impl CommandPalette {
             .map(|p| matches!(p.param_type, ParamType::Username))
             .unwrap_or(false)
     }
+
+    /// Check if the parameter at `arg_pos` for `cmd_name` is required.
+    /// Returns `true` when the parameter exists and is marked `required`,
+    /// or `false` when the parameter is optional or doesn't exist.
+    pub(super) fn is_param_required(&self, cmd_name: &str, arg_pos: usize) -> bool {
+        self.commands
+            .iter()
+            .find(|c| c.cmd == cmd_name)
+            .and_then(|c| c.params.get(arg_pos))
+            .map(|p| p.required)
+            .unwrap_or(false)
+    }
 }
 
 // ── Shared picker state ──────────────────────────────────────────────────────
@@ -635,6 +647,35 @@ mod tests {
     fn is_username_param_false_for_unknown_command() {
         let p = make_palette();
         assert!(!p.is_username_param("nonexistent", 0));
+    }
+
+    // ── is_param_required tests (#839) ────────────────────────────────────────
+
+    #[test]
+    fn is_param_required_true_for_dm_first_arg() {
+        let p = make_palette();
+        // /dm <user> — first param is required
+        assert!(p.is_param_required("dm", 0));
+    }
+
+    #[test]
+    fn is_param_required_false_for_info_first_arg() {
+        let p = make_palette();
+        // /info [username] — first param is optional
+        assert!(!p.is_param_required("info", 0));
+    }
+
+    #[test]
+    fn is_param_required_false_for_subscribe_first_arg() {
+        let p = make_palette();
+        // /subscribe [tier] — first param is optional
+        assert!(!p.is_param_required("subscribe", 0));
+    }
+
+    #[test]
+    fn is_param_required_false_for_unknown_command() {
+        let p = make_palette();
+        assert!(!p.is_param_required("nonexistent", 0));
     }
 
     // ── MentionPicker tests ───────────────────────────────────────────────────

--- a/crates/room-cli/tests/broker.rs
+++ b/crates/room-cli/tests/broker.rs
@@ -1543,7 +1543,7 @@ async fn taskboard_claim_finish_oneshot_returns_response() {
     let td = common::TestDaemon::start(&["tb-os-fin"]).await;
     let token = common::daemon_join(&td.socket_path, "tb-os-fin", "bot").await;
 
-    // Post → claim → finish.
+    // Post → claim → plan → approve → finish.
     let post_wire = taskboard_cmd_wire("post", &["finish-test"]);
     common::daemon_send(&td.socket_path, "tb-os-fin", &token, &post_wire).await;
 
@@ -1555,6 +1555,12 @@ async fn taskboard_claim_finish_oneshot_returns_response() {
         content.contains("claimed by bot"),
         "claim response: {content}"
     );
+
+    let plan_wire = taskboard_cmd_wire("plan", &["tb-001", "my", "plan"]);
+    common::daemon_send(&td.socket_path, "tb-os-fin", &token, &plan_wire).await;
+
+    let approve_wire = taskboard_cmd_wire("approve", &["tb-001"]);
+    common::daemon_send(&td.socket_path, "tb-os-fin", &token, &approve_wire).await;
 
     let finish_wire = taskboard_cmd_wire("finish", &["tb-001"]);
     let resp = common::daemon_send(&td.socket_path, "tb-os-fin", &token, &finish_wire).await;


### PR DESCRIPTION
## Summary
- Fixes palette auto-completion for commands with only optional params (`/help`, `/info`, `/subscribe`, `/stats`)
- Previously, selecting these commands from the palette would set input to the full usage string including placeholders (e.g. `/help [command]`), causing the broker to receive literal bracket text
- Now sets input to just `/<cmd>` without placeholders, and gates sub-picker activation (mention/choice pickers) on `is_param_required()`

## Changes
- `crates/room-cli/src/tui/widgets.rs`: Added `is_param_required()` method to `CommandPalette` + 3 unit tests
- `crates/room-cli/src/tui/input.rs`: Modified `complete_palette_selection()` to check `is_required` before activating sub-pickers; consolidated else branch to use `/<cmd>` format; updated/added 5 tests

## Test plan
- [x] All 84 TUI input tests pass
- [x] All 58 TUI widgets tests pass
- [x] New tests verify optional-param commands don't activate pickers and set correct input
- [ ] Verified docs/README are accurate after this change (no drift)

Closes #839

🤖 Generated with [Claude Code](https://claude.com/claude-code)