### PR TITLE
feat(taskboard): add reject command (#845)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **taskboard:** `/taskboard reject <task-id> [reason]` — reviewer sends task back to
+  implementer (ReviewClaimed → InProgress). Clears reviewer/approved fields. (#845)
 - **taskboard:** Team-restricted task claims — `/taskboard post --team <name>` restricts
   claiming and assignment to team members. Backward-compatible NDJSON persistence. (#516)
 

--- a/crates/room-plugin-taskboard/CHANGELOG.md
+++ b/crates/room-plugin-taskboard/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `/taskboard reject <task-id> [reason]` subcommand — reviewer sends task back to implementer.
+  Transitions ReviewClaimed → InProgress, clears reviewer/approved fields, sets rejection
+  reason in notes. Only reviewer or host can reject. Emits `TaskRejected` event. (#845)
 - `/taskboard review_claim` subcommand — claim reviewer role on tasks in AwaitingReview status.
   Sets reviewer field and restarts lease timer. Emits `ReviewClaimed` event. (#844)
 - `/taskboard qa-queue` subcommand — filtered view showing only tasks in AwaitingReview status,

--- a/crates/room-plugin-taskboard/src/handlers.rs
+++ b/crates/room-plugin-taskboard/src/handlers.rs
@@ -717,6 +717,68 @@ impl TaskboardPlugin {
         )
     }
 
+    pub(super) fn handle_reject(&self, ctx: &CommandContext) -> (String, bool) {
+        let task_id = match ctx.params.get(1) {
+            Some(id) => id,
+            None => {
+                return (
+                    "usage: /taskboard reject <task-id> [reason]".to_owned(),
+                    false,
+                )
+            }
+        };
+        self.sweep_expired();
+        let mut board = self.board.lock().unwrap();
+        let lt = match board.iter_mut().find(|lt| lt.task.id == *task_id) {
+            Some(lt) => lt,
+            None => return (format!("task {task_id} not found"), false),
+        };
+        if lt.task.status != TaskStatus::ReviewClaimed {
+            return (
+                format!(
+                    "task {task_id} is {} (must be review_claimed to reject)",
+                    lt.task.status
+                ),
+                false,
+            );
+        }
+        let is_reviewer = lt.task.reviewer.as_deref() == Some(&ctx.sender);
+        let is_host = ctx.metadata.host.as_deref() == Some(&ctx.sender);
+        if !is_reviewer && !is_host {
+            return (
+                format!("task {task_id} can only be rejected by the reviewer or host"),
+                false,
+            );
+        }
+        let reason = if ctx.params.len() > 2 {
+            Some(ctx.params[2..].join(" "))
+        } else {
+            None
+        };
+        lt.task.status = TaskStatus::InProgress;
+        lt.task.reviewer = None;
+        lt.task.approved_by = None;
+        lt.task.approved_at = None;
+        if let Some(ref reason) = reason {
+            lt.task.notes = Some(reason.clone());
+        }
+        lt.lease_start = Some(std::time::Instant::now());
+        lt.task.updated_at = Some(chrono::Utc::now());
+        let tasks: Vec<Task> = board.iter().map(|lt| lt.task.clone()).collect();
+        let _ = task::save_tasks(&self.storage_path, &tasks);
+        let reason_suffix = reason
+            .as_deref()
+            .map(|r| format!(" — reason: {r}"))
+            .unwrap_or_default();
+        (
+            format!(
+                "task {task_id} rejected by {} — returned to in_progress{reason_suffix}",
+                ctx.sender
+            ),
+            true,
+        )
+    }
+
     pub(super) fn handle_finish(&self, ctx: &CommandContext) -> (String, bool) {
         let task_id = match ctx.params.get(1) {
             Some(id) => id,
@@ -1848,6 +1910,105 @@ mod tests {
         let (plugin, _tmp) = make_plugin();
         let (result, broadcast) =
             plugin.handle_review_claim(&test_ctx("reviewer", &["review_claim"]));
+        assert!(result.contains("usage"));
+        assert!(!broadcast);
+    }
+
+    // -- reject tests -----------------------------------------------------------
+
+    #[test]
+    fn handle_reject_success() {
+        let (plugin, _tmp) = make_plugin();
+        plugin.handle_post(&test_ctx("ba", &["post", "implement feature"]));
+        plugin.handle_claim(&test_ctx("agent", &["claim", "tb-001"]));
+        plugin.handle_plan(&test_ctx("agent", &["plan", "tb-001", "my plan"]));
+        plugin.handle_approve(&test_ctx_with_host(
+            "ba",
+            &["approve", "tb-001"],
+            Some("ba"),
+        ));
+        plugin.handle_request_review(&test_ctx("agent", &["request_review", "tb-001"]));
+        plugin.handle_review_claim(&test_ctx("reviewer", &["review_claim", "tb-001"]));
+        let (result, broadcast) = plugin.handle_reject(&test_ctx_with_host(
+            "reviewer",
+            &["reject", "tb-001", "needs", "tests"],
+            Some("ba"),
+        ));
+        assert!(result.contains("rejected by reviewer"));
+        assert!(result.contains("reason: needs tests"));
+        assert!(broadcast);
+        let board = plugin.board.lock().unwrap();
+        assert_eq!(board[0].task.status, TaskStatus::InProgress);
+        assert!(board[0].task.reviewer.is_none());
+        assert!(board[0].task.approved_by.is_none());
+        assert!(board[0].task.approved_at.is_none());
+        assert_eq!(board[0].task.notes.as_deref(), Some("needs tests"));
+    }
+
+    #[test]
+    fn handle_reject_wrong_status() {
+        let (plugin, _tmp) = make_plugin();
+        plugin.handle_post(&test_ctx("ba", &["post", "implement feature"]));
+        plugin.handle_claim(&test_ctx("agent", &["claim", "tb-001"]));
+        let (result, broadcast) = plugin.handle_reject(&test_ctx_with_host(
+            "agent",
+            &["reject", "tb-001"],
+            Some("ba"),
+        ));
+        assert!(result.contains("must be review_claimed to reject"));
+        assert!(!broadcast);
+    }
+
+    #[test]
+    fn handle_reject_wrong_user() {
+        let (plugin, _tmp) = make_plugin();
+        plugin.handle_post(&test_ctx("ba", &["post", "implement feature"]));
+        plugin.handle_claim(&test_ctx("agent", &["claim", "tb-001"]));
+        plugin.handle_plan(&test_ctx("agent", &["plan", "tb-001", "my plan"]));
+        plugin.handle_approve(&test_ctx_with_host(
+            "ba",
+            &["approve", "tb-001"],
+            Some("ba"),
+        ));
+        plugin.handle_request_review(&test_ctx("agent", &["request_review", "tb-001"]));
+        plugin.handle_review_claim(&test_ctx("reviewer", &["review_claim", "tb-001"]));
+        let (result, broadcast) = plugin.handle_reject(&test_ctx_with_host(
+            "random",
+            &["reject", "tb-001", "bad"],
+            Some("ba"),
+        ));
+        assert!(result.contains("can only be rejected by the reviewer or host"));
+        assert!(!broadcast);
+    }
+
+    #[test]
+    fn handle_reject_by_host() {
+        let (plugin, _tmp) = make_plugin();
+        plugin.handle_post(&test_ctx("ba", &["post", "implement feature"]));
+        plugin.handle_claim(&test_ctx("agent", &["claim", "tb-001"]));
+        plugin.handle_plan(&test_ctx("agent", &["plan", "tb-001", "my plan"]));
+        plugin.handle_approve(&test_ctx_with_host(
+            "ba",
+            &["approve", "tb-001"],
+            Some("ba"),
+        ));
+        plugin.handle_request_review(&test_ctx("agent", &["request_review", "tb-001"]));
+        plugin.handle_review_claim(&test_ctx("reviewer", &["review_claim", "tb-001"]));
+        let (result, broadcast) = plugin.handle_reject(&test_ctx_with_host(
+            "ba",
+            &["reject", "tb-001", "not ready"],
+            Some("ba"),
+        ));
+        assert!(result.contains("rejected by ba"));
+        assert!(broadcast);
+        let board = plugin.board.lock().unwrap();
+        assert_eq!(board[0].task.status, TaskStatus::InProgress);
+    }
+
+    #[test]
+    fn handle_reject_missing_id() {
+        let (plugin, _tmp) = make_plugin();
+        let (result, broadcast) = plugin.handle_reject(&test_ctx("reviewer", &["reject"]));
         assert!(result.contains("usage"));
         assert!(!broadcast);
     }

--- a/crates/room-plugin-taskboard/src/lib.rs
+++ b/crates/room-plugin-taskboard/src/lib.rs
@@ -84,7 +84,7 @@ impl TaskboardPlugin {
         vec![CommandInfo {
             name: "taskboard".to_owned(),
             description:
-                "Manage task lifecycle — post, list, history, mine, qa-queue, show, claim, assign, plan, approve, update, request_review, review_claim, release, finish, cancel"
+                "Manage task lifecycle — post, list, history, mine, qa-queue, show, claim, assign, plan, approve, update, request_review, review_claim, reject, release, finish, cancel"
                     .to_owned(),
             usage: "/taskboard <action> [args...]".to_owned(),
             params: vec![
@@ -104,6 +104,7 @@ impl TaskboardPlugin {
                         "update".to_owned(),
                         "request_review".to_owned(),
                         "review_claim".to_owned(),
+                        "reject".to_owned(),
                         "release".to_owned(),
                         "finish".to_owned(),
                         "cancel".to_owned(),
@@ -183,10 +184,11 @@ impl Plugin for TaskboardPlugin {
                 "release" => self.handle_release(&ctx),
                 "request_review" => self.handle_request_review(&ctx),
                 "review_claim" => self.handle_review_claim(&ctx),
+                "reject" => self.handle_reject(&ctx),
                 "finish" => self.handle_finish(&ctx),
                 "cancel" => self.handle_cancel(&ctx),
-                "" => ("usage: /taskboard <post|list|history|mine|qa-queue|show|claim|assign|plan|approve|update|request_review|review_claim|release|finish|cancel> [args...]".to_owned(), false),
-                other => (format!("unknown action: {other}. use: post, list, history, mine, qa-queue, show, claim, assign, plan, approve, update, request_review, review_claim, release, finish, cancel"), false),
+                "" => ("usage: /taskboard <post|list|history|mine|qa-queue|show|claim|assign|plan|approve|update|request_review|review_claim|reject|release|finish|cancel> [args...]".to_owned(), false),
+                other => (format!("unknown action: {other}. use: post, list, history, mine, qa-queue, show, claim, assign, plan, approve, update, request_review, review_claim, reject, release, finish, cancel"), false),
             };
             if broadcast {
                 // Emit a typed event alongside the system broadcast.
@@ -199,6 +201,7 @@ impl Plugin for TaskboardPlugin {
                     "update" => Some(EventType::TaskUpdated),
                     "request_review" => Some(EventType::ReviewRequested),
                     "review_claim" => Some(EventType::ReviewClaimed),
+                    "reject" => Some(EventType::TaskRejected),
                     "release" => Some(EventType::TaskReleased),
                     "finish" => Some(EventType::TaskFinished),
                     "cancel" => Some(EventType::TaskCancelled),
@@ -264,7 +267,7 @@ mod tests {
             assert!(choices.contains(&"post".to_owned()));
             assert!(choices.contains(&"approve".to_owned()));
             assert!(choices.contains(&"assign".to_owned()));
-            assert_eq!(choices.len(), 16);
+            assert_eq!(choices.len(), 17);
         } else {
             panic!("expected Choice param type");
         }


### PR DESCRIPTION
## Summary

- Add `/taskboard reject <task-id> [reason]` subcommand — reviewer sends task back to implementer
- Transitions ReviewClaimed → InProgress, clears reviewer/approved_by/approved_at fields
- Sets rejection reason in notes, restarts lease timer
- Only reviewer or host can reject
- Emits `TaskRejected` event
- 5 new unit tests, 115 total taskboard tests pass

## Files modified
- `crates/room-plugin-taskboard/src/handlers.rs` — `handle_reject()` + 5 tests
- `crates/room-plugin-taskboard/src/lib.rs` — dispatch, event mapping, usage strings, Choice params
- `crates/room-plugin-taskboard/CHANGELOG.md` — entry for #845
- `CHANGELOG.md` — root entry for #845

## Test plan
- [x] handle_reject_success — full flow from post→claim→plan→approve→request_review→review_claim→reject
- [x] handle_reject_wrong_status — rejects when not in ReviewClaimed
- [x] handle_reject_wrong_user — rejects when sender is not reviewer or host
- [x] handle_reject_by_host — host can reject even if not the reviewer
- [x] handle_reject_missing_id — usage message on missing args
- [ ] Verified docs/README are accurate after this change (no drift)

Closes #845

🤖 Generated with [Claude Code](https://claude.com/claude-code)