### PR TITLE
chore(ci): re-enable sccache (#864)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,9 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    # sccache disabled — GitHub Actions cache outage persists (2026-03-16)
-    # env:
-    #   RUSTC_WRAPPER: sccache
-    #   SCCACHE_GHA_ENABLED: "true"
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -20,7 +19,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-      # - uses: mozilla-actions/sccache-action@v0.0.7
+      - uses: mozilla-actions/sccache-action@v0.0.7
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: mozilla-actions/sccache-action@v0.0.7
+        continue-on-error: true
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **taskboard:** Team-restricted task claims — `/taskboard post --team <name>` restricts
   claiming and assignment to team members. Backward-compatible NDJSON persistence. (#516)
 
+### Changed
+
+- **ci:** Re-enabled sccache in CI workflow now that GitHub Actions cache outage is
+  resolved. Builds use both sccache and Swatinem/rust-cache for faster compilation. (#864)
+
 ### Fixed
 
 - **daemon:** Create runtime socket directory on Linux before binding. On systems with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- **ci:** Re-enabled sccache in CI workflow now that GitHub Actions cache outage is
-  resolved. Builds use both sccache and Swatinem/rust-cache for faster compilation. (#864)
+- **ci:** Re-enabled sccache in CI workflow with `continue-on-error` for graceful
+  degradation when GitHub Actions cache is intermittently unavailable. Builds use both
+  sccache and Swatinem/rust-cache for faster compilation. (#864)
 
 ### Fixed
 


### PR DESCRIPTION
## Summary
- Re-enable sccache in CI now that GitHub Actions cache outage (2026-03-16) is resolved
- Uncommented `RUSTC_WRAPPER`/`SCCACHE_GHA_ENABLED` env vars and `mozilla-actions/sccache-action@v0.0.7`
- sccache works alongside existing `Swatinem/rust-cache@v2` for faster builds

## Verification
- Confirmed GH Actions cache is operational: `gh cache list` shows entries created/accessed on 2026-03-21
- sccache-action reads/writes via GH Actions cache backend — no additional config needed

## Test plan
- [ ] CI workflow runs successfully with sccache re-enabled
- [ ] Verified docs/README are accurate after this change (no drift)

Closes #864

🤖 Generated with [Claude Code](https://claude.com/claude-code)