### PR TITLE
fix: make default_username test resilient to missing USER env var

### DIFF
--- a/crates/room-cli/src/client.rs
+++ b/crates/room-cli/src/client.rs
@@ -206,13 +206,14 @@ mod tests {
 
     #[test]
     fn default_username_returns_user_env_var() {
-        // $USER should be set on macOS/Linux test environments.
+        let prev = std::env::var("USER").ok();
+        std::env::set_var("USER", "testuser");
         let result = default_username();
-        assert!(
-            result.is_some(),
-            "$USER should be set in the test environment"
-        );
-        assert!(!result.unwrap().is_empty(), "$USER should not be empty");
+        assert_eq!(result.as_deref(), Some("testuser"));
+        match prev {
+            Some(v) => std::env::set_var("USER", v),
+            None => std::env::remove_var("USER"),
+        }
     }
 
     /// has_valid_token_file returns false for empty file.


### PR DESCRIPTION
## Summary
- Fix `client::tests::default_username_returns_user_env_var` test that fails when `$USER` env var is not set (sandbox/CI environments)
- Test now sets `USER=testuser` explicitly, verifies the result, and restores the original value
- Follows the same save/restore pattern used in `oneshot/transport.rs` tests

## Test plan
- [x] Test passes when `USER` is unset (sandbox environment)
- [x] Test passes when `USER` is set (standard dev environment)
- [x] Pre-push checks pass (check, fmt, clippy)

- [x] Verified docs/README are accurate after this change (no drift)

Closes #881

🤖 Generated with [Claude Code](https://claude.com/claude-code)