### PR TITLE
feat(taskboard): add /taskboard review_claim command (#844)

### DIFF
--- a/crates/room-plugin-taskboard/CHANGELOG.md
+++ b/crates/room-plugin-taskboard/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `/taskboard review_claim` subcommand — claim reviewer role on tasks in AwaitingReview status.
+  Sets reviewer field and restarts lease timer. Emits `ReviewClaimed` event. (#844)
 - `/taskboard mine` subcommand — filter tasks to show only those assigned to the calling user (#827)
 - `/taskboard history` subcommand — shows finished and cancelled tasks (#824)
 

--- a/crates/room-plugin-taskboard/src/handlers.rs
+++ b/crates/room-plugin-taskboard/src/handlers.rs
@@ -631,6 +631,50 @@ impl TaskboardPlugin {
         )
     }
 
+    pub(super) fn handle_review_claim(&self, ctx: &CommandContext) -> (String, bool) {
+        let task_id = match ctx.params.get(1) {
+            Some(id) => id,
+            None => return ("usage: /taskboard review_claim <task-id>".to_owned(), false),
+        };
+        self.sweep_expired();
+        let mut board = self.board.lock().unwrap();
+        let lt = match board.iter_mut().find(|lt| lt.task.id == *task_id) {
+            Some(lt) => lt,
+            None => return (format!("task {task_id} not found"), false),
+        };
+        if lt.task.status != TaskStatus::AwaitingReview {
+            return (
+                format!(
+                    "task {task_id} is {} (must be in_review to claim for review)",
+                    lt.task.status
+                ),
+                false,
+            );
+        }
+        if lt.task.reviewer.is_some() {
+            return (
+                format!(
+                    "task {task_id} already claimed for review by {}",
+                    lt.task.reviewer.as_deref().unwrap_or("unknown")
+                ),
+                false,
+            );
+        }
+        lt.task.status = TaskStatus::ReviewClaimed;
+        lt.task.reviewer = Some(ctx.sender.clone());
+        lt.lease_start = Some(std::time::Instant::now());
+        lt.task.updated_at = Some(chrono::Utc::now());
+        let tasks: Vec<Task> = board.iter().map(|lt| lt.task.clone()).collect();
+        let _ = task::save_tasks(&self.storage_path, &tasks);
+        (
+            format!(
+                "task {task_id} review claimed by {} — lease started",
+                ctx.sender
+            ),
+            true,
+        )
+    }
+
     pub(super) fn handle_finish(&self, ctx: &CommandContext) -> (String, bool) {
         let task_id = match ctx.params.get(1) {
             Some(id) => id,
@@ -1701,6 +1745,69 @@ mod tests {
         plugin.handle_finish(&test_ctx("agent", &["finish", "tb-001"]));
         let board = plugin.board.lock().unwrap();
         assert_eq!(board[0].task.status, TaskStatus::Finished);
+    }
+
+    // -- review_claim tests -----------------------------------------------------
+
+    #[test]
+    fn handle_review_claim_success() {
+        let (plugin, _tmp) = make_plugin();
+        plugin.handle_post(&test_ctx("ba", &["post", "implement feature"]));
+        plugin.handle_claim(&test_ctx("agent", &["claim", "tb-001"]));
+        plugin.handle_plan(&test_ctx("agent", &["plan", "tb-001", "my plan"]));
+        plugin.handle_approve(&test_ctx_with_host(
+            "ba",
+            &["approve", "tb-001"],
+            Some("ba"),
+        ));
+        plugin.handle_request_review(&test_ctx("agent", &["request_review", "tb-001"]));
+        let (result, broadcast) =
+            plugin.handle_review_claim(&test_ctx("reviewer", &["review_claim", "tb-001"]));
+        assert!(result.contains("review claimed by reviewer"));
+        assert!(broadcast);
+        let board = plugin.board.lock().unwrap();
+        assert_eq!(board[0].task.status, TaskStatus::ReviewClaimed);
+        assert_eq!(board[0].task.reviewer.as_deref(), Some("reviewer"));
+    }
+
+    #[test]
+    fn handle_review_claim_wrong_status() {
+        let (plugin, _tmp) = make_plugin();
+        plugin.handle_post(&test_ctx("ba", &["post", "task"]));
+        plugin.handle_claim(&test_ctx("agent", &["claim", "tb-001"]));
+        let (result, broadcast) =
+            plugin.handle_review_claim(&test_ctx("reviewer", &["review_claim", "tb-001"]));
+        assert!(result.contains("must be in_review"));
+        assert!(!broadcast);
+    }
+
+    #[test]
+    fn handle_review_claim_already_claimed() {
+        let (plugin, _tmp) = make_plugin();
+        plugin.handle_post(&test_ctx("ba", &["post", "task"]));
+        plugin.handle_claim(&test_ctx("agent", &["claim", "tb-001"]));
+        plugin.handle_plan(&test_ctx("agent", &["plan", "tb-001", "plan"]));
+        plugin.handle_approve(&test_ctx_with_host(
+            "ba",
+            &["approve", "tb-001"],
+            Some("ba"),
+        ));
+        plugin.handle_request_review(&test_ctx("agent", &["request_review", "tb-001"]));
+        plugin.handle_review_claim(&test_ctx("reviewer1", &["review_claim", "tb-001"]));
+        // Second claim attempt — status is now ReviewClaimed, not AwaitingReview.
+        let (result, broadcast) =
+            plugin.handle_review_claim(&test_ctx("reviewer2", &["review_claim", "tb-001"]));
+        assert!(result.contains("must be in_review"));
+        assert!(!broadcast);
+    }
+
+    #[test]
+    fn handle_review_claim_missing_id() {
+        let (plugin, _tmp) = make_plugin();
+        let (result, broadcast) =
+            plugin.handle_review_claim(&test_ctx("reviewer", &["review_claim"]));
+        assert!(result.contains("usage"));
+        assert!(!broadcast);
     }
 
     // -- Test helpers -----------------------------------------------------------

--- a/crates/room-plugin-taskboard/src/lib.rs
+++ b/crates/room-plugin-taskboard/src/lib.rs
@@ -84,7 +84,7 @@ impl TaskboardPlugin {
         vec![CommandInfo {
             name: "taskboard".to_owned(),
             description:
-                "Manage task lifecycle — post, list, history, mine, show, claim, assign, plan, approve, update, request_review, release, finish, cancel"
+                "Manage task lifecycle — post, list, history, mine, show, claim, assign, plan, approve, update, request_review, review_claim, release, finish, cancel"
                     .to_owned(),
             usage: "/taskboard <action> [args...]".to_owned(),
             params: vec![
@@ -102,6 +102,7 @@ impl TaskboardPlugin {
                         "approve".to_owned(),
                         "update".to_owned(),
                         "request_review".to_owned(),
+                        "review_claim".to_owned(),
                         "release".to_owned(),
                         "finish".to_owned(),
                         "cancel".to_owned(),
@@ -179,10 +180,11 @@ impl Plugin for TaskboardPlugin {
                 "update" => self.handle_update(&ctx),
                 "release" => self.handle_release(&ctx),
                 "request_review" => self.handle_request_review(&ctx),
+                "review_claim" => self.handle_review_claim(&ctx),
                 "finish" => self.handle_finish(&ctx),
                 "cancel" => self.handle_cancel(&ctx),
-                "" => ("usage: /taskboard <post|list|history|mine|show|claim|assign|plan|approve|update|request_review|release|finish|cancel> [args...]".to_owned(), false),
-                other => (format!("unknown action: {other}. use: post, list, history, mine, show, claim, assign, plan, approve, update, request_review, release, finish, cancel"), false),
+                "" => ("usage: /taskboard <post|list|history|mine|show|claim|assign|plan|approve|update|request_review|review_claim|release|finish|cancel> [args...]".to_owned(), false),
+                other => (format!("unknown action: {other}. use: post, list, history, mine, show, claim, assign, plan, approve, update, request_review, review_claim, release, finish, cancel"), false),
             };
             if broadcast {
                 // Emit a typed event alongside the system broadcast.
@@ -194,6 +196,7 @@ impl Plugin for TaskboardPlugin {
                     "approve" => Some(EventType::TaskApproved),
                     "update" => Some(EventType::TaskUpdated),
                     "request_review" => Some(EventType::ReviewRequested),
+                    "review_claim" => Some(EventType::ReviewClaimed),
                     "release" => Some(EventType::TaskReleased),
                     "finish" => Some(EventType::TaskFinished),
                     "cancel" => Some(EventType::TaskCancelled),
@@ -259,7 +262,7 @@ mod tests {
             assert!(choices.contains(&"post".to_owned()));
             assert!(choices.contains(&"approve".to_owned()));
             assert!(choices.contains(&"assign".to_owned()));
-            assert_eq!(choices.len(), 14);
+            assert_eq!(choices.len(), 15);
         } else {
             panic!("expected Choice param type");
         }


### PR DESCRIPTION
## Summary
- Add `review_claim` subcommand to `/taskboard` that transitions a task from `AwaitingReview` to `ReviewClaimed` status
- Validates task is in review and has no existing reviewer before claiming
- Sets the `reviewer` field and restarts the lease timer
- Fixes existing tests for the new task lifecycle schema (Approved->InProgress, missing reviewer field)

## Dependencies
- Depends on PR #859 (#842 rename review to request_review) merging first — will need rebase after

## Test plan
- [x] 4 new unit tests: success flow, wrong status, already claimed, missing id
- [x] All 110 taskboard tests pass
- [x] Full pre-push checks pass (check, fmt, clippy, test)
- [ ] Verified docs/README are accurate after this change (no drift)

Closes #844

🤖 Generated with [Claude Code](https://claude.com/claude-code)