### PR TITLE
ci: graceful sccache fallback when server startup fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,13 @@ jobs:
           components: rustfmt, clippy
       - uses: mozilla-actions/sccache-action@v0.0.7
         continue-on-error: true
+      - name: Verify sccache
+        id: sccache-check
+        run: |
+          if ! sccache --start-server 2>/dev/null; then
+            echo "RUSTC_WRAPPER=" >> "$GITHUB_ENV"
+            echo "sccache unavailable, falling back to direct compilation"
+          fi
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest


### PR DESCRIPTION
## Summary

- Adds a verification step after `mozilla-actions/sccache-action` that checks if sccache can actually start its server
- If sccache startup fails, unsets `RUSTC_WRAPPER` via `GITHUB_ENV` so cargo falls back to direct compilation
- Fixes the systemic CI failure where `continue-on-error: true` on the sccache-action step lets the workflow continue, but `RUSTC_WRAPPER: sccache` remains set, causing `cargo clippy` and `cargo test` to crash with "sccache: error: Server startup failed: cache storage failed to read"

## Test plan

- [ ] Verify CI passes on this PR (sccache should either work normally or fall back gracefully)
- [ ] Confirm master CI stops failing after merge