### PR TITLE
chore: add crate-scoped testing to pre-push.sh (#863)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **scripts:** `pre-push.sh` now detects changed crates and runs scoped `cargo test -p`
+  instead of full suite. Falls back to full suite on master or cross-crate changes. (#863)
 - **taskboard:** Renamed `review` subcommand to `request_review` for clarity — distinguishes
   the author action (requesting review) from reviewer actions (claiming, approving). All
   status labels, event types, and tests updated. (#842)

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
 BOLD='\033[1m'
 RESET='\033[0m'
 
@@ -22,11 +23,15 @@ pass() {
   printf "${GREEN}[pre-push] PASSED:${RESET} %s\n" "$1"
 }
 
+info() {
+  printf "${YELLOW}[pre-push]${RESET} %s\n" "$1"
+}
+
 # Order matters — each step can invalidate the previous one.
 # 1. cargo check catches syntax/type errors and conflict markers first.
 # 2. cargo fmt reformats; if it changes anything, you have uncommitted diffs.
 # 3. cargo clippy catches lint issues.
-# 4. cargo test runs the full suite.
+# 4. cargo test — crate-scoped when possible, full suite as fallback.
 
 step "cargo check"
 cargo check 2>&1 || fail "cargo check"
@@ -39,5 +44,53 @@ pass "cargo fmt"
 step "cargo clippy -- -D warnings"
 cargo clippy -- -D warnings 2>&1 || fail "cargo clippy"
 pass "cargo clippy"
+
+# Detect changed crates for scoped testing.
+# Falls back to full suite on master, cross-crate changes, or root Cargo.toml changes.
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+
+run_full_suite() {
+  step "cargo test (full suite)"
+  cargo test 2>&1 || fail "cargo test"
+  pass "cargo test (full suite)"
+}
+
+if [ "$CURRENT_BRANCH" = "master" ] || [ "$CURRENT_BRANCH" = "main" ]; then
+  info "on $CURRENT_BRANCH — running full test suite"
+  run_full_suite
+else
+  # Find merge base with master to detect changed files.
+  MERGE_BASE=$(git merge-base origin/master HEAD 2>/dev/null || echo "")
+  if [ -z "$MERGE_BASE" ]; then
+    info "cannot determine merge base — running full test suite"
+    run_full_suite
+  else
+    # Check for root Cargo.toml changes (workspace-level).
+    ROOT_CHANGED=$(git diff --name-only "$MERGE_BASE"..HEAD -- Cargo.toml | wc -l)
+
+    # Extract unique crate names from changed files under crates/.
+    CHANGED_CRATES=$(git diff --name-only "$MERGE_BASE"..HEAD -- 'crates/' \
+      | sed -n 's|^crates/\([^/]*\)/.*|\1|p' \
+      | sort -u)
+
+    CRATE_COUNT=$(echo "$CHANGED_CRATES" | grep -c . || true)
+
+    if [ "$ROOT_CHANGED" -gt 0 ]; then
+      info "root Cargo.toml changed — running full test suite"
+      run_full_suite
+    elif [ "$CRATE_COUNT" -eq 0 ]; then
+      info "no crate changes detected — skipping tests"
+    elif [ "$CRATE_COUNT" -gt 3 ]; then
+      info "$CRATE_COUNT crates changed — running full test suite"
+      run_full_suite
+    else
+      for crate in $CHANGED_CRATES; do
+        step "cargo test -p $crate"
+        cargo test -p "$crate" 2>&1 || fail "cargo test -p $crate"
+        pass "cargo test -p $crate"
+      done
+    fi
+  fi
+fi
 
 printf '\n%s%s[pre-push] All checks passed.%s\n' "$GREEN" "$BOLD" "$RESET"


### PR DESCRIPTION
## Summary

- Update `pre-push.sh` to detect changed crates by diffing against `origin/master`
- Run `cargo test -p <crate>` for each changed crate instead of full suite
- Falls back to full `cargo test` on master/main, when 4+ crates change, or when root `Cargo.toml` changes
- Skips tests when only non-crate files change (scripts, docs, etc.)
- Check/fmt/clippy steps unchanged (run workspace-wide)

## Test plan
- [x] Tested on branch with only script changes — correctly skips tests
- [x] Script runs successfully end-to-end
- [ ] Manual: verify on branch with single-crate changes runs only that crate's tests
- [ ] Verified docs/README are accurate after this change (no drift)

Closes #863

🤖 Generated with [Claude Code](https://claude.com/claude-code)