### PR TITLE
fix(tests): add delay to avoid subscription persist race

### DIFF
--- a/crates/room-cli/tests/manual_agent.rs
+++ b/crates/room-cli/tests/manual_agent.rs
@@ -1348,6 +1348,9 @@ async fn subscribe_command_changes_tier_via_broker() {
     let td = TestDaemon::start(&["t-sub-change"]).await;
 
     let alice_token = common::daemon_join(&td.socket_path, "t-sub-change", "alice").await;
+    // Allow the JOIN handler's persist_subscriptions to complete before sending
+    // a subscribe command, avoiding a TOCTOU race on the subscription file.
+    tokio::time::sleep(Duration::from_millis(100)).await;
 
     // Default tier after join is Full — change to MentionsOnly
     let sub_cmd = serde_json::json!({
@@ -1489,6 +1492,9 @@ async fn unsubscribed_tier_persists_via_broker() {
     let td = TestDaemon::start(&["t-unsub-persist"]).await;
 
     let bob_token = common::daemon_join(&td.socket_path, "t-unsub-persist", "bob").await;
+    // Allow the JOIN handler's persist_subscriptions to complete before sending
+    // a subscribe command, avoiding a TOCTOU race on the subscription file.
+    tokio::time::sleep(Duration::from_millis(100)).await;
 
     // Subscribe as Unsubscribed
     let unsub_cmd = serde_json::json!({


### PR DESCRIPTION
## Summary
- Add 100ms delay after `daemon_join` in two subscription tests to avoid a TOCTOU race
- The JOIN handler's `persist_subscriptions` can race with a subsequent subscribe command's persist, causing the test to read stale subscription data from disk

Affected tests:
- `subscribe_command_changes_tier_via_broker`
- `unsubscribed_tier_persists_via_broker`

Closes #878

- [x] Verified docs/README are accurate after this change (no drift)

## Test plan
- [x] `cargo check --test manual_agent -p room-cli` — compiles cleanly
- [ ] Run affected tests to verify race is eliminated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>