### PR TITLE
docs: remove stale PRD references from README.md (#805)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,10 +29,3 @@ The README covers installation and basic usage. This folder contains deep-dive d
 | [design-253-room-visibility.md](design-253-room-visibility.md) | Design doc for room visibility and ACLs |
 | [design-agent-spawn.md](design-agent-spawn.md) | Design doc for `/agent` and `/spawn` commands (#434) |
 | [design-shared-knowledge.md](design-shared-knowledge.md) | Design doc for shared knowledge system (#480) |
-
-## PRDs
-
-| Folder | Description |
-|--------|-------------|
-| [prd/hive/](prd/hive/) | PRDs for the Hive orchestration layer — workspaces, teams, agent discovery |
-| [prd/agent/](prd/agent/) | PRDs for agent autonomy — personality system, `/agent` plugin, agent health |


### PR DESCRIPTION
## Summary
- Removes stale PRDs section from `docs/README.md` that referenced `prd/hive/` and `prd/agent/` directories
- Those directories were deleted in PR #814 but the README links were not cleaned up
- The `/agent`, `/spawn`, and plugin features mentioned in issue #805 are now in [knoxio/room-ralph](https://github.com/knoxio/room-ralph), not this repo

## Test plan
- [x] Verified `prd/` directory does not exist
- [x] Verified docs/README are accurate after this change (no drift)

Closes #805

🤖 Generated with [Claude Code](https://claude.com/claude-code)