### PR TITLE
refactor(taskboard): new task lifecycle schema (#841)

### DIFF
--- a/crates/room-plugin-taskboard/src/handlers.rs
+++ b/crates/room-plugin-taskboard/src/handlers.rs
@@ -62,6 +62,7 @@ impl TaskboardPlugin {
             updated_at: None,
             notes: None,
             team: team.clone(),
+            reviewer: None,
         };
         board.push(LiveTask::new(task.clone()));
         let all_tasks: Vec<Task> = board.iter().map(|lt| lt.task.clone()).collect();
@@ -275,7 +276,7 @@ impl TaskboardPlugin {
         if !is_poster && !is_host {
             return ("only the task poster or host can approve".to_owned(), false);
         }
-        lt.task.status = TaskStatus::Approved;
+        lt.task.status = TaskStatus::InProgress;
         lt.task.approved_by = Some(ctx.sender.clone());
         lt.task.approved_at = Some(chrono::Utc::now());
         lt.renew_lease();
@@ -321,12 +322,13 @@ impl TaskboardPlugin {
             lt.task.status,
             TaskStatus::Claimed
                 | TaskStatus::Planned
-                | TaskStatus::Approved
+                | TaskStatus::InProgress
                 | TaskStatus::AwaitingReview
+                | TaskStatus::ReviewClaimed
         ) {
             return (
                 format!(
-                    "task {task_id} is {} (must be claimed/planned/approved/in_review to update)",
+                    "task {task_id} is {} (must be claimed/planned/in_progress/in_review/review_claimed to update)",
                     lt.task.status
                 ),
                 false,
@@ -338,7 +340,7 @@ impl TaskboardPlugin {
         let mut warning = String::new();
         if !matches!(
             lt.task.status,
-            TaskStatus::Approved | TaskStatus::AwaitingReview
+            TaskStatus::InProgress | TaskStatus::AwaitingReview | TaskStatus::ReviewClaimed
         ) {
             warning = format!(" [warning: task is {} — not yet approved]", lt.task.status);
         }
@@ -369,12 +371,13 @@ impl TaskboardPlugin {
             lt.task.status,
             TaskStatus::Claimed
                 | TaskStatus::Planned
-                | TaskStatus::Approved
+                | TaskStatus::InProgress
                 | TaskStatus::AwaitingReview
+                | TaskStatus::ReviewClaimed
         ) {
             return (
                 format!(
-                    "task {task_id} is {} (must be claimed/planned/approved/in_review to release)",
+                    "task {task_id} is {} (must be claimed/planned/in_progress/in_review/review_claimed to release)",
                     lt.task.status
                 ),
                 false,
@@ -522,13 +525,10 @@ impl TaskboardPlugin {
             Some(lt) => lt,
             None => return (format!("task {task_id} not found"), false),
         };
-        if !matches!(
-            lt.task.status,
-            TaskStatus::Claimed | TaskStatus::Planned | TaskStatus::Approved
-        ) {
+        if lt.task.status != TaskStatus::InProgress {
             return (
                 format!(
-                    "task {task_id} is {} (must be claimed/planned/approved to move to review)",
+                    "task {task_id} is {} (must be in_progress to move to review)",
                     lt.task.status
                 ),
                 false,
@@ -567,14 +567,11 @@ impl TaskboardPlugin {
         };
         if !matches!(
             lt.task.status,
-            TaskStatus::Claimed
-                | TaskStatus::Planned
-                | TaskStatus::Approved
-                | TaskStatus::AwaitingReview
+            TaskStatus::InProgress | TaskStatus::AwaitingReview | TaskStatus::ReviewClaimed
         ) {
             return (
                 format!(
-                    "task {task_id} is {} (must be claimed/planned/approved/in_review to finish)",
+                    "task {task_id} is {} (must be in_progress/in_review/review_claimed to finish)",
                     lt.task.status
                 ),
                 false,
@@ -722,7 +719,7 @@ mod tests {
         assert!(result.contains("approved"));
         assert!(broadcast);
         let board = plugin.board.lock().unwrap();
-        assert_eq!(board[0].task.status, TaskStatus::Approved);
+        assert_eq!(board[0].task.status, TaskStatus::InProgress);
     }
 
     #[test]
@@ -812,6 +809,12 @@ mod tests {
         let (plugin, _tmp) = make_plugin();
         plugin.handle_post(&test_ctx("ba", &["post", "task"]));
         plugin.handle_claim(&test_ctx("agent", &["claim", "tb-001"]));
+        plugin.handle_plan(&test_ctx("agent", &["plan", "tb-001", "my plan"]));
+        plugin.handle_approve(&test_ctx_with_host(
+            "ba",
+            &["approve", "tb-001"],
+            Some("ba"),
+        ));
         let (result, broadcast) = plugin.handle_finish(&test_ctx("agent", &["finish", "tb-001"]));
         assert!(result.contains("finished"));
         assert!(broadcast);
@@ -1269,6 +1272,12 @@ mod tests {
         let (plugin, _tmp) = make_plugin();
         plugin.handle_post(&test_ctx("ba", &["post", "task"]));
         plugin.handle_claim(&test_ctx("agent-a", &["claim", "tb-001"]));
+        plugin.handle_plan(&test_ctx("agent-a", &["plan", "tb-001", "my plan"]));
+        plugin.handle_approve(&test_ctx_with_host(
+            "ba",
+            &["approve", "tb-001"],
+            Some("ba"),
+        ));
         let (result, broadcast) = plugin.handle_review(&test_ctx("agent-b", &["review", "tb-001"]));
         assert!(result.contains("only be moved to review by the assignee"));
         assert!(!broadcast);
@@ -1290,7 +1299,7 @@ mod tests {
         plugin.handle_post(&test_ctx("ba", &["post", "task"]));
         // Task is Open — cannot move to review.
         let (result, broadcast) = plugin.handle_review(&test_ctx("ba", &["review", "tb-001"]));
-        assert!(result.contains("must be claimed/planned/approved"));
+        assert!(result.contains("must be in_progress"));
         assert!(!broadcast);
     }
 
@@ -1330,6 +1339,12 @@ mod tests {
         let (plugin, _tmp) = make_plugin();
         plugin.handle_post(&test_ctx("ba", &["post", "task"]));
         plugin.handle_claim(&test_ctx("agent", &["claim", "tb-001"]));
+        plugin.handle_plan(&test_ctx("agent", &["plan", "tb-001", "my plan"]));
+        plugin.handle_approve(&test_ctx_with_host(
+            "ba",
+            &["approve", "tb-001"],
+            Some("ba"),
+        ));
         plugin.handle_review(&test_ctx("agent", &["review", "tb-001"]));
         let (result, broadcast) = plugin.handle_finish(&test_ctx("agent", &["finish", "tb-001"]));
         assert!(result.contains("finished"));
@@ -1343,6 +1358,12 @@ mod tests {
         let (plugin, _tmp) = make_plugin();
         plugin.handle_post(&test_ctx("ba", &["post", "task"]));
         plugin.handle_claim(&test_ctx("agent", &["claim", "tb-001"]));
+        plugin.handle_plan(&test_ctx("agent", &["plan", "tb-001", "my plan"]));
+        plugin.handle_approve(&test_ctx_with_host(
+            "ba",
+            &["approve", "tb-001"],
+            Some("ba"),
+        ));
         plugin.handle_review(&test_ctx("agent", &["review", "tb-001"]));
         let (result, broadcast) = plugin.handle_release(&test_ctx("agent", &["release", "tb-001"]));
         assert!(result.contains("released"));
@@ -1356,6 +1377,12 @@ mod tests {
         let (plugin, _tmp) = make_plugin();
         plugin.handle_post(&test_ctx("ba", &["post", "task"]));
         plugin.handle_claim(&test_ctx("agent", &["claim", "tb-001"]));
+        plugin.handle_plan(&test_ctx("agent", &["plan", "tb-001", "my plan"]));
+        plugin.handle_approve(&test_ctx_with_host(
+            "ba",
+            &["approve", "tb-001"],
+            Some("ba"),
+        ));
         plugin.handle_review(&test_ctx("agent", &["review", "tb-001"]));
         let (result, broadcast) =
             plugin.handle_cancel(&test_ctx("ba", &["cancel", "tb-001", "scope changed"]));
@@ -1411,6 +1438,12 @@ mod tests {
         let (plugin, _tmp) = make_plugin();
         plugin.handle_post(&test_ctx("ba", &["post", "task"]));
         plugin.handle_claim(&test_ctx("agent", &["claim", "tb-001"]));
+        plugin.handle_plan(&test_ctx("agent", &["plan", "tb-001", "my plan"]));
+        plugin.handle_approve(&test_ctx_with_host(
+            "ba",
+            &["approve", "tb-001"],
+            Some("ba"),
+        ));
         plugin.handle_review(&test_ctx("agent", &["review", "tb-001"]));
         // sweep_expired should NOT touch AwaitingReview tasks.
         let expired = plugin.sweep_expired();
@@ -1424,6 +1457,12 @@ mod tests {
         let (plugin, _tmp) = make_plugin();
         plugin.handle_post(&test_ctx("ba", &["post", "task"]));
         plugin.handle_claim(&test_ctx("agent", &["claim", "tb-001"]));
+        plugin.handle_plan(&test_ctx("agent", &["plan", "tb-001", "my plan"]));
+        plugin.handle_approve(&test_ctx_with_host(
+            "ba",
+            &["approve", "tb-001"],
+            Some("ba"),
+        ));
         plugin.handle_review(&test_ctx("agent", &["review", "tb-001"]));
         let (result, broadcast) =
             plugin.handle_update(&test_ctx("agent", &["update", "tb-001", "review notes"]));
@@ -1546,6 +1585,7 @@ mod tests {
             updated_at: None,
             notes: None,
             team: Some("backend".to_owned()),
+            reviewer: None,
         };
         let json = serde_json::to_string(&task).unwrap();
         assert!(json.contains("\"team\":\"backend\""));

--- a/crates/room-plugin-taskboard/src/lib.rs
+++ b/crates/room-plugin-taskboard/src/lib.rs
@@ -126,7 +126,10 @@ impl TaskboardPlugin {
             if lt.is_expired(ttl)
                 && matches!(
                     lt.task.status,
-                    TaskStatus::Claimed | TaskStatus::Planned | TaskStatus::Approved
+                    TaskStatus::Claimed
+                        | TaskStatus::Planned
+                        | TaskStatus::InProgress
+                        | TaskStatus::ReviewClaimed
                 )
             {
                 let prev_assignee = lt.task.assigned_to.clone().unwrap_or_default();
@@ -295,6 +298,7 @@ mod tests {
             updated_at: None,
             notes: None,
             team: None,
+            reviewer: None,
         };
         board.push(LiveTask::new(t));
     }
@@ -427,6 +431,7 @@ mod tests {
                     updated_at: None,
                     notes: None,
                     team: None,
+                    reviewer: None,
                 };
                 let mut lt = LiveTask::new(t);
                 lt.lease_start = Some(stale);
@@ -447,6 +452,7 @@ mod tests {
                 updated_at: None,
                 notes: None,
                 team: None,
+                reviewer: None,
             };
             let mut lt_finished = LiveTask::new(finished);
             // Manually inject stale lease to simulate edge case.

--- a/crates/room-plugin-taskboard/src/task.rs
+++ b/crates/room-plugin-taskboard/src/task.rs
@@ -11,8 +11,11 @@ pub enum TaskStatus {
     Open,
     Claimed,
     Planned,
-    Approved,
+    #[serde(alias = "approved")]
+    InProgress,
     AwaitingReview,
+    #[serde(alias = "review_claimed")]
+    ReviewClaimed,
     Finished,
     Cancelled,
 }
@@ -23,8 +26,9 @@ impl std::fmt::Display for TaskStatus {
             TaskStatus::Open => write!(f, "open"),
             TaskStatus::Claimed => write!(f, "claimed"),
             TaskStatus::Planned => write!(f, "planned"),
-            TaskStatus::Approved => write!(f, "approved"),
+            TaskStatus::InProgress => write!(f, "in_progress"),
             TaskStatus::AwaitingReview => write!(f, "in_review"),
+            TaskStatus::ReviewClaimed => write!(f, "review_claimed"),
             TaskStatus::Finished => write!(f, "finished"),
             TaskStatus::Cancelled => write!(f, "cancelled"),
         }
@@ -50,6 +54,9 @@ pub struct Task {
     /// assigned to the task. `None` means unrestricted.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub team: Option<String>,
+    /// The user who claimed the review (ReviewClaimed state).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reviewer: Option<String>,
 }
 
 /// In-memory task with a lease timestamp for TTL tracking.
@@ -65,9 +72,10 @@ pub struct LiveTask {
 impl LiveTask {
     pub fn new(task: Task) -> Self {
         let lease_start = match task.status {
-            TaskStatus::Claimed | TaskStatus::Planned | TaskStatus::Approved => {
-                Some(Instant::now())
-            }
+            TaskStatus::Claimed
+            | TaskStatus::Planned
+            | TaskStatus::InProgress
+            | TaskStatus::ReviewClaimed => Some(Instant::now()),
             // AwaitingReview has no lease (indefinite — paused during review).
             _ => None,
         };
@@ -163,6 +171,7 @@ mod tests {
             updated_at: None,
             notes: None,
             team: None,
+            reviewer: None,
         }
     }
 
@@ -171,18 +180,19 @@ mod tests {
         assert_eq!(TaskStatus::Open.to_string(), "open");
         assert_eq!(TaskStatus::Claimed.to_string(), "claimed");
         assert_eq!(TaskStatus::Planned.to_string(), "planned");
-        assert_eq!(TaskStatus::Approved.to_string(), "approved");
+        assert_eq!(TaskStatus::InProgress.to_string(), "in_progress");
         assert_eq!(TaskStatus::AwaitingReview.to_string(), "in_review");
+        assert_eq!(TaskStatus::ReviewClaimed.to_string(), "review_claimed");
         assert_eq!(TaskStatus::Finished.to_string(), "finished");
         assert_eq!(TaskStatus::Cancelled.to_string(), "cancelled");
     }
 
     #[test]
     fn task_status_serde_round_trip() {
-        let task = make_task("tb-001", TaskStatus::Approved);
+        let task = make_task("tb-001", TaskStatus::InProgress);
         let json = serde_json::to_string(&task).unwrap();
         let parsed: Task = serde_json::from_str(&json).unwrap();
-        assert_eq!(parsed.status, TaskStatus::Approved);
+        assert_eq!(parsed.status, TaskStatus::InProgress);
         assert_eq!(parsed.id, "tb-001");
     }
 
@@ -236,7 +246,7 @@ mod tests {
 
     #[test]
     fn live_task_expire_resets() {
-        let mut task = make_task("tb-001", TaskStatus::Approved);
+        let mut task = make_task("tb-001", TaskStatus::InProgress);
         task.assigned_to = Some("bob".to_owned());
         task.plan = Some("do the thing".to_owned());
         let mut live = LiveTask::new(task);
@@ -306,8 +316,9 @@ mod tests {
             TaskStatus::Open,
             TaskStatus::Claimed,
             TaskStatus::Planned,
-            TaskStatus::Approved,
+            TaskStatus::InProgress,
             TaskStatus::AwaitingReview,
+            TaskStatus::ReviewClaimed,
             TaskStatus::Finished,
             TaskStatus::Cancelled,
         ] {
@@ -355,5 +366,35 @@ mod tests {
         // sweep_expired's status filter. Verify that Finished status is
         // preserved if we DON'T call expire():
         assert_eq!(live.task.status, TaskStatus::Finished);
+    }
+
+    #[test]
+    fn live_task_lease_for_in_progress() {
+        let task = make_task("tb-001", TaskStatus::InProgress);
+        let live = LiveTask::new(task);
+        assert!(live.lease_start.is_some());
+    }
+
+    #[test]
+    fn live_task_lease_for_review_claimed() {
+        let task = make_task("tb-001", TaskStatus::ReviewClaimed);
+        let live = LiveTask::new(task);
+        assert!(live.lease_start.is_some());
+    }
+
+    /// Backwards compat: "approved" in NDJSON deserializes as InProgress.
+    #[test]
+    fn approved_alias_deserializes_as_in_progress() {
+        let json = r#"{"id":"tb-001","description":"test","status":"approved","posted_by":"alice","assigned_to":null,"posted_at":"2026-03-13T00:00:00Z","claimed_at":null,"plan":null,"approved_by":null,"approved_at":null,"updated_at":null,"notes":null}"#;
+        let task: Task = serde_json::from_str(json).unwrap();
+        assert_eq!(task.status, TaskStatus::InProgress);
+    }
+
+    /// Tasks without the reviewer field deserialize correctly (backwards compat).
+    #[test]
+    fn missing_reviewer_field_defaults_to_none() {
+        let json = r#"{"id":"tb-001","description":"test","status":"open","posted_by":"alice","assigned_to":null,"posted_at":"2026-03-13T00:00:00Z","claimed_at":null,"plan":null,"approved_by":null,"approved_at":null,"updated_at":null,"notes":null}"#;
+        let task: Task = serde_json::from_str(json).unwrap();
+        assert!(task.reviewer.is_none());
     }
 }

--- a/crates/room-protocol/src/lib.rs
+++ b/crates/room-protocol/src/lib.rs
@@ -167,6 +167,8 @@ pub enum EventType {
     TaskCancelled,
     StatusChanged,
     ReviewRequested,
+    ReviewClaimed,
+    TaskRejected,
 }
 
 impl fmt::Display for EventType {
@@ -183,6 +185,8 @@ impl fmt::Display for EventType {
             Self::TaskCancelled => write!(f, "task_cancelled"),
             Self::StatusChanged => write!(f, "status_changed"),
             Self::ReviewRequested => write!(f, "review_requested"),
+            Self::ReviewClaimed => write!(f, "review_claimed"),
+            Self::TaskRejected => write!(f, "task_rejected"),
         }
     }
 }
@@ -203,10 +207,13 @@ impl std::str::FromStr for EventType {
             "task_cancelled" => Ok(Self::TaskCancelled),
             "status_changed" => Ok(Self::StatusChanged),
             "review_requested" => Ok(Self::ReviewRequested),
+            "review_claimed" => Ok(Self::ReviewClaimed),
+            "task_rejected" => Ok(Self::TaskRejected),
             other => Err(format!(
                 "unknown event type '{other}'; expected one of: task_posted, task_assigned, \
                  task_claimed, task_planned, task_approved, task_updated, task_released, \
-                 task_finished, task_cancelled, status_changed, review_requested"
+                 task_finished, task_cancelled, status_changed, review_requested, \
+                 review_claimed, task_rejected"
             )),
         }
     }
@@ -1598,6 +1605,8 @@ mod tests {
             EventType::TaskCancelled,
             EventType::StatusChanged,
             EventType::ReviewRequested,
+            EventType::ReviewClaimed,
+            EventType::TaskRejected,
         ] {
             let json = serde_json::to_string(&et).unwrap();
             let back: EventType = serde_json::from_str(&json).unwrap();
@@ -1649,6 +1658,8 @@ mod tests {
             ("task_cancelled", EventType::TaskCancelled),
             ("status_changed", EventType::StatusChanged),
             ("review_requested", EventType::ReviewRequested),
+            ("review_claimed", EventType::ReviewClaimed),
+            ("task_rejected", EventType::TaskRejected),
         ];
         for (s, expected) in cases {
             assert_eq!(s.parse::<EventType>().unwrap(), expected, "failed for {s}");
@@ -1676,6 +1687,8 @@ mod tests {
             EventType::TaskCancelled,
             EventType::StatusChanged,
             EventType::ReviewRequested,
+            EventType::ReviewClaimed,
+            EventType::TaskRejected,
         ] {
             let s = et.to_string();
             let back: EventType = s.parse().unwrap();


### PR DESCRIPTION
## Summary
- Refactor `TaskStatus` enum: remove `Approved`, add `InProgress` (with serde alias for backwards compat) and `ReviewClaimed`
- Add `reviewer: Option<String>` field to `Task` struct (serde default, skip_serializing_if)
- Add `ReviewClaimed` and `TaskRejected` variants to `EventType` enum in room-protocol
- Update all handlers for the new lifecycle: `handle_review` now requires `InProgress`, `handle_finish` requires `InProgress/AwaitingReview/ReviewClaimed`

## Wire format change checklist
- [x] EventType variants added with Display/FromStr/serde round-trip tests
- [x] Registered in existing event dispatch (lib.rs handle())
- [x] CHANGELOG entry — N/A (will be in sprint changelog)
- [x] Protocol-level tests added (serde round-trip, FromStr)

## Changes
- `room-protocol/src/lib.rs`: Add `ReviewClaimed`, `TaskRejected` to `EventType`
- `room-plugin-taskboard/src/task.rs`: Refactor `TaskStatus`, add `reviewer` field, update lease logic
- `room-plugin-taskboard/src/handlers.rs`: Update all handlers + tests for new lifecycle
- `room-plugin-taskboard/src/lib.rs`: Update `sweep_expired` and test helpers

## Test plan
- [x] All existing tests updated for new lifecycle (plan+approve required before review)
- [x] New tests: `live_task_lease_for_in_progress`, `live_task_lease_for_review_claimed`
- [x] Backwards compat tests: `approved_alias_deserializes_as_in_progress`, `missing_reviewer_field_defaults_to_none`
- [x] cargo check/fmt/clippy all pass
- [ ] CI tests pass

## Checklist
- [x] Verified docs/README are accurate after this change (no drift — internal schema change, no user-facing docs affected)

Closes #841

🤖 Generated with [Claude Code](https://claude.com/claude-code)