### PR TITLE
fix(tests): update all_known_commands for agent/spawn removal

### DIFF
--- a/crates/room-daemon/src/plugin/schema.rs
+++ b/crates/room-daemon/src/plugin/schema.rs
@@ -343,8 +343,8 @@ mod tests {
         assert!(names.contains(&"help"));
         // Plugins
         assert!(names.contains(&"stats"));
-        assert!(names.contains(&"agent"));
-        assert!(names.contains(&"spawn"));
+        assert!(names.contains(&"queue"));
+        assert!(names.contains(&"taskboard"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Remove stale assertions for `agent` and `spawn` commands in `all_known_commands_includes_builtins_and_plugins` test
- These commands moved to the [room-ralph](https://github.com/knoxio/room-ralph) repo
- Replace with assertions for `queue` and `taskboard` — the actual built-in plugins

Closes #877

- [x] Verified docs/README are accurate after this change (no drift)

## Test plan
- [x] `cargo test -p room-daemon all_known_commands` — both tests pass
- [x] `cargo clippy -p room-daemon -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>