### PR TITLE
fix(taskboard): suppress lease renewal broadcast noise (#825)

### DIFF
--- a/crates/room-plugin-taskboard/src/handlers.rs
+++ b/crates/room-plugin-taskboard/src/handlers.rs
@@ -350,7 +350,7 @@ impl TaskboardPlugin {
         let _ = task::save_tasks(&self.storage_path, &tasks);
         (
             format!("task {task_id} updated, lease renewed{warning}"),
-            true,
+            false,
         )
     }
 
@@ -766,7 +766,10 @@ mod tests {
             plugin.handle_update(&test_ctx("agent", &["update", "tb-001", "progress note"]));
         assert!(result.contains("lease renewed"));
         assert!(result.contains("warning")); // not approved yet
-        assert!(broadcast);
+        assert!(
+            !broadcast,
+            "update should not broadcast — lease renewals are reply-only"
+        );
         let board = plugin.board.lock().unwrap();
         assert_eq!(board[0].task.notes.as_deref(), Some("progress note"));
     }
@@ -785,7 +788,10 @@ mod tests {
         let (result, broadcast) = plugin.handle_update(&test_ctx("agent", &["update", "tb-001"]));
         assert!(result.contains("lease renewed"));
         assert!(!result.contains("warning"));
-        assert!(broadcast);
+        assert!(
+            !broadcast,
+            "update should not broadcast — lease renewals are reply-only"
+        );
     }
 
     #[test]
@@ -1423,7 +1429,10 @@ mod tests {
             plugin.handle_update(&test_ctx("agent", &["update", "tb-001", "review notes"]));
         assert!(result.contains("lease renewed"));
         assert!(!result.contains("warning"));
-        assert!(broadcast);
+        assert!(
+            !broadcast,
+            "update should not broadcast — lease renewals are reply-only"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Change `/taskboard update` from broadcast to reply-only so "lease renewed" messages are visible only to the sender, not the entire room
- Reduces noise in the room feed — lease renewal was the most frequent system message type
- Notes and lease renewal still work as before, just no longer broadcast to all users

## Changes
- `crates/room-plugin-taskboard/src/handlers.rs`: Change `handle_update` return from `broadcast=true` to `broadcast=false`
- Updated 3 existing test assertions to verify non-broadcast behavior

## Test plan
- [x] Updated `handle_update_renews_lease` test — asserts `!broadcast`
- [x] Updated `handle_update_no_warning_when_approved` test — asserts `!broadcast`
- [x] Updated `handle_update_in_review_no_warning` test — asserts `!broadcast`
- [ ] Verify existing tests still pass (CI)

## Checklist
- [x] Verified docs/README are accurate after this change (no drift)

Closes #825

🤖 Generated with [Claude Code](https://claude.com/claude-code)