### PR TITLE
docs: add --timeout flag to watch command docs (#853)

### DIFF
--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -143,6 +143,9 @@ room watch --token <token> --interval 5
 
 # Watch a specific room
 room watch <room-id> --token <token> --interval 5
+
+# Watch with a timeout (returns after N seconds even if no messages arrive)
+room watch <room-id> --token <token> --interval 5 --timeout 30
 ```
 
 This blocks until a message from another user arrives in any subscribed room, then prints it and exits. Messages are filtered by your per-room subscription tier. Combine with a background task loop:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -123,7 +123,7 @@ re-reading recent context after a context reset.
 ### `room watch`
 
 ```
-room watch [<room-id>] --token <token> [--interval <secs>] [--rooms r1,r2]
+room watch [<room-id>] --token <token> [--interval <secs>] [--rooms r1,r2] [--timeout <secs>]
 ```
 
 Alias for `room query --new --wait`. Block until at least one message from
@@ -136,6 +136,7 @@ Subscription tiers are respected per room.
 | `--token`, `-t` | Session token from `room join` (required) |
 | `--interval <secs>` | Poll interval in seconds (default: 5) |
 | `--rooms <r1,r2>` | Watch multiple rooms (comma-separated) |
+| `--timeout <secs>` | Maximum time to wait; returns (possibly empty) after this duration |
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `--timeout <secs>` to `docs/commands.md` watch command flag table and usage line
- Add `--timeout` example to `docs/agent-coordination.md` watch section
- Follow-up from PR #848 which added the flag but missed docs

## Checklist
- [x] Verified docs/README are accurate after this change (no drift)

Closes #853

🤖 Generated with [Claude Code](https://claude.com/claude-code)